### PR TITLE
Fixes discovery of RenderingSystem_GL on osx.

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -111,6 +111,9 @@ void RenderSystem::setupDummyWindowId()
 void RenderSystem::loadOgrePlugins()
 {
   std::string plugin_prefix = get_ogre_plugin_path() + "/";
+#ifdef Q_OS_MAC
+  plugin_prefix += "lib";
+#endif
   ogre_root_->loadPlugin( plugin_prefix + "RenderSystem_GL" );
   ogre_root_->loadPlugin( plugin_prefix + "Plugin_OctreeSceneManager" );
   ogre_root_->loadPlugin( plugin_prefix + "Plugin_ParticleFX" );


### PR DESCRIPTION
Original error:

```
∫ rosrun rviz rviz 
[ INFO] [1358386092.761466000]: rviz version 1.9.19
[ INFO] [1358386092.761550000]: compiled against OGRE version 1.7.4 (Cthugha)
[ WARN] [1358386096.686693000]: OGRE EXCEPTION(7:InternalErrorException): Could not load dynamic library /usr/local/Cellar/ogre/1.7.4/lib/RenderSystem_GL.  System Error: dlopen(/usr/local/Cellar/ogre/1.7.4/lib/RenderSystem_GL.dylib, 9): image not found in DynLib::load at /tmp/ogre-w5AP/ogre_src_v1-7-4/OgreMain/src/OgreDynLib.cpp (line 91)
terminate called throwing an exceptionAbort trap: 6
```

The libraries are prefixed with lib on OS X.
