### PR TITLE
correctly display selected point's rgb information when registered as a float 

### DIFF
--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -190,28 +190,28 @@ void PointCloudSelectionHandler::createProperties( const Picked& obj, Property* 
           }
           if( name == "rgb" )
           {
-	    uint32_t val;
-	    
-	    // float is still just packed uint8s, so prevent static_cast from manipulating data
-	    if (f.datatype == sensor_msgs::PointField::FLOAT32)
-	    {
-	      float raw_val = valueFromCloud<float>( message, f.offset, f.datatype, message->point_step, index );
-	      val = *(reinterpret_cast<uint32_t*>(&raw_val));
-	    }
-	    else
-	    {
-	      val = valueFromCloud<uint32_t>( message, f.offset, f.datatype, message->point_step, index );
-	    }
-	    
-	    // Mask out any information stored in the upper 8 bits
+            uint32_t val;
+
+            // float is still just packed uint8s, so prevent static_cast from manipulating data
+            if (f.datatype == sensor_msgs::PointField::FLOAT32)
+            {
+              float raw_val = valueFromCloud<float>( message, f.offset, f.datatype, message->point_step, index );
+              val = *(reinterpret_cast<uint32_t*>(&raw_val));
+            }
+            else
+            {
+              val = valueFromCloud<uint32_t>( message, f.offset, f.datatype, message->point_step, index );
+            }
+
+            // Mask out any information stored in the upper 8 bits
             ColorProperty* prop = new ColorProperty( QString( "%1: %2" ).arg( field ).arg( QString::fromStdString( name )),
-						     QColor( (val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff ), "", cat );
+                                                     QColor( (val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff ), "", cat );
             prop->setReadOnly( true );
           }
           else
           {
             float val = valueFromCloud<float>( message, f.offset, f.datatype, message->point_step, index );
-            
+
             FloatProperty* prop = new FloatProperty( QString( "%1: %2" ).arg( field ).arg( QString::fromStdString( name )),
                                                      val, "", cat );
             prop->setReadOnly( true );


### PR DESCRIPTION
When the rgb information is registered as a float, it should still be interpreted as packed uint8s in a uint32, but the existing code static_casts it into a float when reading it out, manipulating the raw data.  
When the rgb(a) information is registered as a uint32, this is correctly handled.  The PCL spec seems to state that rgb is registered as a float, while rgba is registered as a uint32, though rviz does not appear to handle the transparency channel.

http://docs.pointclouds.org/1.7.0/structpcl_1_1_point_x_y_z_r_g_b_normal.html
http://docs.pointclouds.org/1.7.0/structpcl_1_1_point_x_y_z_r_g_b_a.html

Here is where one of the problems occurs:

https://github.com/ros-visualization/rviz/blob/1.9.36/src/rviz/default_plugin/point_cloud_common.cpp#L193
https://github.com/ros-visualization/rviz/blob/1.9.36/src/rviz/default_plugin/point_cloud_transformers.h#L96

As @wjwwood and @hersh correctly assert in #701 , changing them all to reinterpret_casts is clearly not a good idea. 

What I suggest is minimal modification, simply requesting the value as a float if it is registered as a float to avoid manipulation during the cast, then doing the casting as expected.  That way there is no modification to valueFromCloud or when the registered value is uint32

Additionally, there is a minor error that does not mask out data stored in the upper 8 bits.  See the reference and implementation in another rviz file or the PCL documentation:

https://github.com/ros-visualization/rviz/blob/1.9.36/src/rviz/default_plugin/point_cloud_transformers.cpp#L329
http://docs.pointclouds.org/1.7.0/structpcl_1_1_point_x_y_z_r_g_b_a.html
