### PR TITLE
Triangle list marker shading

### DIFF
--- a/src/rviz/default_plugin/markers/triangle_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.cpp
@@ -163,9 +163,23 @@ void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const M
   }
   else
   {
-    for (size_t i = 0; i < num_points; ++i)
+    for (size_t i = 0; i < num_points/3; ++i)
     {
-      manual_object_->position(new_message->points[i].x, new_message->points[i].y, new_message->points[i].z);
+      Ogre::Vector3 a(new_message->points[3*i].x, new_message->points[3*i].y, new_message->points[3*i].z);
+      Ogre::Vector3 b(new_message->points[3*i+1].x, new_message->points[3*i+1].y, new_message->points[3*i+1].z);
+      Ogre::Vector3 c(new_message->points[3*i+2].x, new_message->points[3*i+2].y, new_message->points[3*i+2].z);
+
+      Ogre::Vector3 normal = (b-a).crossProduct(c-a);
+      normal.normalise();
+
+      manual_object_->position(a);
+      manual_object_->normal(normal);
+
+      manual_object_->position(b);
+      manual_object_->normal(normal);
+
+      manual_object_->position(c);
+      manual_object_->normal(normal);
     }
   }
 
@@ -183,8 +197,8 @@ void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const M
     g = new_message->color.g;
     b = new_message->color.b;
     a = new_message->color.a;
-    material_->getTechnique(0)->setAmbient( r,g,b );
-    material_->getTechnique(0)->setDiffuse( 0,0,0,a );
+    material_->getTechnique(0)->setAmbient( .5*r,.5*g,.5*b );
+    material_->getTechnique(0)->setDiffuse( r,g,b,a );
   }
 
   if( (!has_vertex_colors && new_message->color.a < 0.9998) || (has_vertex_colors && any_vertex_has_alpha))

--- a/src/test/triangle_list_marker.yaml
+++ b/src/test/triangle_list_marker.yaml
@@ -3,7 +3,7 @@ header:
   stamp: 
     secs: 0
     nsecs: 0
-  frame_id: base_link
+  frame_id: map
 ns: cube
 id: 1
 type: 11
@@ -45,6 +45,17 @@ points:
     x: 1
     y: 1
     z: 0
+  - 
+    x: 0
+    y: 0
+    z: 0
+  - 
+    x: 1
+    y: 0
+    z: 0
+  - 
+    x: 1
+    y: 0
+    z: 1
 mesh_resource: ''
 mesh_use_embedded_materials: False
----


### PR DESCRIPTION
This pull request is really just phase 1 of this fix.

I noticed a while ago that some of the markers I sent to rviz had no shading, and I just realized the reason is I'm sending them as triangle-lists.  When triangle-list markers were implemented, no one bothered to compute the normal vectors, so Ogre didn't know how to shade them.  This pull request implements it correctly (in my opinion) but only for the case where there is only one color for the whole triangle-list marker.  The marker also supports per-triangle and per-vertex colorizing, but I don't have time to port my fix to those cases right now.

I understand this is probably annoying, but I wanted to get this out there right away.  I (or anyone with some time) can pretty easily fill this out to the other 2 cases.
