### PR TITLE
Adjustable line width for Path display + offset property

### DIFF
--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -43,6 +43,7 @@
 #include "rviz/properties/color_property.h"
 #include "rviz/properties/float_property.h"
 #include "rviz/properties/int_property.h"
+#include "rviz/properties/vector_property.h"
 #include "rviz/validate_floats.h"
 
 #include "rviz/ogre_helpers/billboard_line.h"
@@ -77,6 +78,10 @@ PathDisplay::PathDisplay()
                                              "Number of paths to display.",
                                              this, SLOT( updateBufferLength() ));
   buffer_length_property_->setMin( 1 );
+
+  offset_property_ = new VectorProperty( "Offset", Ogre::Vector3::ZERO,
+                                         "Allows you to offset the path from the origin of the reference frame.  In meters.",
+                                         this, SLOT( updateOffset() ));
 }
 
 PathDisplay::~PathDisplay()
@@ -128,6 +133,13 @@ void PathDisplay::updateLineWidth()
       if( billboard_line ) billboard_line->setLineWidth( line_width );
     }
   }
+  context_->queueRender();
+}
+
+void PathDisplay::updateOffset()
+{
+  scene_node_->setPosition( offset_property_->getVector() );
+  context_->queueRender();
 }
 
 void PathDisplay::destroyObjects()

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -39,11 +39,13 @@
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
+#include "rviz/properties/enum_property.h"
 #include "rviz/properties/color_property.h"
 #include "rviz/properties/float_property.h"
 #include "rviz/properties/int_property.h"
 #include "rviz/validate_floats.h"
 
+#include "rviz/ogre_helpers/billboard_line.h"
 #include "rviz/default_plugin/path_display.h"
 
 namespace rviz
@@ -51,6 +53,20 @@ namespace rviz
 
 PathDisplay::PathDisplay()
 {
+  style_property_ = new EnumProperty( "Line Style", "Lines",
+                                      "The rendering operation to use to draw the grid lines.",
+                                      this, SLOT( updateStyle() ));
+
+  style_property_->addOption( "Lines", LINES );
+  style_property_->addOption( "Billboards", BILLBOARDS );
+
+  line_width_property_ = new FloatProperty( "Line Width", 0.03,
+                                            "The width, in meters, of each path line."
+                                            "Only works with the 'Billboards' style.",
+                                            this, SLOT( updateLineWidth() ), this );
+  line_width_property_->setMin( 0.001 );
+  line_width_property_->hide();
+
   color_property_ = new ColorProperty( "Color", QColor( 25, 255, 0 ),
                                        "Color to draw the path.", this );
 
@@ -80,35 +96,101 @@ void PathDisplay::reset()
   updateBufferLength();
 }
 
