### PR TITLE
prevent link visibility changes due to other property updates

### DIFF
--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -85,6 +85,7 @@ void Robot::setVisible( bool visible )
   {
     root_visual_node_->setVisible( visual_visible_ );
     root_collision_node_->setVisible( collision_visible_ );
+    updateLinkVisibilities();
   }
   else
   {


### PR DESCRIPTION
root_visual_node_->setVisible and root_collision_node_->setVisible force all
link nodes to be visible, so updateLinkVisibilities() is needed after calling
them,
