### PR TITLE
EffortDisplay: Added a check to avoid segfaults when receiving a joint s...

### DIFF
--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -281,6 +281,13 @@ namespace rviz
 
         V_string joints;
         int joint_num = msg->name.size();
+        if (joint_num!=msg->effort.size())
+        {
+            std::string tmp_error="Received a joint state msg with different joint names and efforts size!";
+            ROS_ERROR(tmp_error.c_str());
+            setStatus( rviz::StatusProperty::Error, "TOPIC", QString::fromStdString(tmp_error));
+            return;
+        }
         for (int i = 0; i < joint_num; i++ )
         {
             std::string joint_name = msg->name[i];


### PR DESCRIPTION
...tate without efforts

We were using robot_state_publisher to test a custom GUI with an effortDisplay and a robotModelDisplay.
The effortDisplay was causing crashes because robot_state_publisher does not publish effort information. 
We tried in the normal Rviz and the behavior is the same, so we added a check inside effort_display.cpp to tell the user that he's not sending effort information coherent with joint names.
