### PR TITLE
Fixed a bug in tutorials caused by uninitialized ros::Time here.

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -412,10 +412,7 @@ Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned
 
   stereo_supported_ = is_stereo;
 
-  // ros::Time::init() here is necessary to keep ROS_INFO_THROTTLE()
-  // from throwing an exception about uninitialized time.
-  ros::Time::init();
-  ROS_INFO_THROTTLE(5, "Stereo is %s", stereo_supported_ ? "SUPPORTED" : "NOT SUPPORTED");
+  ROS_INFO_ONCE("Stereo is %s", stereo_supported_ ? "SUPPORTED" : "NOT SUPPORTED");
 
   return window;
 }


### PR DESCRIPTION
visualization_tutorials/librviz_tutorial was crashing for me with an exception caused by ros::Time not being initialized.  The cause was a ROS_INFO_THROTTLE() call added with the stereo-support changes.  Apparently ROS_INFO_THROTTLE() does not use wall time, it must be using ros time.  Calling ros::Time::init() first seems harmless.  Merge if you agree. :)
