### PR TITLE
fix hidden cursor bug

### DIFF
--- a/src/rviz/load_resource.cpp
+++ b/src/rviz/load_resource.cpp
@@ -105,7 +105,7 @@ QCursor makeIconCursor( QString url, bool fill_cache )
   if (icon.width() == 0 || icon.height() == 0)
   {
     ROS_ERROR( "Could not load pixmap '%s' -- using default cursor instead.", url.toStdString().c_str() );
-    return getDefaultCursor(fill_cache);
+    return getDefaultCursor();
   }
   QString cache_key = url + ".cursor";
   return makeIconCursor( icon, cache_key, fill_cache );

--- a/src/rviz/load_resource.h
+++ b/src/rviz/load_resource.h
@@ -48,10 +48,22 @@ namespace rviz
  */
 QPixmap loadPixmap( QString url, bool fill_cache=true );
 
+/* @brief Load the default cursor: an arrow.
+ *        The fill_cache parameter is ignored.
+ */
 QCursor getDefaultCursor( bool fill_cache=true );
 
+/* @brief Create a cursor using a shape in a file/url.
+ *        In case of a failure, the result will be the default arrow cursor.
+ *        If fill_cache is set to true (default), the image will be
+ *        stored in the cache after loading it from disk.
+ */
 QCursor makeIconCursor( QString icon_url, bool fill_cache=true );
 
+/* @brief Create a cursor using the shape in the icon QPixmap.
+ *        If fill_cache is set to true (default), the image will be
+ *        stored in the cache using \e cache_key.
+ */
 QCursor makeIconCursor( QPixmap icon, QString cache_key="", bool fill_cache=true );
 
 


### PR DESCRIPTION
 On some systems loading a pixmap from an svg file can fail.  On these machines
 an empty cursor results, meaning the cursor is invisible inside Rviz.  This
 change works around the problem by using an arrow cursor when the desired cursor
 pixmap canot be loaded.
