### PR TITLE
Rviz in stereo

### DIFF
--- a/src/rviz/ogre_helpers/qt_ogre_render_window.h
+++ b/src/rviz/ogre_helpers/qt_ogre_render_window.h
@@ -34,6 +34,7 @@
 #include "render_widget.h"
 
 #include <OgreColourValue.h>
+#include <OgreRenderTargetListener.h>
 
 namespace Ogre
 {
@@ -51,12 +52,15 @@ namespace rviz
  *  the guts replaced by new RenderSystem and RenderWidget classes
  *  inspired by the initialization sequence of Gazebo's renderer.
  */
-class QtOgreRenderWindow : public RenderWidget {
+class QtOgreRenderWindow : public RenderWidget, public Ogre::RenderTargetListener {
 public:
   /** Constructor.
   	@param parent The parent wxWindow component.
    */
   QtOgreRenderWindow( QWidget* parent = 0 );
+
+  /** Destructor.  */
+  virtual ~QtOgreRenderWindow();
 
   /**
    * Set a callback which is called before each render
@@ -95,6 +99,15 @@ public:
    */
   void setOrthoScale( float scale );
 
+  /** \brief Enable or disable stereo rendering
+   * If stereo is not supported this is ignored.
+   * @return the old setting (whether stereo was enabled before)
+   */
+  bool enableStereo(bool enable);
+
+  /** \brief Prepare to render in stereo if enabled and supported. */
+  void setupStereo();
+
   void setAutoRender(bool auto_render) { auto_render_ = auto_render; }
 
   ////// Functions mimicked from Ogre::Viewport to satisfy timing of
@@ -106,10 +119,20 @@ protected:
   virtual void paintEvent( QPaintEvent* e );
   virtual void resizeEvent( QResizeEvent* event );
 
+  // When stereo is enabled, this is called before rendering each viewport.
+  virtual void preViewportUpdate(const Ogre::RenderTargetViewportEvent& evt);
+
   /**
    * Sets the aspect ratio on the camera
    */
   void setCameraAspectRatio();
+
+  /**
+   * prepare a viewport's camera for stereo rendering.
+   * This should only be called from StereoRenderTargetListener
+   */
+  void prepareStereoViewport(Ogre::Viewport*);
+
 
   Ogre::Viewport* viewport_;
 
@@ -124,6 +147,12 @@ protected:
   Ogre::Camera* camera_;
   bool overlays_enabled_;
   Ogre::ColourValue background_color_;
+
+  // stereo rendering
+  bool stereo_enabled_;				// true if we were asked to render stereo
+  bool rendering_stereo_;			// true if we are actually rendering stereo
+  Ogre::Camera* right_camera_;
+  Ogre::Viewport* right_viewport_;
 };
 
 } // namespace rviz

--- a/src/rviz/ogre_helpers/render_system.h
+++ b/src/rviz/ogre_helpers/render_system.h
@@ -63,10 +63,23 @@ public:
   // @brief Force to use the provided OpenGL version on startup
   static void forceGlVersion( int version );
 
+  // @brief Disable stereo rendering even if supported in HW.
+  static void forceNoStereo();
+
+  // @brief True if we can render stereo on this device.
+  bool isStereoSupported() { return stereo_supported_; }
+
 private:
   RenderSystem();
   void setupDummyWindowId();
   void loadOgrePlugins();
+
+  // helper for makeRenderWindow()
+  Ogre::RenderWindow* tryMakeRenderWindow(const std::string& name,
+                                          unsigned int width,
+                                          unsigned int height,
+                                          const Ogre::NameValuePairList* params,
+                                          int max_attempts);
 
   // Find and configure the render system.
   void setupRenderSystem();
@@ -84,6 +97,8 @@ private:
   int gl_version_;
   int glsl_version_;
   static int force_gl_version_;
+  bool stereo_supported_;
+  static bool force_no_stereo_;
 };
 
 } // end namespace rviz

--- a/src/rviz/view_controller.h
+++ b/src/rviz/view_controller.h
@@ -53,6 +53,7 @@ class EnumProperty;
 class RenderPanel;
 class ViewportMouseEvent;
 class FloatProperty;
