### PR TITLE
Add ability to delete all markers in Marker plugin

### DIFF
--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -204,6 +204,15 @@ void MarkerDisplay::deleteMarkersInNamespace( const std::string& ns )
   }
 }
 
+void MarkerDisplay::deleteAllMarkers()
+{
+  M_IDToMarker::iterator marker_it = markers_.begin();
+  for (; marker_it != markers_.end(); ++marker_it)
+  {
+    deleteMarker( marker_it->first );
+  }
+}
+
 void MarkerDisplay::setMarkerStatus(MarkerID id, StatusLevel level, const std::string& text)
 {
   std::stringstream ss;
@@ -272,6 +281,10 @@ void MarkerDisplay::processMessage( const visualization_msgs::Marker::ConstPtr& 
 
   case visualization_msgs::Marker::DELETE:
     processDelete( message );
+    break;
+
+  case 3: // TODO: visualization_msgs::Marker::DELETEALL when message changes in a future version of ROS
+    deleteAllMarkers();
     break;
 
   default:
@@ -392,6 +405,7 @@ void MarkerDisplay::processAdd( const visualization_msgs::Marker::ConstPtr& mess
 void MarkerDisplay::processDelete( const visualization_msgs::Marker::ConstPtr& message )
 {
   deleteMarker(MarkerID(message->ns, message->id));
+
   context_->queueRender();
 }
 

--- a/src/rviz/default_plugin/marker_display.h
+++ b/src/rviz/default_plugin/marker_display.h
@@ -83,6 +83,9 @@ public:
 
   void deleteMarker(MarkerID id);
 
+  /** @brief Delete all known markers to this plugin, regardless of id or namespace **/
+  void deleteAllMarkers();
+
   void setMarkerStatus(MarkerID id, StatusLevel level, const std::string& text);
   void deleteMarkerStatus(MarkerID id);
 


### PR DESCRIPTION
This simple change allows you to publish a message to Rviz to clear all markers in a particular Marker display via the provided ROS message topic.

To clear all, use the regular `visualization_msgs::Marker::DELETE` action, but leave the `id=0` and `namespace=""` (empty). This would be _very_ useful to me for restarting my application and clearing out all the previous left over markers. I'm always having to click that Reset button.
