### PR TITLE
rviz crashes if a plugin library cannot be found

### DIFF
--- a/src/rviz/add_display_dialog.cpp
+++ b/src/rviz/add_display_dialog.cpp
@@ -579,6 +579,10 @@ void TopicDisplayWidget::findPlugins( DisplayFactory *factory )
     // ROS_INFO("Class: %s", lookup_name.toStdString().c_str());
 
     boost::shared_ptr<Display> disp( factory->make( lookup_name ));
+    if (!disp) {
+      ROS_WARN_STREAM("Failed to load plugin " << lookup_name.toStdString());
+      continue;
+    }
     QSet<QString> topic_types = disp->getTopicTypes();
     Q_FOREACH( QString topic_type, topic_types )
     {


### PR DESCRIPTION
Hi,

I have a plugin package that I did not compile yet for hydro but whose sources are in the `ROS_PACKAGE_PATH`. Whenever I want to use the Add button in the Display toolbox rviz crashes with the following error message:

```
[ERROR] [1378396263.659056676, 533.650000000]: PluginlibFactory: The plugin for class 'hector_rviz_plugins/Vector3' failed to load.  Error: Could not find library corresponding to plugin hector_rviz_plugins/Vector3. Make sure the plugin description XML file has the correct name of the library and that the library actually exists.
rviz: /usr/include/boost/smart_ptr/shared_ptr.hpp:418: T* boost::shared_ptr<T>::operator->() const [with T = rviz::Display]: Assertion `px != 0' failed.
```

I would expect that the display types provided by this package are not available (e.g. greyed out), but I can add other display types.

I am using Ubuntu Precise amd64, ROS hydro with ros-hydro-rviz 1.10.6 from the ROS binary repository. I am not sure if this also happened in groovy, but I think I already saw an Add Display dialog with greyed out display types there.

This bug might be related to #680, but the error message is different.

Johannes
