### PR TITLE
add color information to when users select point cloud

### DIFF
--- a/src/rviz/default_plugin/point_cloud_transformers.h
+++ b/src/rviz/default_plugin/point_cloud_transformers.h
@@ -58,6 +58,7 @@ inline int32_t findChannelIndex(const sensor_msgs::PointCloud2ConstPtr& cloud, c
   return -1;
 }
 
+
 template<typename T>
 inline T valueFromCloud(const sensor_msgs::PointCloud2ConstPtr& cloud, uint32_t offset, uint8_t type, uint32_t point_step, uint32_t index)
 {
@@ -70,7 +71,7 @@ inline T valueFromCloud(const sensor_msgs::PointCloud2ConstPtr& cloud, uint32_t 
   case sensor_msgs::PointField::UINT8:
     {
       uint8_t val = *reinterpret_cast<const uint8_t*>(data);
-      ret = static_cast<T>(val);
+      ret = *reinterpret_cast<T*>(&val);
       break;
     }
 
@@ -78,7 +79,7 @@ inline T valueFromCloud(const sensor_msgs::PointCloud2ConstPtr& cloud, uint32_t 
   case sensor_msgs::PointField::UINT16:
     {
       uint16_t val = *reinterpret_cast<const uint16_t*>(data);
-      ret = static_cast<T>(val);
+      ret = *reinterpret_cast<T*>(&val);
       break;
     }
 
@@ -86,21 +87,21 @@ inline T valueFromCloud(const sensor_msgs::PointCloud2ConstPtr& cloud, uint32_t 
   case sensor_msgs::PointField::UINT32:
     {
       uint32_t val = *reinterpret_cast<const uint32_t*>(data);
-      ret = static_cast<T>(val);
+      ret = *reinterpret_cast<T*>(&val);
       break;
     }
 
   case sensor_msgs::PointField::FLOAT32:
     {
       float val = *reinterpret_cast<const float*>(data);
-      ret = static_cast<T>(val);
+      ret = *reinterpret_cast<T*>(&val);
       break;
     }
 
   case sensor_msgs::PointField::FLOAT64:
     {
       double val = *reinterpret_cast<const double*>(data);
-      ret = static_cast<T>(val);
+      ret = *reinterpret_cast<T*>(&val);
       break;
     }
   default:


### PR DESCRIPTION
Selecting pointcloud date in rviz using select panel button (http://wiki.ros.org/rviz/UserGuide#Select_.28Keyboard_shortcut:_s.29), shows "selection" panel that listed all points which I selected. These data contains, name, position vector and color, but all color information is black. This patch is workaround for this issue and I checked http://wiki.ros.org/rviz/DisplayTypes/PointCloud page to use reinterpret_case for convert float data to Uint data.

```
0.0.2 RGB
Valid channel names: rgb (1 channel), r, g, b (3 channel)

RGB only affects the color of the point.

There are two ways to specify RGB:

3 channels, named "r", "g", and "b", with floating point values between 0 and 1.
1 channel, with the float in the channel reinterpreted as 3 single-byte values with ranges from 0 to 255. 0xff0000 is red, 0xff00 is green, 0xff is blue.
In C++, int rgb = 0xff0000; float float_rgb = *reinterpret_cast<float*>(&rgb); 
In Python,  float_rgb = struct.unpack('f', struct.pack('i', 0xff0000))[0]
```
