### PR TITLE
Added visualization support for fixed-distance rangers.

### DIFF
--- a/src/rviz/default_plugin/range_display.cpp
+++ b/src/rviz/default_plugin/range_display.cpp
@@ -124,7 +124,7 @@ void RangeDisplay::processMessage( const sensor_msgs::Range::ConstPtr& msg )
   Ogre::Quaternion orientation;
   geometry_msgs::Pose pose;
   float displayed_range = 0.0;
-  if(msg->min_range <= msg->range || msg->range <= msg->max_range){
+  if(msg->min_range <= msg->range && msg->range <= msg->max_range){
     displayed_range = msg->range;
   } else if(msg->min_range == msg->max_range){ // Fixed distance ranger
     if(msg->range < 0 && !std::isfinite(msg->range)){ // NaNs and +Inf return false here: both of those should have 0.0 as the range


### PR DESCRIPTION
Message was updated to clarify fixed-distance rangers.  This is the updated visualization function.

Essentially performs limit checks.  Will then draw distance for a detection on a fixed distance ranger, otherwise, will not draw a detection.

http://www.ros.org/wiki/sensor_msgs/Reviews/2012-11-16-Fixed-Distance-Rangers_API_Review
