### PR TITLE
Third person follower view controller

### DIFF
--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -255,7 +255,7 @@
   </class>
   <class name="rviz/ThirdPersonFollower" type="rviz::ThirdPersonFollowerViewController" base_class_type="rviz::ViewController">
     <description>
-      Makes it easy to move around a given point on the XY plane, looking at it from any angle.
+      Follow a target frame and turn the viewing direction with the yaw of the target frame.
     </description>
   </class>
   <class name="rviz/FPS" type="rviz::FPSViewController" base_class_type="rviz::ViewController">

--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -253,6 +253,11 @@
       Makes it easy to move around a given point on the XY plane, looking at it from any angle.
     </description>
   </class>
+  <class name="rviz/ThirdPersonFollower" type="rviz::ThirdPersonFollowerViewController" base_class_type="rviz::ViewController">
+    <description>
+      Makes it easy to move around a given point on the XY plane, looking at it from any angle.
+    </description>
+  </class>
   <class name="rviz/FPS" type="rviz::FPSViewController" base_class_type="rviz::ViewController">
     <description>
       Control the camera like in a First Person Shooter game: drag left to look left, etc.

--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -39,6 +39,7 @@ qt4_wrap_cpp(MOC_FILES
   tools/point_tool.h
   view_controllers/orbit_view_controller.h
   view_controllers/xy_orbit_view_controller.h
+  view_controllers/third_person_follower_view_controller.h
   view_controllers/fixed_orientation_ortho_view_controller.h
   view_controllers/fps_view_controller.h
   wrench_display.h
@@ -101,6 +102,7 @@ set(SOURCE_FILES
   tools/interaction_tool.cpp
   view_controllers/orbit_view_controller.cpp
   view_controllers/xy_orbit_view_controller.cpp
+  view_controllers/third_person_follower_view_controller.cpp
   view_controllers/fixed_orientation_ortho_view_controller.cpp
   view_controllers/fps_view_controller.cpp
   wrench_display.cpp

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+#include <ros/ros.h>
+
+#include <OgreCamera.h>
+#include <OgrePlane.h>
+#include <OgreQuaternion.h>
+#include <OgreRay.h>
+#include <OgreSceneNode.h>
+#include <OgreVector3.h>
+#include <OgreViewport.h>
+
+#include "rviz/display_context.h"
+#include "rviz/ogre_helpers/shape.h"
+#include "rviz/properties/float_property.h"
+#include "rviz/properties/vector_property.h"
+#include "rviz/viewport_mouse_event.h"
+
+#include "rviz/default_plugin/view_controllers/third_person_follower_view_controller.h"
+
+namespace rviz
+{
+
+// move camera up so the focal point appears in the lower image half
+static const float CAMERA_OFFSET = 0.2;
+
+void ThirdPersonFollowerViewController::onInitialize()
+{
+  OrbitViewController::onInitialize();
+  focal_shape_->setColor(0.0f, 1.0f, 1.0f, 0.5f);
+}
+
+bool ThirdPersonFollowerViewController::intersectGroundPlane( Ogre::Ray mouse_ray, Ogre::Vector3 &intersection_3d )
+{
+  //convert rays into reference frame
+  mouse_ray.setOrigin( target_scene_node_->convertWorldToLocalPosition( mouse_ray.getOrigin() ) );
+  mouse_ray.setDirection( target_scene_node_->convertWorldToLocalOrientation( Ogre::Quaternion::IDENTITY ) * mouse_ray.getDirection() );
+
+  Ogre::Plane ground_plane( Ogre::Vector3::UNIT_Z, 0 );
+
+  std::pair<bool, Ogre::Real> intersection = mouse_ray.intersects(ground_plane);
+  if (!intersection.first)
+  {
+    return false;
+  }
+
+  intersection_3d = mouse_ray.getPoint(intersection.second);
+  return true;
+}
+
+void ThirdPersonFollowerViewController::handleMouseEvent(ViewportMouseEvent& event)
+{
+  if ( event.shift() )
+  {
+    setStatus( "<b>Left-Click:</b> Move X/Y.  <b>Right-Click:</b>: Zoom." );
+  }
+  else
+  {
+    setStatus( "<b>Left-Click:</b> Rotate.  <b>Middle-Click:</b> Move X/Y.  <b>Right-Click:</b>: Move Z.  <b>Shift</b>: More options." );
+  }
+
+  int32_t diff_x = 0;
+  int32_t diff_y = 0;
+
+  bool moved = false;
+  if( event.type == QEvent::MouseButtonPress )
+  {
+    focal_shape_->getRootNode()->setVisible(true);
+    moved = true;
+  }
+  else if( event.type == QEvent::MouseButtonRelease )
+  {
+    focal_shape_->getRootNode()->setVisible(false);
+    moved = true;
+  }
+  else if( event.type == QEvent::MouseMove )
+  {
+    diff_x = event.x - event.last_x;
+    diff_y = event.y - event.last_y;
+    moved = true;
+  }
+
+  if( event.left() && !event.shift() )
+  {
+    setCursor( Rotate3D );
+    yaw( diff_x*0.005 );
+    pitch( -diff_y*0.005 );
+  }
+  else if( event.middle() || (event.left() && event.shift()) )
+  {
+    setCursor( MoveXY );
+    // handle mouse movement
+    int width = event.viewport->getActualWidth();
+    int height = event.viewport->getActualHeight();
+
+    Ogre::Ray mouse_ray = event.viewport->getCamera()->getCameraToViewportRay( event.x / (float) width,
+                                                                               event.y / (float) height );
+
+    Ogre::Ray last_mouse_ray =
+      event.viewport->getCamera()->getCameraToViewportRay( event.last_x / (float) width,
+                                                           event.last_y / (float) height );
+
+    Ogre::Vector3 last_intersect, intersect;
+
+    if( intersectGroundPlane( last_mouse_ray, last_intersect ) &&
+        intersectGroundPlane( mouse_ray, intersect ))
+    {
+      Ogre::Vector3 motion = last_intersect - intersect;
+
+      // When dragging near the horizon, the motion can get out of
+      // control.  This throttles it to an arbitrary limit per mouse
+      // event.
+      float motion_distance_limit = 1; /*meter*/
+      if( motion.length() > motion_distance_limit )
+      {
+        motion.normalise();
+        motion *= motion_distance_limit;
+      }
+
+      focal_point_property_->add( motion );
+      emitConfigChanged();
+    }
+  }
+  else if( event.right() )
+  {
+    setCursor( Zoom );
+    zoom( -diff_y * 0.1 * (distance_property_->getFloat() / 10.0f) );
+  }
+  else
+  {
+    setCursor( event.shift() ? MoveXY : Rotate3D );
+  }
+
+  if( event.wheel_delta != 0 )
+  {
+    int diff = event.wheel_delta;
+    zoom( diff * 0.001 * distance_property_->getFloat() );
+    moved = true;
+  }
+
+  if( moved )
+  {
+    context_->queueRender();
+  }
+}
+
+void ThirdPersonFollowerViewController::mimic( ViewController* source_view )
+{
+  FramePositionTrackingViewController::mimic( source_view );
+
+  Ogre::Camera* source_camera = source_view->getCamera();
+  // do some trigonometry
+  Ogre::Ray camera_dir_ray( source_camera->getRealPosition(), source_camera->getRealDirection() );
+  Ogre::Ray camera_down_ray( source_camera->getRealPosition(), -1.0 * source_camera->getRealUp() );
+
+  Ogre::Vector3 a,b;
+
+  if( intersectGroundPlane( camera_dir_ray, b ) &&
+      intersectGroundPlane( camera_down_ray, a ) )
+  {
+    float l_a = source_camera->getPosition().distance( b );
+    float l_b = source_camera->getPosition().distance( a );
+
+    distance_property_->setFloat(( l_a * l_b ) / ( CAMERA_OFFSET * l_a + l_b ));
+    float distance = distance_property_->getFloat();
+
+    camera_dir_ray.setOrigin( source_camera->getRealPosition() - source_camera->getRealUp() * distance * CAMERA_OFFSET );
+    Ogre::Vector3 new_focal_point;
+    intersectGroundPlane( camera_dir_ray, new_focal_point );
+    focal_point_property_->setVector( new_focal_point );
+
+    calculatePitchYawFromPosition( source_camera->getPosition() - source_camera->getUp() * distance * CAMERA_OFFSET );
+  }
+}
+
+void ThirdPersonFollowerViewController::updateCamera()
+{
+  OrbitViewController::updateCamera();
+  camera_->setPosition( camera_->getPosition() + camera_->getUp() * distance_property_->getFloat() * CAMERA_OFFSET );
+}
+
+void ThirdPersonFollowerViewController::updateTargetSceneNode()
+{
+	if ( FramePositionTrackingViewController::getNewTransform() )
+	{
+  	target_scene_node_->setPosition( reference_position_ );
+  	target_scene_node_->setOrientation( reference_orientation_ );
+
+		context_->queueRender();
+	}
+}
+
+void ThirdPersonFollowerViewController::lookAt( const Ogre::Vector3& point )
+{
+  Ogre::Vector3 camera_position = camera_->getPosition();
+  Ogre::Vector3 new_focal_point = target_scene_node_->getOrientation().Inverse() * (point - target_scene_node_->getPosition());
+  new_focal_point.z = 0;
+  distance_property_->setFloat( new_focal_point.distance( camera_position ));
+  focal_point_property_->setVector( new_focal_point );
+
+  calculatePitchYawFromPosition(camera_position);
+}
+
+} // end namespace rviz
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS( rviz::ThirdPersonFollowerViewController, rviz::ViewController )

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
@@ -38,6 +38,7 @@
 #include <OgreSceneNode.h>
 #include <OgreVector3.h>
 #include <OgreViewport.h>
+#include <OgreMath.h>
 
 #include "rviz/display_context.h"
 #include "rviz/ogre_helpers/shape.h"
@@ -213,7 +214,9 @@ void ThirdPersonFollowerViewController::updateTargetSceneNode()
 	if ( FramePositionTrackingViewController::getNewTransform() )
 	{
   	target_scene_node_->setPosition( reference_position_ );
-  	target_scene_node_->setOrientation( reference_orientation_ );
+  	Ogre::Radian ref_yaw = reference_orientation_.getYaw();
+  	Ogre::Quaternion ref_yaw_quat(Ogre::Math::Cos(ref_yaw/2), 0, 0, Ogre::Math::Sin(ref_yaw/2));
+  	target_scene_node_->setOrientation( ref_yaw_quat );
 
 		context_->queueRender();
 	}

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
@@ -58,7 +58,6 @@ void ThirdPersonFollowerViewController::onInitialize()
 {
   OrbitViewController::onInitialize();
   focal_shape_->setColor(0.0f, 1.0f, 1.0f, 0.5f);
-  last_yaw_ = 0.f;
 }
 
 bool ThirdPersonFollowerViewController::intersectGroundPlane( Ogre::Ray mouse_ray, Ogre::Vector3 &intersection_3d )

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
@@ -58,6 +58,7 @@ void ThirdPersonFollowerViewController::onInitialize()
 {
   OrbitViewController::onInitialize();
   focal_shape_->setColor(0.0f, 1.0f, 1.0f, 0.5f);
+  last_yaw_ = 0.f;
 }
 
 bool ThirdPersonFollowerViewController::intersectGroundPlane( Ogre::Ray mouse_ray, Ogre::Vector3 &intersection_3d )
@@ -211,15 +212,15 @@ void ThirdPersonFollowerViewController::updateCamera()
 
 void ThirdPersonFollowerViewController::updateTargetSceneNode()
 {
-	if ( FramePositionTrackingViewController::getNewTransform() )
-	{
-  	target_scene_node_->setPosition( reference_position_ );
-  	Ogre::Radian ref_yaw = reference_orientation_.getYaw();
-  	Ogre::Quaternion ref_yaw_quat(Ogre::Math::Cos(ref_yaw/2), 0, 0, Ogre::Math::Sin(ref_yaw/2));
-  	target_scene_node_->setOrientation( ref_yaw_quat );
+  if ( FramePositionTrackingViewController::getNewTransform() )
+  {
+    target_scene_node_->setPosition( reference_position_ );
+    Ogre::Radian ref_yaw = reference_orientation_.getRoll( false ); // OGRE camera frame looks along -Z, so they call rotation around Z "roll".
+    Ogre::Quaternion ref_yaw_quat(Ogre::Math::Cos(ref_yaw/2), 0, 0, Ogre::Math::Sin(ref_yaw/2));
+    target_scene_node_->setOrientation( ref_yaw_quat );
 
-		context_->queueRender();
-	}
+    context_->queueRender();
+  }
 }
 
 void ThirdPersonFollowerViewController::lookAt( const Ogre::Vector3& point )

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2009, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RVIZ_THIRD_PERSON_VIEW_CONTROLLER_H
+#define RVIZ_THIRD_PERSON_VIEW_CONTROLLER_H
+
+#include "rviz/default_plugin/view_controllers/orbit_view_controller.h"
+
+#include <OgreVector3.h>
+
+namespace Ogre
+{
+class SceneNode;
+}
+
+namespace rviz
+{
+
+class TfFrameProperty;
+
+/**
+ * \brief Like the orbit view controller, but focal point moves only in the x-y plane.
+ */
+class ThirdPersonFollowerViewController : public OrbitViewController
+{
+Q_OBJECT
+public:
+  virtual void onInitialize();
+
+  virtual void handleMouseEvent(ViewportMouseEvent& evt);
+
+  virtual void lookAt( const Ogre::Vector3& point );
+
+  /** @brief Configure the settings of this view controller to give,
+   * as much as possible, a similar view as that given by the
+   * @a source_view.
+   *
+   * @a source_view must return a valid @c Ogre::Camera* from getCamera(). */
+  virtual void mimic( ViewController* source_view );
+
+protected:
+  virtual void updateCamera();
+
+  virtual void updateTargetSceneNode();
+
+  bool intersectGroundPlane( Ogre::Ray mouse_ray, Ogre::Vector3 &intersection_3d );
+};
+
+}
+
+#endif // RVIZ_VIEW_CONTROLLER_H

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
@@ -70,8 +70,6 @@ protected:
   virtual void updateTargetSceneNode();
 
   bool intersectGroundPlane( Ogre::Ray mouse_ray, Ogre::Vector3 &intersection_3d );
-
-  float last_yaw_;
 };
 
 }

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
@@ -70,6 +70,8 @@ protected:
   virtual void updateTargetSceneNode();
 
   bool intersectGroundPlane( Ogre::Ray mouse_ray, Ogre::Vector3 &intersection_3d );
