### PR TITLE
Fix add by topic for Marker and MarkerArray

### DIFF
--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -459,6 +459,11 @@ void MarkerDisplay::reset()
   clearMarkers();
 }
 
+void MarkerDisplay::setTopic( const QString &topic, const QString &datatype )
+{
+  marker_topic_property_->setString( topic );
+}
+
 /////////////////////////////////////////////////////////////////////////////////
 // MarkerNamespace
 

--- a/src/rviz/default_plugin/marker_display.h
+++ b/src/rviz/default_plugin/marker_display.h
@@ -86,6 +86,8 @@ public:
   void setMarkerStatus(MarkerID id, StatusLevel level, const std::string& text);
   void deleteMarkerStatus(MarkerID id);
 
+  virtual void setTopic( const QString &topic, const QString &datatype );
+
 protected:
   virtual void onEnable();
   virtual void onDisable();


### PR DESCRIPTION
The `MarkerDisplay` class wasn't overloading `Display::setTopic()` which by default does nothing.  

I've done a simple test in hydro and would assume the changes can be applied to indigo as well.

Fix #798
