### PR TITLE
RVIZ should use ros::MessageEvents for connection information

### DIFF
--- a/src/rviz/default_plugin/effort_display.h
+++ b/src/rviz/default_plugin/effort_display.h
@@ -270,7 +270,7 @@ public:
 	bool testMessage(const MEvent& evt)
 	    {
 		const MConstPtr& message = evt.getMessage();
-		std::string callerid = evt.getPublisherName();//message->__connection_header ? (*message->__connection_header)["callerid"] : "unknown";
+		std::string callerid = evt.getPublisherName();
 		std::string frame_id = ros::message_traits::FrameId<M>::value(*message);
 		ros::Time stamp = ros::message_traits::TimeStamp<M>::value(*message);
 

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -238,9 +238,11 @@ void MarkerDisplay::incomingMarker( const visualization_msgs::Marker::ConstPtr& 
   message_queue_.push_back(marker);
 }
 
-void MarkerDisplay::failedMarker(const visualization_msgs::Marker::ConstPtr& marker, tf::FilterFailureReason reason)
+void MarkerDisplay::failedMarker(const ros::MessageEvent<visualization_msgs::Marker>& marker_evt, tf::FilterFailureReason reason)
 {
-  std::string error = context_->getFrameManager()->discoverFailureReason(marker->header.frame_id, marker->header.stamp, marker->__connection_header ? (*marker->__connection_header)["callerid"] : "unknown", reason);
+  visualization_msgs::Marker::ConstPtr marker = marker_evt.getConstMessage();
+  std::string authority = marker_evt.getPublisherName();
+  std::string error = context_->getFrameManager()->discoverFailureReason(marker->header.frame_id, marker->header.stamp, authority, reason);
   setMarkerStatus(MarkerID(marker->ns, marker->id), StatusProperty::Error, error);
 }
 

--- a/src/rviz/default_plugin/marker_display.h
+++ b/src/rviz/default_plugin/marker_display.h
@@ -140,7 +140,7 @@ private:
    */
   void incomingMarker(const visualization_msgs::Marker::ConstPtr& marker);
 
-  void failedMarker(const visualization_msgs::Marker::ConstPtr& marker, tf::FilterFailureReason reason);
+  void failedMarker(const ros::MessageEvent<visualization_msgs::Marker>& marker_evt, tf::FilterFailureReason reason);
 
   typedef std::map<MarkerID, MarkerBasePtr> M_IDToMarker;
   typedef std::set<MarkerBasePtr> S_MarkerBase;

--- a/src/rviz/frame_manager.h
+++ b/src/rviz/frame_manager.h
@@ -206,15 +206,21 @@ private:
   bool adjustTime( const std::string &frame, ros::Time &time );
 
   template<class M>
-  void messageCallback(const boost::shared_ptr<M const>& msg, Display* display)
+  void messageCallback(const ros::MessageEvent<M>& msg_evt, Display* display)
   {
-    messageArrived(msg->header.frame_id, msg->header.stamp, msg->__connection_header ? (*msg->__connection_header)["callerid"] : "unknown", display);
+    boost::shared_ptr<M const> const &msg = msg_evt.getConstMessage();
+    std::string authority = msg_evt.getPublisherName();
+
+    messageArrived(msg->header.frame_id, msg->header.stamp, authority, display);
   }
 
   template<class M>
-  void failureCallback(const boost::shared_ptr<M const>& msg, tf::FilterFailureReason reason, Display* display)
+  void failureCallback(const ros::MessageEvent<M>& msg_evt, tf::FilterFailureReason reason, Display* display)
   {
-    messageFailed(msg->header.frame_id, msg->header.stamp, msg->__connection_header ? (*msg->__connection_header)["callerid"] : "unknown", reason, display);
+    boost::shared_ptr<M const> const &msg = msg_evt.getConstMessage();
+    std::string authority = msg_evt.getPublisherName();
+
+    messageFailed(msg->header.frame_id, msg->header.stamp, authority, reason, display);
   }
 
   void messageArrived(const std::string& frame_id, const ros::Time& stamp, const std::string& caller_id, Display* display);


### PR DESCRIPTION
Tested patch uses ros::MessageEvents for connection information, not the "__connection_header" field of a ROS message.
