### PR TITLE
Fix screenshot

### DIFF
--- a/src/rviz/screenshot_dialog.cpp
+++ b/src/rviz/screenshot_dialog.cpp
@@ -41,11 +41,14 @@
 
 #include "scaled_image_widget.h"
 #include "screenshot_dialog.h"
+#include "visualization_manager.h"
 
 namespace rviz
 {
 
-ScreenshotDialog::ScreenshotDialog( QWidget* main_window, QWidget* render_window, const QString& default_save_dir )
+ScreenshotDialog::ScreenshotDialog( QWidget* main_window, QWidget* render_window,
+    VisualizationManager *vis_manager,
+    const QString& default_save_dir )
   : QWidget( NULL ) // This should be a top-level window to act like a dialog.
   , main_window_( main_window )
   , render_window_( render_window )
@@ -53,6 +56,7 @@ ScreenshotDialog::ScreenshotDialog( QWidget* main_window, QWidget* render_window
   , delay_timer_( new QTimer( this ))
   , first_time_( true )
   , default_save_dir_( default_save_dir )
+  , vis_manager_(vis_manager)
 {
   image_widget_ = new ScaledImageWidget( .5 );
 
@@ -146,7 +150,9 @@ void ScreenshotDialog::save()
     "/rviz_screenshot_" +
     QDateTime::currentDateTime().toString( "yyyy_MM_dd-hh_mm_ss" ) +
     ".png";
+  vis_manager_->stopUpdate();
   QString filename = QFileDialog::getSaveFileName( this, "Save image", default_save_file );
+  vis_manager_->startUpdate();
   if( filename != "" )
   {
     QString with_slashes = QDir::fromNativeSeparators( filename );

--- a/src/rviz/screenshot_dialog.h
+++ b/src/rviz/screenshot_dialog.h
@@ -42,6 +42,7 @@ namespace rviz
 {
 
 class ScaledImageWidget;
+class VisualizationManager;
 
 /**
  * \brief A dialog for grabbing a screen shot.
@@ -54,7 +55,9 @@ class ScreenshotDialog: public QWidget
 {
 Q_OBJECT
 public:
-  ScreenshotDialog( QWidget* main_window, QWidget* render_window, const QString& default_save_dir = QString() );
+  ScreenshotDialog( QWidget* main_window, QWidget* render_window,
+      VisualizationManager *vis_manager,
+      const QString& default_save_dir = QString() );
   virtual ~ScreenshotDialog() {}
 
 Q_SIGNALS:
@@ -83,6 +86,7 @@ private:
   QSize saved_size_;
   bool first_time_;
   QString default_save_dir_;
+  VisualizationManager* vis_manager_;
 };
 
 } // namespace rviz

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -982,7 +982,7 @@ void VisualizationFrame::onSaveAs()
 
 void VisualizationFrame::onSaveImage()
 {
-  ScreenshotDialog* dialog = new ScreenshotDialog( this, render_panel_, QString::fromStdString( last_image_dir_ ));
+  ScreenshotDialog* dialog = new ScreenshotDialog( this, render_panel_, manager_, QString::fromStdString( last_image_dir_ ));
   connect( dialog, SIGNAL( savedInDirectory( const QString& )),
            this, SLOT( setImageSaveDirectory( const QString& )));
   dialog->show();


### PR DESCRIPTION
This fixes the "empty dialog" bug I reported in #783

It looks like the root cause here is that the QT event loop is starved by the main update loop in rviz. See https://code.google.com/p/qgtkstyle/issues/detail?id=85 and http://stackoverflow.com/questions/16240608/when-the-window-of-qfiledialoggetopenfilename-opening-the-program-has-unexpec for background.

PR against hydro-devel because it's the branch that I'm currently running. I suspect this will work in indigo as well, but I don't have a machine to test it on.
