### PR TITLE
Fixed read off end of array in triangle_list_marker.

### DIFF
--- a/src/rviz/default_plugin/markers/triangle_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.cpp
@@ -157,7 +157,7 @@ void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const M
     for (size_t i = 0; i < num_points; ++i)
     {
       manual_object_->position(new_message->points[i].x, new_message->points[i].y, new_message->points[i].z);
-      any_vertex_has_alpha = any_vertex_has_alpha || (new_message->colors[i].a < 0.9998);
+      any_vertex_has_alpha = any_vertex_has_alpha || (new_message->colors[i/3].a < 0.9998);
       manual_object_->colour(new_message->colors[i/3].r, new_message->colors[i/3].g, new_message->colors[i/3].b, new_message->color.a * new_message->colors[i/3].a);
     }
   }


### PR DESCRIPTION
I ran across this while running valgrind on rviz.  I don't know that it actually causes a crash, but it certainly was not correct.  Now it is.  Yay!