+class BoolProperty;
 
 class ViewController: public Property
 {
@@ -154,6 +155,7 @@ Q_SIGNALS:
 private Q_SLOTS:
 
   void updateNearClipDistance();
+  void updateStereoProperties();
 
 protected:
   /** @brief Do subclass-specific initialization.  Called by
@@ -185,6 +187,10 @@ protected:
   QCursor cursor_;
 
   FloatProperty* near_clip_property_;
+  BoolProperty* stereo_enable_;
+  BoolProperty* stereo_eye_swap_;
+  FloatProperty* stereo_eye_separation_;
+  FloatProperty* stereo_focal_distance_;
 
   void setStatus( const QString & message );
 

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -155,6 +155,7 @@ VisualizationFrame::VisualizationFrame( QWidget* parent )
 
 VisualizationFrame::~VisualizationFrame()
 {
+  delete render_panel_;
   delete manager_;
 
   for( int i = 0; i < custom_panels_.size(); i++ )

--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -133,6 +133,7 @@ bool VisualizerApp::init( int argc, char** argv )
       ("ogre-log,l", "Enable the Ogre.log file (output in cwd) and console output.")
       ("in-mc-wrapper", "Signal that this is running inside a master-chooser wrapper")
       ("opengl", po::value<int>(), "Force OpenGL version (use '--opengl 210' for OpenGL 2.1 compatibility mode)")
+      ("no-stereo", "Disable the use of stereo rendering.")
       ("verbose,v", "Enable debug visualizations");
     po::variables_map vm;
     std::string display_config, fixed_frame, splash_path, help_path;
@@ -140,6 +141,7 @@ bool VisualizerApp::init( int argc, char** argv )
     bool in_mc_wrapper = false;
     bool verbose = false;
     int force_gl_version = 0;
+	bool disable_stereo = false;
     try
     {
       po::store( po::parse_command_line( argc, argv, options ), vm );
@@ -188,6 +190,11 @@ bool VisualizerApp::init( int argc, char** argv )
         enable_ogre_log = true;
       }
 
+      if (vm.count("no-stereo"))
+      {
+        disable_stereo = true;
+      }
+
       if (vm.count("opengl"))
       {
         //std::cout << vm["opengl"].as<std::string>() << std::endl;
@@ -224,6 +231,11 @@ bool VisualizerApp::init( int argc, char** argv )
     if ( force_gl_version )
     {
       RenderSystem::forceGlVersion( force_gl_version );
+    }
+
+    if ( disable_stereo )
+    {
+      RenderSystem::forceNoStereo();
     }
 
     frame_ = new VisualizationFrame;


### PR DESCRIPTION
This adds stereo rendering support to Rviz.

To see stereo Rviz must be built against a version of Ogre that was
built with the OGRE_STEREO_ENABLE config option enabled.  This option
is currently only supported in the branch of Ogre found here
  https://bitbucket.org/crefvik/ogre
or here
  https://bitbucket.org/acornacorn/ogre

To see stereo you will need:
- a stereo monitor
  (I am using an ASUS VG278H)
- a video card that supports quad-buffer stereo.
  (I am using an NVIDIA Quadro K4000)

To build rviz with stereo support:
remove debian-installed ogre:

```
    sudo apt-get remove libogre-1.7.4 libogre-dev
```

build the stereo-enabled ogre:

```
    cd $HOME
    mkdir my-ogre
    cd my-ogre
    hg clone https://bitbucket.org/crefvik/ogre
    mkdir build
    cd build
    cmake -DOGRE_FULL_RPATH=ON -DOGRE_BUILD_STEREO_SUPPORT=ON ../ogre
    sudo make install
```

then build rviz as usual using catkin_make

```
    cd $HOME
    mkdir -p my-workspace/src
    cd my-workspace/src
    git clone https://github.com/ros-visualization/rviz.git
    cd ..
    catkin_make
```

Run rviz

```
    roscore & rosrun rviz rviz
```

If your HW supports stereo you should see a double image (stereo when
wearing the glasses).  Properties in the ViewController panel can be
used to set eye-separation, focal-distance, to swap the eyes, and to
disable stereo.

If stereo is supported on your hardware, rviz will automatically
render in stereo unless you either
- disable stereo by unchecking the "Enable Stereo Rendering" property in the view panel.
- use the --no-stereo commandline option (stereo properties will be hidden)

If stereo is not suppported on your hardware, rviz will not render in
stereo and the stereo-related properties will be hidden.
