### PR TITLE
Click point patch

### DIFF
--- a/src/rviz/selection/selection_manager.h
+++ b/src/rviz/selection/selection_manager.h
@@ -150,31 +150,46 @@ public:
   /** Return true if the point at x, y in the viewport is showing an
    * object, false otherwise.  If it is showing an object, result will
    * be changed to contain the 3D point corresponding to it. */
-  bool get3DPoint( Ogre::Viewport* viewport, int x, int y, Ogre::Vector3& result_point );
+  bool get3DPoint( Ogre::Viewport* viewport, const int x, const int y, Ogre::Vector3& result_point );
 
   /** @brief Gets the 3D points in a box around a point in a view port
       
       @param[in] viewport        Rendering area clicked on.
-      @param[in] x               x coordinate of center of box.
-      @param[in] y               y coordinate of center of box.
-      @param[in] patch_padding   The number of points of on each side of center.
+      @param[in] x               x coordinate of upper-left corner of box.
+      @param[in] y               y coordinate of upper-left corner of box.
+      @param[in] width           The width of the rendered box in pixels.
+      @param[in] height          The height of the rendered box in pixels.
       @param[in] skip_missing    Whether to skip non-existing points or insert NaNs for them
       
       @param[out] result_points  The vector of output points.      
+
+      @returns                   True if any valid point is rendered in the box. NaN points count, 
+                                 so if skip_missing is false, this will always return true if 
+                                 width and height are > 0.
+                                 
    */
-  bool get3DPatch( Ogre::Viewport* viewport, int x, int y, unsigned patch_padding, bool skip_missing, std::vector<Ogre::Vector3> &result_points );
+  bool get3DPatch( Ogre::Viewport* viewport, const int x, const int y, const unsigned width, 
+                   const unsigned height, const bool skip_missing, 
+                   std::vector<Ogre::Vector3> &result_points );
 
 
     /** @brief Renders a depth image in a box around a point in a view port
       
       @param[in] viewport        Rendering area clicked on.
-      @param[in] x               x coordinate of center of box.
-      @param[in] y               y coordinate of center of box.
-      @param[in] patch_padding   The number of points of on each side of center.
+      @param[in] x               x coordinate of upper-left corner of box.
+      @param[in] y               y coordinate of upper-left corner of box.
+      @param[in] width           The width of the rendered box in pixels.
+      @param[in] height          The height of the rendered box in pixels.
       
-      @param[out] depth_vector  The vector of depth values.      
+      @param[out] depth_vector   The vector of depth values.      
+
+      @returns                   True if rendering operation to render
+                                 depth data to the depth texture buffer
+                                 succeeds. Failure likely indicates a 
+                                 pretty serious problem.
    */
-  bool getPatchDepthImage( Ogre::Viewport* viewport, int x, int y,  unsigned patch_padding, std::vector<float> & depth_vector);
+  bool getPatchDepthImage( Ogre::Viewport* viewport, const int x, const int y,  const unsigned width, 
+                           const unsigned height, std::vector<float> & depth_vector);
 
   // Implementation for Ogre::RenderQueueListener.
   void renderQueueStarted( uint8_t queueGroupId,
@@ -204,11 +219,11 @@ private:
   bool render( Ogre::Viewport* viewport, Ogre::TexturePtr tex,
                int x1, int y1, int x2, int y2,
                Ogre::PixelBox& dst_box, std::string material_scheme,
-               unsigned texture_size );
+               unsigned texture_width, unsigned textured_height );
 
   void unpackColors(const Ogre::PixelBox& box, V_CollObject& pixels);
 
-  void setDepthTextureSize(unsigned size);
+  void setDepthTextureSize(unsigned width, unsigned height);
 
   void publishDebugImage( const Ogre::PixelBox& pixel_box, const std::string& label );
 
@@ -239,7 +254,7 @@ private:
 
   // Graphics card -based depth finding of clicked points.
   Ogre::TexturePtr depth_render_texture_;
-  uint32_t depth_texture_size_;
+  uint32_t depth_texture_width_, depth_texture_height_;
   Ogre::PixelBox depth_pixel_box_;
 
   uint32_t uid_counter_;


### PR DESCRIPTION
Implements get3DPatch and getPatchDepthImage and reimplements get3DPoint as a special case of get3DPatch.

getPatchDepthImage renders a depth image to the clicked viewport's camera in a box around the clicked position.

get3DPatch captures the depth image and then reprojects it to produce the 3D points in the region.
