### PR TITLE
allow tools to get access to any keyevent

### DIFF
--- a/src/rviz/default_plugin/tools/selection_tool.cpp
+++ b/src/rviz/default_plugin/tools/selection_tool.cpp
@@ -67,6 +67,7 @@ SelectionTool::SelectionTool()
   , moving_( false )
 {
   shortcut_key_ = 's';
+  access_all_keys_ = true;
 }
 
 SelectionTool::~SelectionTool()

--- a/src/rviz/tool.cpp
+++ b/src/rviz/tool.cpp
@@ -42,7 +42,7 @@ namespace rviz
 Tool::Tool()
   : property_container_( new Property() )
 {
-  keep_control_ = false;
+  access_all_keys_ = false;
 }
 
 Tool::~Tool()

--- a/src/rviz/tool.cpp
+++ b/src/rviz/tool.cpp
@@ -42,6 +42,7 @@ namespace rviz
 Tool::Tool()
   : property_container_( new Property() )
 {
+  keep_control_ = false;
 }
 
 Tool::~Tool()

--- a/src/rviz/tool.h
+++ b/src/rviz/tool.h
@@ -76,7 +76,7 @@ public:
 
   char getShortcutKey() { return shortcut_key_; }
 
-  bool keepControl() { return keep_control_;}
+  bool accessAllKeys() { return access_all_keys_; }
 
   virtual void activate() = 0;
   virtual void deactivate() = 0;
@@ -159,7 +159,7 @@ protected:
   DisplayContext* context_;
 
   char shortcut_key_;
-  bool keep_control_;
+  bool access_all_keys_;
 
   QIcon icon_;
 

--- a/src/rviz/tool.h
+++ b/src/rviz/tool.h
@@ -76,6 +76,8 @@ public:
 
   char getShortcutKey() { return shortcut_key_; }
 
+  bool keepControl() { return keep_control_;}
+
   virtual void activate() = 0;
   virtual void deactivate() = 0;
 
@@ -157,6 +159,7 @@ protected:
   DisplayContext* context_;
 
   char shortcut_key_;
+  bool keep_control_;
 
   QIcon icon_;
 

--- a/src/rviz/tool_manager.h
+++ b/src/rviz/tool_manager.h
@@ -133,12 +133,16 @@ private Q_SLOTS:
   void updatePropertyVisibility( Property* property );
 
 private:
+
+  uint toKey( QString const & str );
   PluginlibFactory<Tool>* factory_;
   PropertyTreeModel* property_tree_model_;
   QList<Tool*> tools_;
   DisplayContext* context_;
   Tool* current_tool_;
   Tool* default_tool_;
