### PR TITLE
Fix mesh alpha tinting

### DIFF
--- a/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
@@ -82,8 +82,7 @@ void MeshResourceMarker::reset()
     }
   }
   materials_.clear();
-  // the actual passes are deleted by the material
-  color_tint_passes_.clear();
+
 }
 
 void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const MarkerConstPtr& new_message)
@@ -219,31 +218,18 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
   //  if the mesh_use_embedded_materials is true and color is non-zero
   //  then the color will be used to tint the embedded materials
   if (update_color)
-  { // add a pass to every material to perform the color tinting
+  { 
     S_MaterialPtr::iterator material_it;
     for (material_it = materials_.begin(); material_it != materials_.end(); material_it++)
     {
       Ogre::Technique* technique = (*material_it)->getTechnique(0);
-      
-      //color_tint_passes_.push_back(technique->createPass());
       technique->setAmbient( r*0.5, g*0.5, b*0.5 );
       technique->setDiffuse( r, g, b, a );
-     technique->setSceneBlending( blending );
-     technique->setDepthWriteEnabled( depth_write );
-     technique->setLightingEnabled( true );
+      technique->setSceneBlending( blending );
+      technique->setDepthWriteEnabled( depth_write );
+      technique->setLightingEnabled( true );
     }
    
-
-   // for (std::vector<Ogre::Pass*>::iterator it = color_tint_passes_.begin();
-       //  it != color_tint_passes_.end();
-        // ++it)
-   // {
-     //(*it)->setAmbient(0.5 * r, 0.5 * g, 0.5 * b);
-     //(*it)->setDiffuse(r, g, b, a);
-     //(*it)->setSceneBlending(blending);
-    //(*it)->setDepthWriteEnabled(depth_write);
-     //(*it)->setLightingEnabled(true);
-    //}
   }
 
   Ogre::Vector3 pos, scale;

--- a/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
@@ -221,7 +221,9 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
   { 
     if( new_message->mesh_use_embedded_materials && r == 0 && g == 0 && b == 0 && a == 0 )
     {
-      r = 1; g = 1; b = 1; a = 1;
+    blending = Ogre::SBT_REPLACE;
+    depth_write = true;
+    r = 1; g = 1; b = 1; a = 1;
     }
     S_MaterialPtr::iterator material_it;
     for (material_it = materials_.begin(); material_it != materials_.end(); material_it++)

--- a/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
@@ -95,6 +95,27 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
 
   scene_node_->setVisible(false);
 
+  // Get the color information from the message
+  float r = new_message->color.r;
+  float g = new_message->color.g;
+  float b = new_message->color.b;
+  float a = new_message->color.a;
+
+  Ogre::SceneBlendType blending;
+  bool depth_write;
+
+  if (a < 0.9998)
+  {
+    blending = Ogre::SBT_TRANSPARENT_ALPHA;
+    depth_write = false;
+  }
+  else
+  {
+    blending = Ogre::SBT_REPLACE;
+    depth_write = true;
+  }
+
+
   if (!entity_ ||
       old_message->mesh_resource != new_message->mesh_resource ||
       old_message->mesh_use_embedded_materials != new_message->mesh_use_embedded_materials)
@@ -124,13 +145,14 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
     std::string id = ss.str();
     entity_ = context_->getSceneManager()->createEntity(id, new_message->mesh_resource);
     scene_node_->attachObject(entity_);
-
+    
     // create a default material for any sub-entities which don't have their own.
     ss << "Material";
     Ogre::MaterialPtr default_material = Ogre::MaterialManager::getSingleton().create(ss.str(), ROS_PACKAGE_NAME);
     default_material->setReceiveShadows(false);
     default_material->getTechnique(0)->setLightingEnabled(true);
     default_material->getTechnique(0)->setAmbient(0.5, 0.5, 0.5);
+
     materials_.insert(default_material);
 
     if (new_message->mesh_use_embedded_materials)
@@ -171,13 +193,7 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
       entity_->setMaterial(default_material);
     }
 
-    // add a pass to every material to perform the color tinting
-    S_MaterialPtr::iterator material_it;
-    for (material_it = materials_.begin(); material_it != materials_.end(); material_it++)
-    {
-      Ogre::Technique* technique = (*material_it)->getTechnique(0);
-      color_tint_passes_.push_back(technique->createPass());
-    }
+   
 
     // always update color on resource change
     update_color = true;
@@ -203,36 +219,31 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
   //  if the mesh_use_embedded_materials is true and color is non-zero
   //  then the color will be used to tint the embedded materials
   if (update_color)
-  {
-    float r = new_message->color.r;
-    float g = new_message->color.g;
-    float b = new_message->color.b;
-    float a = new_message->color.a;
-
-    Ogre::SceneBlendType blending;
-    bool depth_write;
-
-    if (a < 0.9998)
+  { // add a pass to every material to perform the color tinting
+    S_MaterialPtr::iterator material_it;
+    for (material_it = materials_.begin(); material_it != materials_.end(); material_it++)
     {
-      blending = Ogre::SBT_TRANSPARENT_ALPHA;
-      depth_write = false;
+      Ogre::Technique* technique = (*material_it)->getTechnique(0);
+      
+      //color_tint_passes_.push_back(technique->createPass());
+      technique->setAmbient( r*0.5, g*0.5, b*0.5 );
+      technique->setDiffuse( r, g, b, a );
+     technique->setSceneBlending( blending );
+     technique->setDepthWriteEnabled( depth_write );
+     technique->setLightingEnabled( true );
     }
-    else
-    {
-      blending = Ogre::SBT_REPLACE;
-      depth_write = true;
-    }
+   
 
-    for (std::vector<Ogre::Pass*>::iterator it = color_tint_passes_.begin();
-         it != color_tint_passes_.end();
-         ++it)
-    {
-      (*it)->setAmbient(0.5 * r, 0.5 * g, 0.5 * b);
-      (*it)->setDiffuse(r, g, b, a);
-      (*it)->setSceneBlending(blending);
-      (*it)->setDepthWriteEnabled(depth_write);
-      (*it)->setLightingEnabled(true);
-    }
+   // for (std::vector<Ogre::Pass*>::iterator it = color_tint_passes_.begin();
+       //  it != color_tint_passes_.end();
+        // ++it)
+   // {
+     //(*it)->setAmbient(0.5 * r, 0.5 * g, 0.5 * b);
+     //(*it)->setDiffuse(r, g, b, a);
+     //(*it)->setSceneBlending(blending);
+    //(*it)->setDepthWriteEnabled(depth_write);
+     //(*it)->setLightingEnabled(true);
+    //}
   }
 
   Ogre::Vector3 pos, scale;
@@ -257,4 +268,3 @@ S_MaterialPtr MeshResourceMarker::getMaterials()
 }
 
 }
