### PR TITLE
Add dependency on opengl

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -48,6 +48,7 @@
   <build_depend>urdf</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
+  <build_depend>opengl</build_depend>
 
   <run_depend>assimp</run_depend>
   <run_depend>eigen</run_depend>
@@ -79,6 +80,7 @@
   <run_depend>urdf</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>yaml-cpp</run_depend>
+  <run_depend>opengl</run_depend>
 
   <export>
     <rviz plugin="${prefix}/plugin_description.xml"/>


### PR DESCRIPTION
rviz calls find_package(OpenGL), so it should have a direct dependency
on OpenGL. This matters on ARM, where the other packages that rviz
depends on use OpenGL.ES, and don't provide a transitive dependency on
OpenGL.