+
+void PathDisplay::updateStyle()
+{
+  LineStyle style = (LineStyle) style_property_->getOptionInt();
+
+  switch( style )
+  {
+  case LINES:
+  default:
+    line_width_property_->hide();
+    break;
+
+  case BILLBOARDS:
+    line_width_property_->show();
+    break;
+  }
+
+  updateBufferLength();
+}
+
+void PathDisplay::updateLineWidth()
+{
+  LineStyle style = (LineStyle) style_property_->getOptionInt();
+  float line_width = line_width_property_->getFloat();
+
+  if(style == BILLBOARDS) {
+    for( size_t i = 0; i < billboard_lines_.size(); i++ )
+    {
+      rviz::BillboardLine* billboard_line = billboard_lines_[ i ];
+      if( billboard_line ) billboard_line->setLineWidth( line_width );
+    }
+  }
+}
+
 void PathDisplay::destroyObjects()
 {
+  // Destroy all simple lines, if any
   for( size_t i = 0; i < manual_objects_.size(); i++ )
   {
-    Ogre::ManualObject* manual_object = manual_objects_[ i ];
+    Ogre::ManualObject*& manual_object = manual_objects_[ i ];
     if( manual_object )
     {
       manual_object->clear();
       scene_manager_->destroyManualObject( manual_object );
+      manual_object = NULL; // ensure it doesn't get destroyed again
+    }
+  }
+
+  // Destroy all billboards, if any
+  for( size_t i = 0; i < billboard_lines_.size(); i++ )
+  {
+    rviz::BillboardLine*& billboard_line = billboard_lines_[ i ];
+    if( billboard_line )
+    {
+      delete billboard_line; // also destroys the corresponding scene node
+      billboard_line = NULL; // ensure it doesn't get destroyed again
     }
   }
 }
 
 void PathDisplay::updateBufferLength()
 {
+  // Delete old path objects
   destroyObjects();
 
+  // Read options
   int buffer_length = buffer_length_property_->getInt();
-  QColor color = color_property_->getColor();
+  LineStyle style = (LineStyle) style_property_->getOptionInt();
 
-  manual_objects_.resize( buffer_length );
-  for( size_t i = 0; i < manual_objects_.size(); i++ )
+  // Create new path objects
+  switch(style)
   {
-    Ogre::ManualObject* manual_object = scene_manager_->createManualObject();
-    manual_object->setDynamic( true );
-    scene_node_->attachObject( manual_object );
+  case LINES: // simple lines with fixed width of 1px
+    manual_objects_.resize( buffer_length );
+    for( size_t i = 0; i < manual_objects_.size(); i++ )
+    {
+      Ogre::ManualObject* manual_object = scene_manager_->createManualObject();
+      manual_object->setDynamic( true );
+      scene_node_->attachObject( manual_object );
 
-    manual_objects_[ i ] = manual_object;
+      manual_objects_[ i ] = manual_object;
+    }
+    break;
+
+  case BILLBOARDS: // billboards with configurable width
+    billboard_lines_.resize( buffer_length );
+    for( size_t i = 0; i < billboard_lines_.size(); i++ )
+    {
+      rviz::BillboardLine* billboard_line = new rviz::BillboardLine(scene_manager_, scene_node_);
+      billboard_lines_[ i ] = billboard_line;
+    }
+    break;
   }
+
+
 }
 
 bool validateFloats( const nav_msgs::Path& msg )
@@ -120,15 +202,35 @@ bool validateFloats( const nav_msgs::Path& msg )
 
 void PathDisplay::processMessage( const nav_msgs::Path::ConstPtr& msg )
 {
-  Ogre::ManualObject* manual_object = manual_objects_[ messages_received_ % buffer_length_property_->getInt() ];
-  manual_object->clear();
+  // Calculate index of oldest element in cyclic buffer
+  size_t bufferIndex = messages_received_ % buffer_length_property_->getInt();
 
+  LineStyle style = (LineStyle) style_property_->getOptionInt();
+  Ogre::ManualObject* manual_object = NULL;
+  rviz::BillboardLine* billboard_line = NULL;
+
+  // Delete oldest element
+  switch(style)
+  {
+  case LINES:
+    manual_object = manual_objects_[ bufferIndex ];
+    manual_object->clear();
+    break;
+
+  case BILLBOARDS:
+    billboard_line = billboard_lines_[ bufferIndex ];
+    billboard_line->clear();
+    break;
+  }
+
+  // Check if path contains invalid coordinate values
   if( !validateFloats( *msg ))
   {
     setStatus( StatusProperty::Error, "Topic", "Message contained invalid floating point values (nans or infs)" );
     return;
   }
 
+  // Lookup transform into fixed frame
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
   if( !context_->getFrameManager()->getTransform( msg->header, position, orientation ))
@@ -146,17 +248,39 @@ void PathDisplay::processMessage( const nav_msgs::Path::ConstPtr& msg )
   color.a = alpha_property_->getFloat();
 
   uint32_t num_points = msg->poses.size();
-  manual_object->estimateVertexCount( num_points );
-  manual_object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP );
-  for( uint32_t i=0; i < num_points; ++i)
+  float line_width = line_width_property_->getFloat();
+
+  switch(style)
   {
-    const geometry_msgs::Point& pos = msg->poses[ i ].pose.position;
-    Ogre::Vector3 xpos = transform * Ogre::Vector3( pos.x, pos.y, pos.z );
-    manual_object->position( xpos.x, xpos.y, xpos.z );
-    manual_object->colour( color );
+  case LINES:
+    manual_object->estimateVertexCount( num_points );
+    manual_object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP );
+    for( uint32_t i=0; i < num_points; ++i)
+    {
+      const geometry_msgs::Point& pos = msg->poses[ i ].pose.position;
+      Ogre::Vector3 xpos = transform * Ogre::Vector3( pos.x, pos.y, pos.z );
+      manual_object->position( xpos.x, xpos.y, xpos.z );
+      manual_object->colour( color );
+    }
+
+    manual_object->end();
+    break;
+
+  case BILLBOARDS:
+    billboard_line->setNumLines( 1 );
+    billboard_line->setMaxPointsPerLine( num_points );
+    billboard_line->setLineWidth( line_width );
+
+    for( uint32_t i=0; i < num_points; ++i)
+    {
+      const geometry_msgs::Point& pos = msg->poses[ i ].pose.position;
+      Ogre::Vector3 xpos = transform * Ogre::Vector3( pos.x, pos.y, pos.z );
+      billboard_line->addPoint( xpos, color );
+    }
+
+    break;
   }
 
