### PR TITLE
Fix mesh bug in moveit_ros/visualization.

### DIFF
--- a/src/rviz/ogre_helpers/mesh_shape.cpp
+++ b/src/rviz/ogre_helpers/mesh_shape.cpp
@@ -55,6 +55,7 @@ MeshShape::~MeshShape()
   // destroy the entity first
   if (entity_)
   {
+    entity_->detachFromParent();
     scene_manager_->destroyEntity( entity_ );
     entity_ = NULL;
   }
@@ -124,7 +125,8 @@ void MeshShape::endTriangles()
   {
     started_ = false;
     manual_object_->end();
-    std::string name = "ConvertedMeshShape@" + boost::lexical_cast<std::string>(this);
+    static uint32_t count = 0;
+    std::string name = "ConvertedMeshShape@" + boost::lexical_cast<std::string>(count++);
     manual_object_->convertToMesh(name);
     entity_ = scene_manager_->createEntity(name);
     if (entity_)


### PR DESCRIPTION
This fixes https://github.com/ros-planning/moveit_ros/issues/348.

This class could be streamlined by entirely removing the `entity_` member and never calling convertToMesh(), since ManualObjects can be added to SceneNodes just like Entities.  There is no need for the intermediary.  In fact, this is probably leaking mesh objects into Ogre that are never cleaned up.  This change is smaller to just fix the bug so I don't need to think about side effects immediately.

The bug happens because the calling code is frequently destroying and re-creating these objects (that is a bad idea, I know, but someone else wrote it) and so the same pointer value is frequently re-used for a different mesh.  But since we've baked the pointer value into the mesh name that we gave Ogre, we often get the wrong mesh showing up.  Sigh.  This just replaces the string-ified pointer with an always-incrementing counter.
