### PR TITLE
bugfix: interactive point cloud markers

### DIFF
--- a/src/rviz/default_plugin/markers/points_marker.cpp
+++ b/src/rviz/default_plugin/markers/points_marker.cpp
@@ -43,6 +43,25 @@
 namespace rviz
 {
 
+// This dummy class prevents SelectionManager from destroying our
+// pick color
+class PointsSelectionHandler: public MarkerSelectionHandler
+{
+public:
+
+  PointsSelectionHandler( PointCloud* points, const MarkerBase* marker, MarkerID id, DisplayContext* context ) :
+  MarkerSelectionHandler( marker, id, context ),
+  points_( points ) {};
+
+  virtual void preRenderPass(uint32_t pass)
+  {
+    points_->setPickColor( SelectionManager::handleToColor( getHandle() ));
+  }
+
+private:
+  PointCloud* points_;
+};
+
 PointsMarker::PointsMarker(MarkerDisplay* owner, DisplayContext* context, Ogre::SceneNode* parent_node)
 : MarkerBase(owner, context, parent_node)
 , points_(0)
@@ -131,9 +150,12 @@ void PointsMarker::onNewMessage(const MarkerConstPtr& old_message, const MarkerC
     point.setColor(r, g, b);
   }
 
-  points_->addPoints(&points.front(), points.size());
+  handler_.reset( new PointsSelectionHandler( points_, this, MarkerID( new_message->ns, new_message->id ), context_ ));
 
-  handler_.reset( new MarkerSelectionHandler( this, MarkerID( new_message->ns, new_message->id ), context_ ));
+  // does not work for some reason:
+  // handler_->addTrackedObject( points_ );
+
+  points_->addPoints(&points.front(), points.size());
   points_->setPickColor( SelectionManager::handleToColor( handler_->getHandle() ));
 }
 


### PR DESCRIPTION
This makes the selection of point / cube / sphere list markers work again. SelectionManager sets all handles to zero at the beginning of each selection for some reason. 

MarkerSelectionHandler restores it in preRenderPass when you call addTrackedObject first, but that doesn't work for Point Clouds for some reason. Didn't look into that deeper.

It seems like something more fundamental is wrong that should be fixed, but this bugfix will do for now.
