### PR TITLE
Update map via QT signal instead of in ros thread

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -67,6 +67,7 @@ MapDisplay::MapDisplay()
   , width_( 0 )
   , height_( 0 )
 {
+  connect(this, SIGNAL( mapUpdated() ), this, SLOT( showMap() ));
   topic_property_ = new RosTopicProperty( "Topic", "",
                                           QString::fromStdString( ros::message_traits::datatype<nav_msgs::OccupancyGrid>() ),
                                           "nav_msgs::OccupancyGrid topic to subscribe to.",
@@ -453,7 +454,8 @@ bool validateFloats(const nav_msgs::OccupancyGrid& msg)
 void MapDisplay::incomingMap(const nav_msgs::OccupancyGrid::ConstPtr& msg)
 {
   current_map_ = *msg;
-  showMap();
+  // updated via signal in case ros spinner is in a different thread
+  Q_EMIT mapUpdated();
   loaded_ = true;
 }
 
@@ -483,7 +485,8 @@ void MapDisplay::incomingUpdate(const map_msgs::OccupancyGridUpdate::ConstPtr& u
             &update->data[ y * update->width ],
             update->width );
   }
-  showMap();
+  // updated via signal in case ros spinner is in a different thread
+  Q_EMIT mapUpdated();
 }
 
 void MapDisplay::showMap()

--- a/src/rviz/default_plugin/map_display.h
+++ b/src/rviz/default_plugin/map_display.h
@@ -83,11 +83,17 @@ public:
 
   virtual void setTopic( const QString &topic, const QString &datatype );
 
+Q_SIGNALS:
+  /** @brief Emitted when a new map is received*/
+  void mapUpdated();
+
 protected Q_SLOTS:
   void updateAlpha();
   void updateTopic();
   void updateDrawUnder();
   void updatePalette();
+  /** @brief Show current_map_ in the scene. */
+  void showMap();
 
 protected:
   // overrides from Display
@@ -102,9 +108,6 @@ protected:
 
   /** @brief Copy update's data into current_map_ and call showMap(). */ 
   void incomingUpdate(const map_msgs::OccupancyGridUpdate::ConstPtr& update);
-
-  /** @brief Show current_map_ in the scene. */
-  void showMap();
 
   void clear();
 


### PR DESCRIPTION
Resolved issues when running RViz in rqt where the incomingMap callback
is not issued from RViz's main QThread causing a crash in Ogre. Map
updates are now handled by emitting a signal to update the map from the
callback thread.

Addresses https://github.com/ros-visualization/rqt/issues/96
