### PR TITLE
Changed parameter names and documentation in Arrow class from 'radius' to 'diameter'

### DIFF
--- a/src/rviz/ogre_helpers/arrow.cpp
+++ b/src/rviz/ogre_helpers/arrow.cpp
@@ -40,8 +40,8 @@
 namespace rviz
 {
 
-Arrow::Arrow( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, float shaft_length, float shaft_radius,
-              float head_length, float head_radius )
+Arrow::Arrow( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, float shaft_length, float shaft_diameter,
+              float head_length, float head_diameter )
 : Object( scene_manager )
 {
   if ( !parent_node )
@@ -55,7 +55,7 @@ Arrow::Arrow( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, f
   head_ = new Shape( Shape::Cone, scene_manager_, scene_node_ );
   head_->setOffset(Ogre::Vector3(0.0f, 0.5f, 0.0f));
 
-  set( shaft_length, shaft_radius, head_length, head_radius );
+  set( shaft_length, shaft_diameter, head_length, head_diameter );
 
   setOrientation( Ogre::Quaternion::IDENTITY );
 }
@@ -68,12 +68,12 @@ Arrow::~Arrow()
   scene_manager_->destroySceneNode( scene_node_->getName() );
 }
 
-void Arrow::set( float shaft_length, float shaft_radius, float head_length, float head_radius )
+void Arrow::set( float shaft_length, float shaft_diameter, float head_length, float head_diameter )
 {
-  shaft_->setScale(Ogre::Vector3(shaft_radius, shaft_length, shaft_radius));
+  shaft_->setScale(Ogre::Vector3(shaft_diameter, shaft_length, shaft_diameter));
   shaft_->setPosition( Ogre::Vector3( 0.0f, shaft_length/2.0f, 0.0f ) );
 
-  head_->setScale( Ogre::Vector3( head_radius, head_length, head_radius ) );
+  head_->setScale( Ogre::Vector3( head_diameter, head_length, head_diameter ) );
   head_->setPosition( Ogre::Vector3( 0.0f, shaft_length, 0.0f ) );
 }
 

--- a/src/rviz/ogre_helpers/arrow.h
+++ b/src/rviz/ogre_helpers/arrow.h
@@ -65,23 +65,23 @@ public:
    * @param scene_manager The scene manager to use to construct any necessary objects
    * @param parent_node A scene node to use as the parent of this object.  If NULL, uses the root scene node.
    * @param shaft_length Length of the arrow's shaft
-   * @param shaft_radius Radius of the arrow's shaft
+   * @param shaft_diameter Diameter of the arrow's shaft
    * @param head_length Length of the arrow's head
-   * @param head_radius Radius of the arrow's head
+   * @param head_diameter Diameter of the arrow's head
    */
-  Arrow( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node = 0, float shaft_length = 1.0f, float shaft_radius = 0.1f,
-      float head_length = 0.3f, float head_radius =  0.2f );
+  Arrow( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node = 0, float shaft_length = 1.0f, float shaft_diameter = 0.1f,
+      float head_length = 0.3f, float head_diameter =  0.2f );
   virtual ~Arrow();
 
   /**
    * \brief Set the parameters for this arrow
    *
    * @param shaft_length Length of the arrow's shaft
-   * @param shaft_radius Radius of the arrow's shaft
+   * @param shaft_diameter Diameter of the arrow's shaft
    * @param head_length Length of the arrow's head
-   * @param head_radius Radius of the arrow's head
+   * @param head_diameter Diameter of the arrow's head
    */
-  void set( float shaft_length, float shaft_radius, float head_length, float head_radius );
+  void set( float shaft_length, float shaft_diameter, float head_length, float head_diameter );
 
   /**
    * \brief Set the color of this arrow.  Sets both the head and shaft color to the same value.  Values are in the range [0, 1]

--- a/src/test/arrow_marker_test.py
+++ b/src/test/arrow_marker_test.py
@@ -38,7 +38,7 @@ def make_marker(marker_type, scale, r, g, b, a):
     m.color.a = a;
     return m
 
-def make_arrow_points_marker(tail, tip, idnum):
+def make_arrow_points_marker(scale, tail, tip, idnum):
     # make a visualization marker array for the occupancy grid
     m = Marker()
     m.action = Marker.ADD
@@ -49,9 +49,7 @@ def make_arrow_points_marker(tail, tip, idnum):
     m.type = Marker.ARROW
     m.pose.orientation.y = 0
     m.pose.orientation.w = 1
-    m.scale.x = 0.5
-    m.scale.y = 1.0
-    m.scale.z = 0.5
+    m.scale = scale
     m.color.r = 0.2
     m.color.g = 0.5
     m.color.b = 1.0
@@ -63,9 +61,15 @@ def make_arrow_points_marker(tail, tip, idnum):
 while not rospy.is_shutdown():
     rospy.loginfo('Publishing arrow marker')
   
-    marker_pub.publish(make_arrow_points_marker(Point(0,0,0), Point(2,2,0), 0))
-    marker_pub.publish(make_arrow_points_marker(Point(0,0,0), Point(1,-1,1), 1))
-    marker_pub.publish(make_arrow_points_marker(Point(-1,-1,-1), Point(1,-1,-1), 2))
+    #marker_pub.publish(make_arrow_points_marker(Point(0,0,0), Point(2,2,0), 0))
+    #marker_pub.publish(make_arrow_points_marker(Point(0,0,0), Point(1,-1,1), 1))
+    #marker_pub.publish(make_arrow_points_marker(Point(-1,-1,-1), Point(1,-1,-1), 2))
+
+    #this arrow should look exactly like the other one, except that is
+    #is twice a wide in the z direction.
+    scale = Vector3(2,4,0.69)
+    marker_pub.publish(make_arrow_points_marker(scale,Point(0,0,0), Point(3,0,0), 3))
+    
     scale = Vector3(3,2,1)
     marker_pub.publish(make_marker(Marker.SPHERE,   scale, 1, .5, .2, .3))
     marker_pub.publish(make_marker(Marker.CYLINDER, scale, .5, .2, 1, .3))


### PR DESCRIPTION
Also, changed documentation on http://www.ros.org/wiki/rviz/DisplayTypes/Marker#Arrow_.28ARROW.3D0.29

With this and the recent change from @aleeper, the code & ROS API should all agree.

That means, what was previously named 'radius' on the wiki was actually 'double radius'.