-

--- a/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
@@ -219,6 +219,10 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
   //  then the color will be used to tint the embedded materials
   if (update_color)
   { 
+    if( new_message->mesh_use_embedded_materials && r == 0 && g == 0 && b == 0 && a == 0 )
+    {
+      r = 1; g = 1; b = 1; a = 1;
+    }
     S_MaterialPtr::iterator material_it;
     for (material_it = materials_.begin(); material_it != materials_.end(); material_it++)
     {

--- a/src/rviz/default_plugin/markers/mesh_resource_marker.h
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.h
@@ -64,8 +64,7 @@ protected:
   //! Scaling factor to convert units. Currently relevant for Collada only.
   float unit_rescale_;
 
-  //! list of passes created for adding color tint to the mesh
-  std::vector<Ogre::Pass*> color_tint_passes_;
+
 };
 
 }


### PR DESCRIPTION
Reinstated original form of mesh tinting and removed color pass technique that was introduced in #752. The color pass technique was overriding mesh texture and alpha values. It appears that the issue present in #751 was actually a result of a piece of code that would make a mesh pure white if the message sent rgba values of 0000. I can't pinpoint why, but I estimate that somehow that was erroneously turning collada markers pure white. Tested change with rviz/src/test/mesh_marker_test.cpp and ran several tests with collada markers, using mesh_use_embedded_materials true and false. Transparency and mesh tinting appear to work as desired.