### PR TITLE
init tool's shortcut_key_ and fixed toKeys()

### DIFF
--- a/src/rviz/tool.cpp
+++ b/src/rviz/tool.cpp
@@ -43,6 +43,7 @@ Tool::Tool()
   : property_container_( new Property() )
 {
   access_all_keys_ = false;
+  shortcut_key_ = '\0';
 }
 
 Tool::~Tool()

--- a/src/rviz/tool_manager.cpp
+++ b/src/rviz/tool_manager.cpp
@@ -111,31 +111,20 @@ void ToolManager::save( Config config ) const
   }
 }
 
-uint ToolManager::toKey( QString const & str )
+bool ToolManager::toKey( QString const& str, uint& key )
 {
-    QKeySequence seq( str );
-    uint keyCode;
+  QKeySequence seq( str );
 
-    // We should only working with a single key here
-    if( seq.count() == 1 )
-    {
-        keyCode = seq[0];
-    }
-    else
-    {
-        // Should be here only if a modifier key (e.g. Ctrl, Alt) is pressed.
-        assert( seq.count() == 0 );
-
-        // Add a non-modifier key "A" to the picture because QKeySequence
-        // seems to need that to acknowledge the modifier. We know that A has
-        // a keyCode of 65 (or 0x41 in hex)
-        seq = QKeySequence( str + "+A" );
-        assert( seq.count() == 1 );
-        assert( seq[0] > 65 );
-        keyCode = seq[0] - 65;
-    }
-
-    return keyCode;
+  // We should only working with a single key here
+  if( seq.count() == 1 )
+  {
+    key = seq[ 0 ];
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 void ToolManager::handleChar( QKeyEvent* event, RenderPanel* panel )
@@ -241,8 +230,17 @@ Tool* ToolManager::addTool( const QString& class_id )
   tool->setName( addSpaceToCamelCase( factory_->getClassName( class_id )));
   tool->setIcon( factory_->getIcon( class_id ) );
   tool->initialize( context_ );
-  int key = toKey( QString( tool->getShortcutKey() ) );
-  shortkey_to_tool_map_[ key ] = tool;
+
+  if( tool->getShortcutKey() != '\0' )
+  {
+    uint key;
+    QString str = QString( tool->getShortcutKey() );
+
+    if( toKey( str, key ) )
+    {
+      shortkey_to_tool_map_[ key ] = tool;
+    }
+  }
 
   Property* container = tool->getPropertyContainer();
   connect( container, SIGNAL( childListChanged( Property* )), this, SLOT( updatePropertyVisibility( Property* )));

--- a/src/rviz/tool_manager.h
+++ b/src/rviz/tool_manager.h
@@ -134,7 +134,7 @@ private Q_SLOTS:
 
 private:
 
-  uint toKey( QString const & str );
+  bool toKey( QString const& str, uint& key_out );
   PluginlibFactory<Tool>* factory_;
   PropertyTreeModel* property_tree_model_;
   QList<Tool*> tools_;


### PR DESCRIPTION
* initialized the shortcut_key_ param with '/0' to be able to check whether a tool has a shortkey assigned or not
* made the tool manager check if a tool has a shortkey before converting the char to a key code
* (hopefully) fixed the toKeys method by removing the assertions, making at a boolean returning function and allowing a single key only,
  as this is what is to be expected from the shortcut_key_ param

this should fix #851