### PR TITLE
support multiple material for one link

### DIFF
--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -160,12 +160,12 @@ private Q_SLOTS:
 private:
   void setRenderQueueGroup( Ogre::uint8 group );
   bool getEnabled() const;
-  void createEntityForGeometryElement( const urdf::LinkConstPtr& link, const urdf::Geometry& geom, const urdf::Pose& origin, Ogre::SceneNode* scene_node, Ogre::Entity*& entity );
+  void createEntityForGeometryElement( const urdf::LinkConstPtr& link, const urdf::Geometry& geom, const urdf::Pose& origin, const std::string material_name, Ogre::SceneNode* scene_node, Ogre::Entity*& entity );
 
   void createVisual( const urdf::LinkConstPtr& link);
   void createCollision( const urdf::LinkConstPtr& link);
   void createSelection();
-  Ogre::MaterialPtr getMaterialForLink( const urdf::LinkConstPtr& link );
+  Ogre::MaterialPtr getMaterialForLink( const urdf::LinkConstPtr& link, const std::string material_name = "" );
 
 
 protected:


### PR DESCRIPTION
This is patches for setting multiple materials for one link. I understand this is not clean patch, but anyway send PR and hoping someone will find more better way.

c.f: http://answers.ros.org/question/154816/color-issue-with-urdf-and-multiple-visual-tags/

you need following patch to urdf_parser.

```
diff --git a/urdf_parser/src/link.cpp b/urdf_parser/src/link.cpp
index b69824a..e324651 100644
--- a/urdf_parser/src/link.cpp
+++ b/urdf_parser/src/link.cpp
@@ -380,7 +380,8 @@ bool parseVisual(Visual &vis, TiXmlElement *config)
     }
   }

-  vis.group_name = std::string("default");
+  //vis.group_name = std::string("default");
+  vis.group_name = vis.material_name;
   const char *group_name_char = config->Attribute("group");
   if (group_name_char)
     logWarn("The notion of a group name for visual tags is not supported by URDF.");
```
