### PR TITLE
Use assimp-dev dep for building

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -45,7 +45,7 @@
   <build_depend>libqt4-opengl-dev</build_depend>
   <build_depend>libogre-dev</build_depend>
   <build_depend>yaml-cpp</build_depend>
-  <build_depend>assimp</build_depend>
+  <build_depend>assimp-dev</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>map_msgs</build_depend>
   <build_depend>tinyxml</build_depend>


### PR DESCRIPTION
The assimp-dev dep has existed for a while now. We should use that for building and leave the runtime dep as-is.

See https://github.com/ros/rosdistro/commit/a506ef945febc0cd886bbc29ab976751d1cb1f3b

Blocks https://github.com/ros-visualization/rviz/issues/730 for Fedora
