### PR TITLE
minor gui improvements

### DIFF
--- a/src/rviz/tool_manager.cpp
+++ b/src/rviz/tool_manager.cpp
@@ -183,7 +183,7 @@ void ToolManager::setCurrentTool( Tool* tool )
     current_tool_->activate();
   }
 
-  Q_EMIT toolChanged( tool );
+  Q_EMIT toolChanged( current_tool_ );
 }
 
 void ToolManager::setDefaultTool( Tool* tool )

--- a/src/rviz/tool_manager.cpp
+++ b/src/rviz/tool_manager.cpp
@@ -282,6 +282,11 @@ void ToolManager::removeTool( int index )
   Q_EMIT configChanged();
 }
 
+void ToolManager::refreshTool( Tool* tool )
+{
+  Q_EMIT toolRefreshed( tool );
+}
+
 QStringList ToolManager::getToolClasses()
 {
   QStringList class_names;

--- a/src/rviz/tool_manager.h
+++ b/src/rviz/tool_manager.h
@@ -80,6 +80,9 @@ public:
 
   void removeAll();
 
+  /** @brief Triggers redrawing the tool's icon/text in the toolbar. */
+  void refreshTool( Tool* tool );
+
   /**
    * \brief Set the current tool.
    * The current tool is given all mouse and keyboard events which
@@ -126,6 +129,9 @@ Q_SIGNALS:
   void toolChanged( Tool* );
 
   void toolRemoved( Tool* );
+
+  /** @brief Emitted by refreshTool() to gedraw the tool's icon in the toolbar'. */
+  void toolRefreshed( Tool* );
 
 private Q_SLOTS:
   /** @brief If @a property has children, it is added to the tool

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -306,6 +306,7 @@ void VisualizationFrame::initialize(const QString& display_config_file )
   connect( manager_, SIGNAL( configChanged() ), this, SLOT( setDisplayConfigModified() ));
   connect( tool_man, SIGNAL( toolAdded( Tool* )), this, SLOT( addTool( Tool* )));
   connect( tool_man, SIGNAL( toolRemoved( Tool* )), this, SLOT( removeTool( Tool* )));
+  connect( tool_man, SIGNAL( toolRefreshed( Tool* )), this, SLOT( refreshTool( Tool* )));
   connect( tool_man, SIGNAL( toolChanged( Tool* )), this, SLOT( indicateToolIsCurrent( Tool* )));
 
   manager_->initialize();
@@ -1069,6 +1070,13 @@ void VisualizationFrame::removeTool( Tool* tool )
       break;
     }
   }
+}
+
+void VisualizationFrame::refreshTool( Tool* tool )
+{
+  QAction* action = tool_to_action_map_[ tool ];
+  action->setIcon( tool->getIcon() );
+  action->setIconText( tool->getName() );
 }
 
 void VisualizationFrame::indicateToolIsCurrent( Tool* tool )

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -195,6 +195,11 @@ protected Q_SLOTS:
   /** @brief Remove the given tool from the frame's toolbar. */
   void removeTool( Tool* tool );
 
+  /** @brief Refresh the given tool in this frame's' toolbar.
+   *
+   * This will update the icon and the text of the corresponding QAction. */
+  void refreshTool( Tool* tool );
+
   /** @brief Mark the given tool as the current one.
    *
    * This is purely a visual change in the GUI, it does not call any


### PR DESCRIPTION
i stumbled upon a minor issue while creating a tool that behaves like a trigger. in the rare case where a tool invokes another tool during it's activation the gui becomes inconsistent. 

then i found that there's no method to redraw a tool's icon and text in the toolbar, so i wrote a small refresh method.