### PR TITLE
deleting markers does not require transform

### DIFF
--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -250,6 +250,11 @@ void MarkerDisplay::incomingMarker( const visualization_msgs::Marker::ConstPtr& 
 void MarkerDisplay::failedMarker(const ros::MessageEvent<visualization_msgs::Marker>& marker_evt, tf::FilterFailureReason reason)
 {
   visualization_msgs::Marker::ConstPtr marker = marker_evt.getConstMessage();
+  if (marker->action == visualization_msgs::Marker::DELETE ||
+      marker->action == 3)  // TODO: visualization_msgs::Marker::DELETEALL when message changes in a future version of ROS
+  {
+    return this->processMessage(marker);
+  }
   std::string authority = marker_evt.getPublisherName();
   std::string error = context_->getFrameManager()->discoverFailureReason(marker->header.frame_id, marker->header.stamp, authority, reason);
   setMarkerStatus(MarkerID(marker->ns, marker->id), StatusProperty::Error, error);


### PR DESCRIPTION
Currently if you send a DELETE or DELETE_ALL with no `header.frame_id`, or an untransformable `header.frame_id`, the deletion does not happen. There is no reason to need the `frame_id` for delete, we should go ahead and do the delete anyways (MoveIt uses a similar logic in the tf filter fail for object insertion/deletion).

Probably also fixes what @JessChL was seeing in #865