### PR TITLE
fix the issue with using boost::signal with tf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,10 @@ find_package(catkin REQUIRED
   visualization_msgs
 )
 
+if(${tf_VERSION} VERSION_LESS "1.11.3")
+  add_definitions("-DRVIZ_USE_BOOST_SIGNAL_1")
+endif()
+
 
 find_package(Eigen REQUIRED)
 

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -284,7 +284,7 @@ namespace rviz
         if (joint_num != msg->effort.size())
         {
             std::string tmp_error = "Received a joint state msg with different joint names and efforts size!";
-            ROS_ERROR(tmp_error.c_str());
+            ROS_ERROR("%s", tmp_error.c_str());
             setStatus(rviz::StatusProperty::Error, "TOPIC", QString::fromStdString(tmp_error));
             return;
         }

--- a/src/rviz/default_plugin/effort_display.h
+++ b/src/rviz/default_plugin/effort_display.h
@@ -30,9 +30,15 @@ namespace urdf
 // https://code.ros.org/trac/ros-pkg/ticket/5467
 namespace tf
 {
+#ifdef TF_MESSAGEFILTER_DEBUG
+# undef TF_MESSAGEFILTER_DEBUG
+#endif
 #define TF_MESSAGEFILTER_DEBUG(fmt, ...) \
   ROS_DEBUG_NAMED("message_filter", "MessageFilter [target=%s]: "fmt, getTargetFramesString().c_str(), __VA_ARGS__)
 
+#ifdef TF_MESSAGEFILTER_WARN
+# undef TF_MESSAGEFILTER_WARN
+#endif
 #define TF_MESSAGEFILTER_WARN(fmt, ...) \
   ROS_WARN_NAMED("message_filter", "MessageFilter [target=%s]: "fmt, getTargetFramesString().c_str(), __VA_ARGS__)
 
@@ -43,7 +49,11 @@ public:
 	typedef boost::shared_ptr<M const> MConstPtr;
 	typedef ros::MessageEvent<M const> MEvent;
 	typedef boost::function<void(const MConstPtr&, FilterFailureReason)> FailureCallback;
+#ifdef RVIZ_USE_BOOST_SIGNAL_1
 	typedef boost::signal<void(const MConstPtr&, FilterFailureReason)> FailureSignal;
+#else
+	typedef boost::signals2::signal<void(const MConstPtr&, FilterFailureReason)> FailureSignal;
+#endif
 
 	// If you hit this assert your message does not have a header, or does not have the HasHeader trait defined for it
 	ROS_STATIC_ASSERT(ros::message_traits::HasHeader<M>::value);
@@ -484,7 +494,11 @@ public:
 
 	ros::Duration time_tolerance_; ///< Provide additional tolerance on time for messages which are stamped but can have associated duration
 
+#ifdef RVIZ_USE_BOOST_SIGNAL_1
 	boost::signals::connection tf_connection_;
+#else
+	boost::signals2::connection tf_connection_;
+#endif
 	message_filters::Connection message_connection_;
 
 	FailureSignal failure_signal_;
@@ -601,7 +615,7 @@ protected:
   /** @brief Incoming message callback.  Checks if the message pointer
    * is valid, increments messages_received_, then calls
    * processMessage(). */
-  void incomingMessage( const typename sensor_msgs::JointState::ConstPtr& msg )
+  void incomingMessage( const sensor_msgs::JointState::ConstPtr& msg )
     {
       if( !msg )
       {
@@ -617,7 +631,7 @@ protected:
   /** @brief Implement this to process the contents of a message.
    *
    * This is called by incomingMessage(). */
-  virtual void processMessage( const typename sensor_msgs::JointState::ConstPtr& msg ) = 0;
+  virtual void processMessage( const sensor_msgs::JointState::ConstPtr& msg ) = 0;
 
   message_filters::Subscriber<sensor_msgs::JointState> sub_;
   tf::MessageFilterJointState* tf_filter_;


### PR DESCRIPTION
`tf` recently moved to `boost::signal2`, so the effort display needed to be updated too.

I made it so that it would conditionally use `boost::signal2` if the `tf` version is greater than or equal to `1.11.3`.

I also fixed some compiler warnings in this code.

This code (the effort display) is actually pretty wicked... I commented on the original pull request which added it as a built-in display type.

closes #700
