### PR TITLE
find_package python version detected by catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,6 @@ endif()
 
 find_package(OpenGL REQUIRED)
 
-find_package(PythonLibs REQUIRED)
-
 find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
 
 find_package(catkin REQUIRED
@@ -127,6 +125,7 @@ if(${tf_VERSION} VERSION_LESS "1.11.3")
   add_definitions("-DRVIZ_USE_BOOST_SIGNAL_1")
 endif()
 
+find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 
 find_package(Eigen REQUIRED)
 


### PR DESCRIPTION
Otherwise it might happen that catkin (and the rest of the workspace) uses 2.x
and rviz detects & tries to use 3.x. This can produce some nasty collisions.

See rospack, roslz4, qt_gui_cpp and others for similar invokation.