### PR TITLE
Add missing libraries to rviz link step, fixes OS X build.

### DIFF
--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -188,6 +188,7 @@ target_link_libraries(${PROJECT_NAME}
   ${OGRE_OV_LIBRARIES_ABS}
   ${OPENGL_LIBRARIES}
   ${QT_LIBRARIES}
+  ${rviz_ADDITIONAL_LIBRARIES}
   ${urdfdom_LIBRARIES}
   assimp
   yaml-cpp


### PR DESCRIPTION
Fix as described here: http://answers.ros.org/question/64048/osx-groovy-rviz-runtime-error-librviz-symbol-not-found/?answer=64106#post-id-64106

attn: @wjwwood
