### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,29 @@ find_package(Boost REQUIRED
   thread
 )
 
+find_package(ASSIMP QUIET)
+if (NOT ASSIMP_FOUND)
+  pkg_check_modules(ASSIMP assimp)
+endif()
+if (ASSIMP_FOUND)
+  if( NOT ${ASSIMP_VERSION} VERSION_LESS "2.0.1150" )
+    add_definitions(-DASSIMP_UNIFIED_HEADER_NAMES)
+    message(STATUS "Assimp version has unified headers")
+  else()
+    message(STATUS "Assimp version does not have unified headers")
+  endif()
+  include_directories(${ASSIMP_INCLUDE_DIRS})
+  link_directories(${ASSIMP_LIBRARY_DIRS})
+else()
+  message(STATUS "could not find assimp (perhaps available thorugh ROS package?), so assimping assimp v2")
+  set(ASSIMP_LIBRARIES assimp)
+  set(ASSIMP_LIBRARY_DIRS)
+  set(ASSIMP_CXX_FLAGS)
+  set(ASSIMP_CFLAGS_OTHER)
+  set(ASSIMP_LINK_FLAGS)
+  set(ASSIMP_INCLUDE_DIRS)
+endif()
+
 
 find_package(PkgConfig REQUIRED)
 


### PR DESCRIPTION
This is an update to the pull request https://github.com/ros-visualization/rviz/pull/825

Moves find package logic up to the main CMakeLists.txt so both image_view and rviz can find it. 

Addresses issue https://github.com/ros-visualization/rviz/issues/824