### PR TITLE
Fix compatibility with latest OGRE

### DIFF
--- a/src/rviz/ogre_helpers/ogre_logging.cpp
+++ b/src/rviz/ogre_helpers/ogre_logging.cpp
@@ -43,6 +43,18 @@ public:
   RosLogListener(): min_lml(Ogre::LML_CRITICAL) {};
   virtual ~RosLogListener() {}
 
+#if OGRE_VERSION >= ((1 << 16) | (8 << 8))
+  virtual void messageLogged( const Ogre::String& message, Ogre::LogMessageLevel lml, bool maskDebug, const Ogre::String &logName, bool& skipThisMessage )
+  {
+    if ( !skipThisMessage )
+    {
+      if ( lml >= min_lml )
+      {
+        ROS_LOG((ros::console::levels::Level)(lml-1), ROSCONSOLE_DEFAULT_NAME, "%s", message.c_str() );
+      }
+    }
+   }
+#else
   virtual void messageLogged( const Ogre::String& message, Ogre::LogMessageLevel lml, bool maskDebug, const Ogre::String &logName )
   {
     if ( lml >= min_lml )
@@ -50,6 +62,7 @@ public:
       ROS_LOG((ros::console::levels::Level)(lml-1), ROSCONSOLE_DEFAULT_NAME, "%s", message.c_str() );
     }
   }
+#endif
   Ogre::LogMessageLevel min_lml;
 };
 

--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -861,7 +861,9 @@ Ogre::Real PointCloudRenderable::getSquaredViewDepth(const Ogre::Camera* cam) co
 
 void PointCloudRenderable::getWorldTransforms(Ogre::Matrix4* xform) const
 {
-   *xform = m_matWorldTransform * parent_->getParentNode()->_getFullTransform();
+   Ogre::Matrix4 worldTransform;
+   SimpleRenderable::getWorldTransforms(&worldTransform);
+   *xform = worldTransform * parent_->getParentNode()->_getFullTransform();
 }
 
 const Ogre::LightList& PointCloudRenderable::getLights() const


### PR DESCRIPTION
In PointCloudRenderable::getWorldTransforms, call parent method
to obtain the world transform, as the name the matrix is stored in
has changed in newer versions. In RosLogListener, use updated signature
for Ogre::LogListener::messageLogged, if OGRE is newer than version
1.8.0.
