### PR TITLE
turn off (broken) horiz scrollbar on property tree window

### DIFF
--- a/src/rviz/properties/property_tree_widget.cpp
+++ b/src/rviz/properties/property_tree_widget.cpp
@@ -55,6 +55,7 @@ PropertyTreeWidget::PropertyTreeWidget( QWidget* parent )
   setAnimated( true );
   setSelectionMode( QAbstractItemView::ExtendedSelection );
   setEditTriggers( QAbstractItemView::AllEditTriggers );
+  setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 
   QTimer* timer = new QTimer( this );
   connect( timer, SIGNAL( timeout() ), this, SLOT( update() ));


### PR DESCRIPTION
The horizontal scrollbar is not useful and problems occur on some Linux systems
when it shows up.
