### PR TITLE
Added method to set TransformListener shared_ptr.

### DIFF
--- a/src/rviz/frame_manager.cpp
+++ b/src/rviz/frame_manager.cpp
@@ -39,9 +39,11 @@
 namespace rviz
 {
 
-FrameManager::FrameManager()
+FrameManager::FrameManager(boost::shared_ptr<tf::TransformListener> tf)
 {
-  tf_.reset(new tf::TransformListener(ros::NodeHandle(), ros::Duration(10*60), true));
+  if (!tf) tf_.reset(new tf::TransformListener(ros::NodeHandle(), ros::Duration(10*60), true));
+  else tf_ = tf;
+
   setSyncMode( SyncOff );
   setPause(false);
 }

--- a/src/rviz/frame_manager.h
+++ b/src/rviz/frame_manager.h
@@ -71,7 +71,10 @@ public:
     SyncApprox
   };
 
-  FrameManager();
+  /** @brief Constructor
+   * @param tf a pointer to tf::TransformListener (should not be used anywhere else because of thread safety)
+   */
+  FrameManager(boost::shared_ptr<tf::TransformListener> tf = boost::shared_ptr<tf::TransformListener>());
 
   /** @brief Destructor.
    *

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -114,7 +114,7 @@ public:
   boost::mutex render_mutex_;
 };
 
-VisualizationManager::VisualizationManager( RenderPanel* render_panel, WindowManagerInterface* wm )
+VisualizationManager::VisualizationManager( RenderPanel* render_panel, WindowManagerInterface* wm, boost::shared_ptr<tf::TransformListener> tf )
 : ogre_root_( Ogre::Root::getSingletonPtr() )
 , update_timer_(0)
 , shutting_down_(false)
@@ -127,7 +127,7 @@ VisualizationManager::VisualizationManager( RenderPanel* render_panel, WindowMan
 , private_( new VisualizationManagerPrivate )
 , default_visibility_bit_( visibility_bit_allocator_.allocBit() )
 {
-  frame_manager_ = new FrameManager();
+  frame_manager_ = new FrameManager(tf);
 
   render_panel->setAutoRender(false);
 

--- a/src/rviz/visualization_manager.h
+++ b/src/rviz/visualization_manager.h
@@ -106,8 +106,9 @@ public:
    * @param render_panel a pointer to the main render panel widget of the app.
    * @param wm a pointer to the window manager (which is really just a
    *        VisualizationFrame, the top-level container widget of rviz).
+   * @param tf a pointer to tf::TransformListener which will be internally used by FrameManager.
    */
-  VisualizationManager( RenderPanel* render_panel, WindowManagerInterface* wm = 0 );
+  VisualizationManager( RenderPanel* render_panel, WindowManagerInterface* wm = 0, boost::shared_ptr<tf::TransformListener> tf = boost::shared_ptr<tf::TransformListener>() );
 
   /**
    * \brief Destructor


### PR DESCRIPTION
This can be useful for instance when TransformListener with some custom settings (buffer length, nodehandle with specific remappings etc) is needed. See https://github.com/ros-visualization/rviz/issues/802.