-  manual_object->end();
 }
 
 } // namespace rviz

--- a/src/rviz/default_plugin/path_display.h
+++ b/src/rviz/default_plugin/path_display.h
@@ -48,6 +48,7 @@ class FloatProperty;
 class IntProperty;
 class EnumProperty;
 class BillboardLine;
+class VectorProperty;
 
 
 /**
@@ -75,6 +76,7 @@ private Q_SLOTS:
   void updateBufferLength();
   void updateStyle();
   void updateLineWidth();
+  void updateOffset();
 
 private:
   void destroyObjects();
@@ -87,6 +89,7 @@ private:
   FloatProperty* alpha_property_;
   FloatProperty* line_width_property_;
   IntProperty* buffer_length_property_;
+  VectorProperty* offset_property_;
 
   enum LineStyle {
     LINES,

--- a/src/rviz/default_plugin/path_display.h
+++ b/src/rviz/default_plugin/path_display.h
@@ -46,6 +46,9 @@ namespace rviz
 class ColorProperty;
 class FloatProperty;
 class IntProperty;
+class EnumProperty;
+class BillboardLine;
+
 
 /**
  * \class PathDisplay
@@ -70,15 +73,26 @@ protected:
 
 private Q_SLOTS:
   void updateBufferLength();
+  void updateStyle();
+  void updateLineWidth();
 
 private:
   void destroyObjects();
 
   std::vector<Ogre::ManualObject*> manual_objects_;
+  std::vector<rviz::BillboardLine*> billboard_lines_;
 
+  EnumProperty* style_property_;
   ColorProperty* color_property_;
   FloatProperty* alpha_property_;
+  FloatProperty* line_width_property_;
   IntProperty* buffer_length_property_;
+
+  enum LineStyle {
+    LINES,
+    BILLBOARDS
+  };
+
 };
 
 } // namespace rviz


### PR DESCRIPTION
This adds a new display style called "Billboards" to the Path display, similar to how it is implemented for the Grid display. For the "Billboards" style, the line width can be adjusted, which implements enhancement request #650 and is helpful when e.g. displaying paths using a projector. The old display style "Lines" is preserved and left untouched for backwards compatibility.

I also added an "Offset" property to the Path display, that allows to shift the displayed path in relation to the origin of the fixed frame. Useful to e.g. shift the Z coordinate when displaying lots of information in Rviz that otherwise overlaps.
