### PR TITLE
also process empty pointclouds

### DIFF
--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -917,11 +917,6 @@ void PointCloudCommon::addMessage(const sensor_msgs::PointCloudConstPtr& cloud)
 
 void PointCloudCommon::addMessage(const sensor_msgs::PointCloud2ConstPtr& cloud)
 {
-  if (cloud->width * cloud->height == 0)
-  {
-    return;
-  }
-
   processMessage(cloud);
 }
 


### PR DESCRIPTION
Otherwise, given a stream of clouds with some of them empty, the last
non-empty message will still be displayed until a the next non-empty cloud
comes in.