### PR TITLE
ogre_helpers: Fix STL import and detect binary files masquerading as ASCII ones

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -718,7 +718,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path)
       }
 
       ogre_tools::STLLoader loader;
-      if (!loader.load(res.data.get()))
+      if (!loader.load(res.data.get(),res.size,resource_path))
       {
         ROS_ERROR("Failed to load file [%s]", resource_path.c_str());
         return Ogre::MeshPtr();

--- a/src/rviz/ogre_helpers/stl_loader.cpp
+++ b/src/rviz/ogre_helpers/stl_loader.cpp
@@ -91,6 +91,13 @@ bool STLLoader::load(const std::string& path)
 bool STLLoader::load(uint8_t* buffer)
 {
   uint8_t* pos = buffer;
+
+  // check for ascii type
+  if(std::string((char*)buffer,5) == std::string("solid")) {
+    ROS_ERROR("Trying to load STL file from binary buffer, but the given data is an ASCII STL file. Please convert it to a binary STL file instead.");
+    return false;
+  }
+
   pos += 80; // skip the 80 byte header
 
   unsigned int numTriangles = *(unsigned int*)pos;

--- a/src/rviz/ogre_helpers/stl_loader.h
+++ b/src/rviz/ogre_helpers/stl_loader.h
@@ -46,7 +46,7 @@ public:
   ~STLLoader();
 
   bool load(const std::string& path);
-  bool load(uint8_t* buffer);
+  bool load(uint8_t* buffer, const size_t num_bytes, const std::string& origin);
 
   Ogre::MeshPtr toMesh(const std::string& name);
 
@@ -58,6 +58,10 @@ public:
 
   typedef std::vector<Triangle> V_Triangle;
   V_Triangle triangles_;
+
+protected:
+  //! Load a binary STL file
+  bool load_binary(uint8_t* buffer);
 };
 
 }


### PR DESCRIPTION
The RViz STL importer can only read binary files.

ASCII STL files are supposed to be designated by the first five chars of the file being "solid"

Lots of binary STL files out there don't care for your standards and start with "solid" anyway. I think the SolidWorks STL exporter does this.

This warns people if their STL files are malformed, and reports errors if they're not binary files. If it's determined that they're not valid binary files, where valid means "won't crash rviz" then it returns false and reports the problem.

Note that this takes more care to consider broken STL files than Assimp does. Assimp will reject binary files which start with "solid". If we use the same test, many ROS urdf models will stop working.

This also replaces the fragile c-style buffer heap allocation with a `std::vector` which won't leak.

This patch is not API compatible.
This patch is most likely not ABI compatible.

https://en.wikipedia.org/wiki/STL_(file_format)#ASCII_STL