### PR TITLE
scale ambient by 0.5 for collada and other assimp-loaded resources

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -550,7 +550,7 @@ void loadMaterials(const std::string& resource_path,
         break;
     }
 
-    mat->setAmbient(ambient);
+    mat->setAmbient(ambient * 0.5);
     mat->setDiffuse(diffuse);
     specular.a = diffuse.a;
     mat->setSpecular(specular);


### PR DESCRIPTION
I've been bringing up a new robot in RVIZ/Gazebo using Collada meshes and URDF and have found that it was nearly impossible to get the meshes to look remotely similar within Gazebo and RVIZ. If the robot looked OK in Gazebo it was washed out in RVIZ, if it was OK in RVIZ it was too dark in Gazebo.

Searching the RVIZ codebase for "setAmbient" shows that almost always the r,g,b values have been scaled by 0.5 (not sure why). As soon as I add this commit, I no longer get washed out collada files (Tested with both my new robot and the PR2). This commit does not change anything for users specifying pure STL files or OGRE mesh files, only Collada users.

This is a potential solution for https://github.com/ros-visualization/rviz/issues/515