+
+  float last_yaw_;
 };
 
 }

--- a/src/rviz/frame_position_tracking_view_controller.cpp
+++ b/src/rviz/frame_position_tracking_view_controller.cpp
@@ -92,21 +92,29 @@ void FramePositionTrackingViewController::updateTargetFrame()
   onTargetFrameChanged( old_position, old_orientation );
 }
 
-void FramePositionTrackingViewController::updateTargetSceneNode()
+bool FramePositionTrackingViewController::getNewTransform()
 {
   Ogre::Vector3 new_reference_position;
   Ogre::Quaternion new_reference_orientation;
 
-  if( context_->getFrameManager()->getTransform( target_frame_property_->getFrameStd(), ros::Time(),
-                                                 new_reference_position, new_reference_orientation ))
+  bool got_transform = context_->getFrameManager()->getTransform( target_frame_property_->getFrameStd(), ros::Time(),
+        new_reference_position, new_reference_orientation );
+  if( got_transform )
   {
-    target_scene_node_->setPosition( new_reference_position );
-
-    reference_position_ = new_reference_position;
-    reference_orientation_ = new_reference_orientation;
-
-    context_->queueRender();
+  	reference_position_ = new_reference_position;
+  	reference_orientation_ = new_reference_orientation;
   }
+  return got_transform;
+}
+
+void FramePositionTrackingViewController::updateTargetSceneNode()
+{
+	if ( getNewTransform() )
+	{
+  	target_scene_node_->setPosition( reference_position_ );
+
+		context_->queueRender();
+	}
 
 // Need to incorporate this functionality somehow....  Maybe right into TfFrameProperty itself.
 /////  if( frame_manager_->transformHasProblems( getTargetFrame().toStdString(), ros::Time(), error ))
@@ -119,6 +127,7 @@ void FramePositionTrackingViewController::updateTargetSceneNode()
 /////    // target_prop->setToOK();
 /////    global_status_->setStatus( StatusProperty::Ok, "Target Frame", "OK" );
 /////  }
+
 }
 
 void FramePositionTrackingViewController::mimic( ViewController* source_view )

