### PR TITLE
Check if position and orientation of links of robots contain NaNs when updating pose of robot links

### DIFF
--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -735,6 +735,27 @@ void Robot::update(const LinkUpdater& updater)
                                    collision_position, collision_orientation
                                    ))
     {
+      // Check if visual_position, visual_orientation, collision_position and collision_position
+      if (visual_orientation.isNaN()) 
+        {
+          ROS_ERROR_THROTTLE(1.0, "visual orientation of %s contains NaNs. Skipping render as long as the orientation is invalid", link->getName().c_str());
+          continue;
+        }
+      if (visual_position.isNaN()) 
+        {
+          ROS_ERROR_THROTTLE(1.0, "visual position of %s contains NaNs. Skipping render as long as the position is invalid", link->getName().c_str());
+          continue;
+        }
+      if (collision_orientation.isNaN()) 
+        {
+          ROS_ERROR_THROTTLE(1.0, "collision orientation of %s contains NaNs. Skipping render as long as the orientation is invalid", link->getName().c_str());
+          continue;
+        }
+      if (collision_position.isNaN()) 
+        {
+          ROS_ERROR_THROTTLE(1.0, "collision position of %s contains NaNs. Skipping render as long as the position is invalid", link->getName().c_str());
+          continue;
+        }
       link->setTransforms( visual_position, visual_orientation, collision_position, collision_orientation );
 
       std::vector<std::string>::const_iterator joint_it = link->getChildJointNames().begin();


### PR DESCRIPTION
On my environment, sometimes rviz crashes because of setting nan transformation of robot links.

This patch checks if robot links transformation contains NaNs and when they include NaNs, skip updating transformations of links.

```
Program received signal SIGABRT, Aborted.
0x00007ffff62970d5 in raise () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) where
#0  0x00007ffff62970d5 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff629a83b in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007ffff628fd9e in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007ffff628fe42 in __assert_fail () from /lib/x86_64-linux-gnu/libc.so.6
#4  0x00007ffff3630ae6 in Ogre::Node::setPosition(Ogre::Vector3 const&) ()
   from /usr/lib/x86_64-linux-gnu/libOgreMain.so.1.7.4
#5  0x00007ffff7a9937e in rviz::RobotLink::setTransforms(Ogre::Vector3 const&, Ogre::Quaternion const&, Ogre::Vector3 con\
st&, Ogre::Quaternion const&) ()
   from /home/leus/ros/hydro/devel/lib/librviz.so
#6  0x00007ffff7aa22b6 in rviz::Robot::update(rviz::LinkUpdater const&) ()
   from /home/leus/ros/hydro/devel/lib/librviz.so
#7  0x00007ffef7b9f492 in rviz::RobotModelDisplay::update(float, float) ()
   from /home/leus/ros/hydro/devel/lib/libdefault_plugin.so
#8  0x00007ffff7a03b5e in rviz::DisplayGroup::update(float, float) ()
   from /home/leus/ros/hydro/devel/lib/librviz.so
#9  0x00007ffff7af593d in rviz::VisualizationManager::onUpdate() ()
   from /home/leus/ros/hydro/devel/lib/librviz.so
#10 0x00007ffff7b10532 in rviz::VisualizationManager::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) ()
   from /home/leus/ros/hydro/devel/lib/librviz.so
#11 0x00007ffff29b6281 in QMetaObject::activate(QObject*, QMetaObject const*, int, void**) () from /usr/lib/x86_64-linux-\
gnu/libQtCore.so.4
```

