### PR TITLE
Add python headers for python bindings

### DIFF
--- a/src/python_bindings/sip/CMakeLists.txt
+++ b/src/python_bindings/sip/CMakeLists.txt
@@ -40,7 +40,7 @@ find_package(python_qt_binding REQUIRED)
 include(${python_qt_binding_EXTRAS_DIR}/sip_helper.cmake)
 
 # maintain context for different named target
-set(rviz_sip_INCLUDE_DIRS ${rviz_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/src ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
+set(rviz_sip_INCLUDE_DIRS ${rviz_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/src ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 set(rviz_sip_LIBRARIES ${rviz_LIBRARIES} ${PROJECT_NAME})
 set(rviz_sip_LIBRARY_DIRS ${rviz_LIBRARY_DIRS} ${CATKIN_DEVEL_PREFIX}/lib)
 set(rviz_sip_LDFLAGS_OTHER ${rviz_LDFLAGS_OTHER} -Wl,-rpath,${CATKIN_DEVEL_PREFIX}/lib)


### PR DESCRIPTION
Adding ${PYTHON_INCLUDE_DIRS} to the sip python bindings.

Needed at least on OSX/10.9 to compile successfully.

This should maybe be also ported to groovy and indigo.