--- a/src/rviz/frame_position_tracking_view_controller.cpp
+++ b/src/rviz/frame_position_tracking_view_controller.cpp
@@ -101,20 +101,20 @@ bool FramePositionTrackingViewController::getNewTransform()
         new_reference_position, new_reference_orientation );
   if( got_transform )
   {
-  	reference_position_ = new_reference_position;
-  	reference_orientation_ = new_reference_orientation;
+    reference_position_ = new_reference_position;
+    reference_orientation_ = new_reference_orientation;
   }
   return got_transform;
 }
 
 void FramePositionTrackingViewController::updateTargetSceneNode()
 {
-	if ( getNewTransform() )
-	{
-  	target_scene_node_->setPosition( reference_position_ );
+  if ( getNewTransform() )
+  {
+    target_scene_node_->setPosition( reference_position_ );
 
-		context_->queueRender();
-	}
+    context_->queueRender();
+  }
 
 // Need to incorporate this functionality somehow....  Maybe right into TfFrameProperty itself.
 /////  if( frame_manager_->transformHasProblems( getTargetFrame().toStdString(), ros::Time(), error ))

--- a/src/rviz/frame_position_tracking_view_controller.h
+++ b/src/rviz/frame_position_tracking_view_controller.h
@@ -86,9 +86,11 @@ protected:
    * @see updateTargetFrame() */
   virtual void onTargetFrameChanged( const Ogre::Vector3& old_reference_position, const Ogre::Quaternion& old_reference_orientation ) {}
 
+  bool getNewTransform();
+
   /** @brief Update the position of the target_scene_node_ from the TF
    * frame specified in the Target Frame property. */
-  void updateTargetSceneNode();
+  virtual void updateTargetSceneNode();
 
   TfFrameProperty* target_frame_property_;
   Ogre::SceneNode* target_scene_node_;


### PR DESCRIPTION
This new view controller follows a target frame. In contrast to XYOrdbit the camera also turns with the target frame. This could be handy if you are doing 3D mapping of a hallway with corners for example.