### PR TITLE
Fix memory leak in BillboardLine destructor (material not being destroyed correctly)

### DIFF
--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -86,7 +86,7 @@ BillboardLine::~BillboardLine()
 
   scene_manager_->destroySceneNode( scene_node_->getName() );
 
-  material_->unload();
+  Ogre::MaterialManager::getSingleton().remove(material_->getName());
 }
 
 Ogre::BillboardChain* BillboardLine::createChain()


### PR DESCRIPTION
See issue #745, this pull request fixes the memory leak
