### PR TITLE
refactored interactive markers so they can be used in other displays

### DIFF
--- a/src/rviz/default_plugin/interactive_marker_display.h
+++ b/src/rviz/default_plugin/interactive_marker_display.h
@@ -82,6 +82,8 @@ protected Q_SLOTS:
   void updateTopic();
   void updateShowDescriptions();
   void updateShowAxes();
+  void publishFeedback(visualization_msgs::InteractiveMarkerFeedback &feedback);
+  void onStatusUpdate( StatusProperty::Level level, const std::string& name, const std::string& text );
 
 private:
 
@@ -132,6 +134,8 @@ private:
   BoolProperty* show_axes_property_;
 
   boost::shared_ptr<interactive_markers::InteractiveMarkerClient> im_client_;
+
+  ros::Publisher feedback_pub_;
 
   std::string topic_ns_;
 };

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.h
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.h
@@ -46,7 +46,7 @@
 #include "rviz/ogre_helpers/axes.h"
 
 #include "rviz/default_plugin/interactive_markers/interactive_marker_control.h"
-
+#include "rviz/properties/status_property.h"
 
 namespace Ogre {
 class SceneNode;
@@ -63,7 +63,7 @@ class InteractiveMarker : public QObject
 {
 Q_OBJECT
 public:
-  InteractiveMarker( InteractiveMarkerDisplay *owner, DisplayContext* context, std::string topic_ns, std::string client_id );
+  InteractiveMarker( Ogre::SceneNode* scene_node, DisplayContext* context );
   virtual ~InteractiveMarker();
 
   // reset contents to reflect the data from a new message
@@ -138,6 +138,11 @@ public:
   /** @return A shared_ptr to the QMenu owned by this InteractiveMarker. */
   boost::shared_ptr<QMenu> getMenu() { return menu_; }
 
+Q_SIGNALS:
+
+void userFeedback(visualization_msgs::InteractiveMarkerFeedback &feedback);
+void statusUpdate( StatusProperty::Level level, const std::string& name, const std::string& text );
+
 protected Q_SLOTS:
   void handleMenuSelect( int menu_item_id );
 
@@ -157,7 +162,6 @@ protected:
   // current level.
   void populateMenu( QMenu* menu, std::vector<uint32_t>& ids );
 
-  InteractiveMarkerDisplay *owner_;
   DisplayContext* context_;
 
   // pose of parent coordinate frame
@@ -219,7 +223,6 @@ protected:
 
   InteractiveMarkerControlPtr description_control_;
 
-  ros::Publisher feedback_pub_;
   std::string topic_ns_;
   std::string client_id_;
 


### PR DESCRIPTION
Needed for moveit rviz plugin. It allows directly creating IM inside rviz, without the need of an IM server and client display
