### PR TITLE
remove explicit dependency on urdfdom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,6 @@ find_package(PythonLibs REQUIRED)
 
 find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
 
-find_package(urdfdom REQUIRED)
-
 find_package(catkin REQUIRED
   COMPONENTS
   angles
@@ -115,14 +113,12 @@ catkin_package(
     ${EIGEN_INCLUDE_DIRS}
     ${OGRE_OV_INCLUDE_DIRS}
     ${OPENGL_INCLUDE_DIR}
-    ${urdfdom_INCLUDE_DIRS}
   LIBRARIES
     rviz
     default_plugin
     ${OGRE_OV_LIBRARIES_ABS}
     ${rviz_ADDITIONAL_LIBRARIES}
     ${OPENGL_LIBRARIES}
-    ${urdfdom_LIBRARIES}
   CATKIN_DEPENDS
     geometry_msgs
     image_geometry
@@ -148,7 +144,6 @@ include_directories(SYSTEM
   ${OGRE_OV_INCLUDE_DIRS}
   ${OPENGL_INCLUDE_DIR}
   ${PYTHON_INCLUDE_PATH}
-  ${urdfdom_INCLUDE_DIRS}
 )
 include_directories(src ${catkin_INCLUDE_DIRS})
 

--- a/package.xml
+++ b/package.xml
@@ -46,7 +46,6 @@
   <build_depend>tf</build_depend>
   <build_depend>tinyxml</build_depend>
   <build_depend>urdf</build_depend>
-  <build_depend>urdfdom</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
 
@@ -78,7 +77,6 @@
   <run_depend>tf</run_depend>
   <run_depend>tinyxml</run_depend>
   <run_depend>urdf</run_depend>
-  <run_depend>urdfdom</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>yaml-cpp</run_depend>
 

--- a/src/python_bindings/sip/CMakeLists.txt
+++ b/src/python_bindings/sip/CMakeLists.txt
@@ -40,7 +40,7 @@ find_package(python_qt_binding REQUIRED)
 include(${python_qt_binding_EXTRAS_DIR}/sip_helper.cmake)
 
 # maintain context for different named target
-set(rviz_sip_INCLUDE_DIRS ${rviz_INCLUDE_DIRS} "${PROJECT_SOURCE_DIR}/src" ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
+set(rviz_sip_INCLUDE_DIRS ${rviz_INCLUDE_DIRS} "${PROJECT_SOURCE_DIR}/src" ${catkin_INCLUDE_DIRS})
 set(rviz_sip_LIBRARIES ${rviz_LIBRARIES} ${PROJECT_NAME})
 set(rviz_sip_LIBRARY_DIRS ${rviz_LIBRARY_DIRS} ${CATKIN_DEVEL_PREFIX}/lib)
 set(rviz_sip_LDFLAGS_OTHER ${rviz_LDFLAGS_OTHER} -Wl,-rpath,\\"${CATKIN_DEVEL_PREFIX}/lib\\")

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -189,7 +189,6 @@ target_link_libraries(${PROJECT_NAME}
   ${OPENGL_LIBRARIES}
   ${QT_LIBRARIES}
   ${rviz_ADDITIONAL_LIBRARIES}
-  ${urdfdom_LIBRARIES}
   assimp
   yaml-cpp
 )

--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -109,7 +109,7 @@ set(SOURCE_FILES
 )
 
 add_library(default_plugin ${SOURCE_FILES})
-target_link_libraries(default_plugin ${PROJECT_NAME} ${catkin_LIBRARIES} ${QT_LIBRARIES} ${OGRE_OV_LIBRARIES_ABS} ${Boost_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(default_plugin ${PROJECT_NAME} ${catkin_LIBRARIES} ${QT_LIBRARIES} ${OGRE_OV_LIBRARIES_ABS} ${Boost_LIBRARIES})
 
 install(TARGETS default_plugin
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,15 +1,15 @@
 message("TODO: convert rviz tests to catkin.")
 
 add_executable(send_images EXCLUDE_FROM_ALL send_images.cpp)
-target_link_libraries(send_images ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(send_images ${catkin_LIBRARIES})
 add_dependencies(tests send_images)
 
 add_executable(marker_test EXCLUDE_FROM_ALL marker_test.cpp)
-target_link_libraries(marker_test ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(marker_test ${catkin_LIBRARIES})
 add_dependencies(tests marker_test)
 
 add_executable(mesh_marker_test EXCLUDE_FROM_ALL mesh_marker_test.cpp)
-target_link_libraries(mesh_marker_test ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(mesh_marker_test ${catkin_LIBRARIES})
 add_dependencies(tests mesh_marker_test)
 
 
@@ -74,15 +74,15 @@ add_dependencies(tests mesh_marker_test)
 ##   ##   ../rviz/default_plugin/interactive_markers/interactive_marker_client.cpp)
 ##   ##  
 add_executable(send_lots_of_points EXCLUDE_FROM_ALL send_lots_of_points_node.cpp)
-target_link_libraries(send_lots_of_points ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(send_lots_of_points ${catkin_LIBRARIES})
 add_dependencies(tests send_lots_of_points)
 
 add_executable(send_point_cloud_2 EXCLUDE_FROM_ALL send_point_cloud_2.cpp)
-target_link_libraries(send_point_cloud_2 ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(send_point_cloud_2 ${catkin_LIBRARIES})
 add_dependencies(tests send_point_cloud_2)
 
 add_executable(send_grid_cells EXCLUDE_FROM_ALL send_grid_cells_node.cpp)
-target_link_libraries(send_grid_cells ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(send_grid_cells ${catkin_LIBRARIES})
 add_dependencies(tests send_grid_cells)
 
 ##   ## rosbuild_add_executable(vis_panel_example vis_panel_example.cpp)


### PR DESCRIPTION
`urdfdom` is provided via `urdf` and so the `catkin_*` CMake variables replace the `urdfdom_*` variables. The current setup was unbalanced anyways because along with `urdfdom`, `urdfdom_headers` should have been being depended on and used. This precipitated from `urdfdom`'s rosdep key changing as it became a system dependency in Indigo, whereas before it was distributed as a ROS package.
