### PR TITLE
Allow force and torque in Wrench to be scaled separately

### DIFF
--- a/src/rviz/default_plugin/wrench_display.cpp
+++ b/src/rviz/default_plugin/wrench_display.cpp
@@ -35,10 +35,15 @@ namespace rviz
                                      "0 is fully transparent, 1.0 is fully opaque.",
                                      this, SLOT( updateColorAndAlpha() ));
 
-	scale_property_ =
-            new rviz::FloatProperty( "Arrow Scale", 2.0,
-                                     "arrow scale",
+	force_scale_property_ =
+            new rviz::FloatProperty( "Force Arrow Scale", 2.0,
+                                     "force arrow scale",
                                      this, SLOT( updateColorAndAlpha() ));
+
+    torque_scale_property_ =
+            new rviz::FloatProperty( "Torque Arrow Scale", 2.0,
+                                     "torque arrow scale",
+                                     this, SLOT( updateColorAndAlpha() ));            
 
 	width_property_ =
             new rviz::FloatProperty( "Arrow Width", 0.5,
@@ -75,7 +80,8 @@ namespace rviz
     void WrenchStampedDisplay::updateColorAndAlpha()
     {
         float alpha = alpha_property_->getFloat();
-        float scale = scale_property_->getFloat();
+        float force_scale = force_scale_property_->getFloat();
+        float torque_scale = torque_scale_property_->getFloat();
         float width = width_property_->getFloat();
         Ogre::ColourValue force_color = force_color_property_->getOgreColor();
         Ogre::ColourValue torque_color = torque_color_property_->getOgreColor();
@@ -84,7 +90,8 @@ namespace rviz
 	{
             visuals_[i]->setForceColor( force_color.r, force_color.g, force_color.b, alpha );
             visuals_[i]->setTorqueColor( torque_color.r, torque_color.g, torque_color.b, alpha );
-            visuals_[i]->setScale( scale );
+            visuals_[i]->setForceScale( force_scale );
+            visuals_[i]->setTorqueScale( torque_scale );
             visuals_[i]->setWidth( width );
 	}
     }
@@ -140,13 +147,15 @@ namespace rviz
 	visual->setFramePosition( position );
 	visual->setFrameOrientation( orientation );
         float alpha = alpha_property_->getFloat();
-        float scale = scale_property_->getFloat();
+        float force_scale = force_scale_property_->getFloat();
+        float torque_scale = torque_scale_property_->getFloat();
         float width = width_property_->getFloat();
         Ogre::ColourValue force_color = force_color_property_->getOgreColor();
         Ogre::ColourValue torque_color = torque_color_property_->getOgreColor();
 	visual->setForceColor( force_color.r, force_color.g, force_color.b, alpha );
 	visual->setTorqueColor( torque_color.r, torque_color.g, torque_color.b, alpha );
-        visual->setScale( scale );
+        visual->setForceScale( force_scale );
+        visual->setTorqueScale( torque_scale );
         visual->setWidth( width );
 
         // And send it to the end of the circular buffer

--- a/src/rviz/default_plugin/wrench_display.h
+++ b/src/rviz/default_plugin/wrench_display.h
@@ -54,7 +54,7 @@ namespace rviz
 
 	// Property objects for user-editable properties.
         rviz::ColorProperty *force_color_property_, *torque_color_property_;
-        rviz::FloatProperty *alpha_property_, *scale_property_, *width_property_;
+        rviz::FloatProperty *alpha_property_, *force_scale_property_, *torque_scale_property_, *width_property_;
 	rviz::IntProperty *history_length_property_;
     };
 } // end namespace rviz_plugin_tutorials

--- a/src/rviz/default_plugin/wrench_visual.cpp
+++ b/src/rviz/default_plugin/wrench_visual.cpp
@@ -50,8 +50,8 @@ namespace rviz
     {
         Ogre::Vector3 force(msg->wrench.force.x, msg->wrench.force.y, msg->wrench.force.z);
         Ogre::Vector3 torque(msg->wrench.torque.x, msg->wrench.torque.y, msg->wrench.torque.z);
-        double force_length = force.length() * scale_;
-        double torque_length = torque.length() * scale_;
+        double force_length = force.length() * force_scale_;
+        double torque_length = torque.length() * torque_scale_;
 	arrow_force_->setScale(Ogre::Vector3(force_length, width_, width_)); 
 	arrow_torque_->setScale(Ogre::Vector3(torque_length, width_, width_));
 
@@ -100,9 +100,14 @@ namespace rviz
 	circle_arrow_torque_->setColor( r, g, b, a );
     }
 
-    void  WrenchStampedVisual::setScale( float s ) {
-      scale_ = s;
+    void  WrenchStampedVisual::setForceScale( float s ) {
+      force_scale_ = s;
     }
+
+    void  WrenchStampedVisual::setTorqueScale( float s ) {
+      torque_scale_ = s;
+    }
+
     void  WrenchStampedVisual::setWidth( float w ) {
       width_ = w;
     }

--- a/src/rviz/default_plugin/wrench_visual.h
+++ b/src/rviz/default_plugin/wrench_visual.h
@@ -48,7 +48,8 @@ public:
     // parameters and therefore don't come from the WrenchStamped message.
     void setForceColor( float r, float g, float b, float a );
     void setTorqueColor( float r, float g, float b, float a );
-    void setScale( float s );
+    void setForceScale( float s );
+    void setTorqueScale( float s );
     void setWidth( float w );
 
 private:
@@ -57,7 +58,7 @@ private:
     rviz::Arrow* arrow_torque_;
     rviz::BillboardLine* circle_torque_;
     rviz::Arrow* circle_arrow_torque_;
-    float scale_, width_;
+    float force_scale_, torque_scale_, width_;
 
     // A SceneNode whose pose is set to match the coordinate frame of
     // the WrenchStamped message header.


### PR DESCRIPTION
since force and torque are different quantities, the units of their scalings are different (meters per Newton and meters per Newton-meter, respectively), and so they should really have separate scalings. Practically, the torques in my Wrench are usually much smaller than the forces if I use the same scaling.

I am on Groovy, but it looks like this patch can apply to all releases up to present.