### PR TITLE
Fix segfault on exit for OSX

### DIFF
--- a/src/rviz/ogre_helpers/qt_ogre_render_window.cpp
+++ b/src/rviz/ogre_helpers/qt_ogre_render_window.cpp
@@ -160,17 +160,20 @@ Ogre::Viewport* QtOgreRenderWindow::getViewport () const
 
 void QtOgreRenderWindow::setCamera( Ogre::Camera* camera )
 {
-  camera_ = camera;
-  viewport_->setCamera( camera );
-
-  setCameraAspectRatio();
-
-  if (camera_ && rendering_stereo_ && !right_camera_)
+  if (camera)
   {
-    right_camera_ = camera_->getSceneManager()->createCamera(camera_->getName() + "-right");
-  }
+    camera_ = camera;
+    viewport_->setCamera( camera );
 
-  update();
+    setCameraAspectRatio();
+
+    if (camera_ && rendering_stereo_ && !right_camera_)
+    {
+      right_camera_ = camera_->getSceneManager()->createCamera(camera_->getName() + "-right");
+    }
+
+    update();
+  }
 }
 
 void QtOgreRenderWindow::setOverlaysEnabled( bool overlays_enabled )


### PR DESCRIPTION
On OSX, when you exit rviz you get a segfault. Apparently it tries to set an invalid camera pointer. Not sure if this is the best fix, maybe the reason the camera is invalid should also be fixed?

Related to issue 737: https://github.com/ros-visualization/rviz/issues/737
