### PR TITLE
Fix/spurious print

### DIFF
--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -197,7 +197,6 @@ void RenderPanel::showContextMenu( boost::shared_ptr<QMenu> menu )
 
 void RenderPanel::onContextMenuHide()
 {
-  std::cout << "hide\n";
   context_menu_visible_ = false;
 }
 


### PR DESCRIPTION
The important fix in this PR is in `render_panel.cpp`, where I removed a print that was happening **every time** an interactive marker menu was hidden.

While I was digging around in the code trying to figure out why highlighting doesn't work I also fixed some minor style issues in `interactive_marker_control.cpp`:
- use `static const float` in a cpp file instead of `#define`
- make a function brace consistent with the style in rviz.

Unfortunately highlighting still doesn't work :(