+  std::map<int,Tool*> shortkey_to_tool_map_;
+
 };
 
 } // end namespace rviz

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1058,7 +1058,7 @@ void VisualizationFrame::onToolbarActionTriggered( QAction* action )
     if( tool != current_tool )
     {
       // check if the current tool want's to keep control
-      if( current_tool->keepControl() )
+      if( current_tool->accessAllKeys() )
       {
         // if yes, this means that the incoming shortkey has to be passed to the tool manager
         QKeyEvent* key = new QKeyEvent( QEvent::KeyPress , toKey( action->shortcut() ), Qt::NoModifier,  action->shortcut() );

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1029,16 +1029,18 @@ uint VisualizationFrame::toKey( QString const & str )
 
     // We should only working with a single key here
     if( seq.count() == 1 )
+    {
         keyCode = seq[0];
-    else {
+    }
+    else
+    {
         // Should be here only if a modifier key (e.g. Ctrl, Alt) is pressed.
         assert( seq.count() == 0 );
-
         // Add a non-modifier key "A" to the picture because QKeySequence
         // seems to need that to acknowledge the modifier. We know that A has
         // a keyCode of 65 (or 0x41 in hex)
         seq = QKeySequence( str + "+A" );
-        assert( seq.count() == 1);
+        assert( seq.count() == 1 );
         assert( seq[0] > 65 );
         keyCode = seq[0] - 65;
     }
@@ -1061,7 +1063,10 @@ void VisualizationFrame::onToolbarActionTriggered( QAction* action )
       if( current_tool->accessAllKeys() )
       {
         // if yes, this means that the incoming shortkey has to be passed to the tool manager
-        QKeyEvent* key = new QKeyEvent( QEvent::KeyPress , toKey( action->shortcut() ), Qt::NoModifier,  action->shortcut() );
+        QKeyEvent* key = new QKeyEvent( QEvent::KeyPress,
+                                        toKey( action->shortcut() ),
+                                        Qt::NoModifier,
+                                        action->shortcut() );
         manager_->handleChar( key, render_panel_ );
         // since the shortkey triggers the action button (in the tool panel) to be checked,
         // the action has to be dechecked again and the current tool needs to be checked,

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1022,12 +1022,67 @@ void VisualizationFrame::addTool( Tool* tool )
   remove_tool_menu_->addAction( tool->getName() );
 }
 
+uint VisualizationFrame::toKey( QString const & str )
+{
+    QKeySequence seq( str );
+    uint keyCode;
+
+    // We should only working with a single key here
+    if( seq.count() == 1 )
+        keyCode = seq[0];
+    else {
+        // Should be here only if a modifier key (e.g. Ctrl, Alt) is pressed.
+        assert( seq.count() == 0 );
+
+        // Add a non-modifier key "A" to the picture because QKeySequence
+        // seems to need that to acknowledge the modifier. We know that A has
+        // a keyCode of 65 (or 0x41 in hex)
+        seq = QKeySequence( str + "+A" );
+        assert( seq.count() == 1);
+        assert( seq[0] > 65 );
+        keyCode = seq[0] - 65;
+    }
+
+    return keyCode;
+}
+
 void VisualizationFrame::onToolbarActionTriggered( QAction* action )
 {
+  // get both the triggered tool and the currently active tool
   Tool* tool = action_to_tool_map_[ action ];
+  Tool* current_tool = manager_->getToolManager()->getCurrentTool();
+
   if( tool )
   {
-    manager_->getToolManager()->setCurrentTool( tool );
+    // if the incoming tool is different from the current one
+    if( tool != current_tool )
+    {
+      // check if the current tool want's to keep control
+      if( current_tool->keepControl() )
+      {
+        // if yes, this means that the incoming shortkey has to be passed to the tool manager
+        QKeyEvent* key = new QKeyEvent( QEvent::KeyPress , toKey( action->shortcut() ), Qt::NoModifier,  action->shortcut() );
+        manager_->handleChar( key, render_panel_ );
+        // since the shortkey triggers the action button (in the tool panel) to be checked,
+        // the action has to be dechecked again and the current tool needs to be checked,
+        // so the gui is still consistent
+        action->setChecked( false );
+        tool_to_action_map_[ current_tool ]->setChecked( true );
+      }
+      else
+      {
+        // if no, we set the incoming tool to be the current one
+        manager_->getToolManager()->setCurrentTool( tool );
+      }
+    }
+    else //if the incoming tool is already the current one,
+    {
+      // we want to deactivate the tool
+      manager_->getToolManager()->getCurrentTool()->deactivate();
+      //and fallback to the default tool
+      manager_->getToolManager()->setCurrentTool( manager_->getToolManager()->getDefaultTool() );
+      action->setChecked( false );
+    }
   }
 }
 

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1014,7 +1014,6 @@ void VisualizationFrame::addTool( Tool* tool )
   action->setIcon( tool->getIcon() );
   action->setIconText( tool->getName() );
   action->setCheckable( true );
-  action->setShortcut( QKeySequence( QString( tool->getShortcutKey() )));
   toolbar_->insertAction( add_tool_action_, action );
   action_to_tool_map_[ action ] = tool;
   tool_to_action_map_[ tool ] = action;
@@ -1022,72 +1021,13 @@ void VisualizationFrame::addTool( Tool* tool )
   remove_tool_menu_->addAction( tool->getName() );
 }
 
-uint VisualizationFrame::toKey( QString const & str )
-{
-    QKeySequence seq( str );
-    uint keyCode;
-
-    // We should only working with a single key here
-    if( seq.count() == 1 )
-    {
-        keyCode = seq[0];
-    }
-    else
-    {
-        // Should be here only if a modifier key (e.g. Ctrl, Alt) is pressed.
-        assert( seq.count() == 0 );
-        // Add a non-modifier key "A" to the picture because QKeySequence
-        // seems to need that to acknowledge the modifier. We know that A has
-        // a keyCode of 65 (or 0x41 in hex)
-        seq = QKeySequence( str + "+A" );
-        assert( seq.count() == 1 );
-        assert( seq[0] > 65 );
-        keyCode = seq[0] - 65;
-    }
-
-    return keyCode;
-}
-
 void VisualizationFrame::onToolbarActionTriggered( QAction* action )
 {
-  // get both the triggered tool and the currently active tool
   Tool* tool = action_to_tool_map_[ action ];
-  Tool* current_tool = manager_->getToolManager()->getCurrentTool();
 
   if( tool )
   {
-    // if the incoming tool is different from the current one
-    if( tool != current_tool )
-    {
-      // check if the current tool want's to keep control
-      if( current_tool->accessAllKeys() )
-      {
-        // if yes, this means that the incoming shortkey has to be passed to the tool manager
-        QKeyEvent* key = new QKeyEvent( QEvent::KeyPress,
-                                        toKey( action->shortcut() ),
-                                        Qt::NoModifier,
-                                        action->shortcut() );
-        manager_->handleChar( key, render_panel_ );
-        // since the shortkey triggers the action button (in the tool panel) to be checked,
-        // the action has to be dechecked again and the current tool needs to be checked,
-        // so the gui is still consistent
-        action->setChecked( false );
-        tool_to_action_map_[ current_tool ]->setChecked( true );
-      }
-      else
-      {
-        // if no, we set the incoming tool to be the current one
-        manager_->getToolManager()->setCurrentTool( tool );
-      }
-    }
-    else //if the incoming tool is already the current one,
-    {
-      // we want to deactivate the tool
-      manager_->getToolManager()->getCurrentTool()->deactivate();
-      //and fallback to the default tool
-      manager_->getToolManager()->setCurrentTool( manager_->getToolManager()->getDefaultTool() );
-      action->setChecked( false );
-    }
+    manager_->getToolManager()->setCurrentTool( tool );
   }
 }
 

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -272,8 +272,6 @@ protected:
 
   void hideDockImpl( Qt::DockWidgetArea area, bool hide );
 
-  uint toKey(QString const & str);
-
   RenderPanel* render_panel_;
 
   QAction* show_help_action_;

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -272,6 +272,8 @@ protected:
 
   void hideDockImpl( Qt::DockWidgetArea area, bool hide );
 
+  uint toKey(QString const & str);
+
   RenderPanel* render_panel_;
 
   QAction* show_help_action_;


### PR DESCRIPTION
The current shortkey handling for RViz Tools is quite rigid, since it prevents tools from internally using shortkeys that overlay those defined to switch between tools. An issue, I stumbled across various times now and always worked around by choosing 'free' keys, but since those are limited, I would like to a) start a general discussion on the handling of shortkeys and get an idea what the community/the maintainers think about this issues, b) propose a minimal invasive patch that extendes the shortkey handling and c) offer my help to work out a proper shortkey handling.

