### PR TITLE
Fix disabling of groups (#709)

### DIFF
--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -279,7 +279,7 @@ Qt::ItemFlags Property::getViewFlags( int column ) const
 {
   // if the parent propery is a disabled bool property or
   // has its own enabled view flag not set, disable this property as well
-  Qt::ItemFlags enabled_flag = Qt::ItemIsEnabled;//is_read_only_ || ( parent_ && parent_->getDisableChildren() ) ? Qt::NoItemFlags : Qt::ItemIsEnabled;
+  Qt::ItemFlags enabled_flag = ( parent_ && parent_->getDisableChildren() ) ? Qt::NoItemFlags : Qt::ItemIsEnabled;  // || is_read_only_
 
   if( column == 0 )
   {


### PR DESCRIPTION
This was broken with commit 5897285, which reverted the changes from
commit c6dacb1, but rather than only removing the change concerning
the read-only attribute, commented out the entire check, including
the parent_->getDisableChildren() call (which existed prior to
commit 5897285).