a) General Discussion

I checked the source code an realized that the shortkeys that call a Tool are placed within the QActions which represent the Tools in the Toolbar and that if a shortkey is pressed the Toolbar deactivates the current tool and activates the tool connected to the QAction/shortkey. This leads to two counter-intuitive behaviors.

At first, it leads to deactivating and directly activating a tool again, if one presses the respective shortkey twice. Suppose a tool gathers some sort of data internally, which is flushed on deactivate(). In the current use case, this data would be lost, while the tool is still active, seem annoying to me. I would rather expect that pressing the shortkey of an inactive tool would activate it, and pressing the shortkey of an already active tool deactivates it and leads back to the default tool. Data might still be lost, but at least the UI would be intuitively stress this, due to the change to default.

Secondly, and more importantly, shortkeys that are meant not to activate a tool, but to support a tools usage are always overriden by the toolbar shortkeys, if those happen to be alike. As an example, consider the 'Select' Tool which features pressing 'f' to focus the camera on the currently selected item. If now another tool registers 'f' as it's shortkey and is added to the toolbar, pressing 'f' while using 'Select' results in switching to the other tool, not in focusing the item. Which is even more annoying, since the internal shortkeys of an active tool should have priority over the switching to another tool.

What do you think? Do you agree?

b) Patch

I cooked up a small patch that would get rid of these problems in a minimal invasive manner. Here's what i did:

1) The Tool BaseClass was extended by a boolean called 'keep_control_', which indicates if tool want's to get access to all keypresses that occur, even those that would usually activate another tool. By default this boolean is set to false, and thus there is no need for all Tools out there to be changed in any way.

2) If a shortkey is caught by on of the QActions representing the Tools it is checked whether the current tool want's to keepControl() or not. If so, the shortkey of the QAction is turned into a KeyEvent and handed down to the current tool, so that it can use it for it's purposes. If not, the tool is switched. Or reset to default, if the shortkey happens to be the one of the current tool, which is in fact the method to switch from a "control keeping" tool to any other.

These are the changes that come with the PR. To test the new keep_control_ feature, one can checkout [this repository](http://github.com/uos/rviz_fps_plugin)  on the "keepControl" branch, where I extended the tool to declare keep_control_. I would be glad if these changes would be pulled. 

c) Designing a proper shortkey management

But I think we could even go farther and develop an even better shortkey handling for RViz Tools. My PR is quite rigid in itself again, since a tool that "keeps control" just get's all key events even if it does not use them at all. I think I would be great if we did the following:

Let the Tool base class declare fields for the keys they operate on, each with a name, description and getter and setter methods. There should be a "primary shortkey" for activation and a set of "secondary shortkeys" for internal usage. Then let's get rid of the shortkeys within the QActions and just use them for directly switching tools by clicking the toolbar and move all Tool related shortkey handling into the handleChar method of the ToolManager. Where should be checked if the pressed key is within the secondary shortkey collection of the current tool. If so it should be passed down to the tool. If not it should be checked if the key deactivates the current tool or activates another and act accordingly. If a key that is both secondary key of the current tool and primary of another this could be mentioned in the status bar, so users are aware of this.
Further the tool manager could keep track of all used keys and detect potential conflicts. With the name, description and getters and setters at hand overview and modification GUI could be implemented to resolve those conflicts or just support custom key layouts, which could be stored in the config files.

I already fooled around with some of these ideas and would offer to develop this functionality of you RViz using people out there think that this would be beneficial for all of us. If so, please feel free to provide any feedback or feature ideas that might be useful to consider.
