### PR TITLE
Fix #888: TF plugin handles static transform of tf2.

### DIFF
--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -469,7 +469,9 @@ void TFDisplay::updateFrame( FrameInfo* frame )
   // Check last received time so we can grey out/fade out frames that have stopped being published
   ros::Time latest_time;
   tf->getLatestCommonTime( fixed_frame_.toStdString(), frame->name_, latest_time, 0 );
-  if( latest_time != frame->last_time_to_fixed_ )
+
+  if(( latest_time != frame->last_time_to_fixed_ ) ||
+     ( latest_time == ros::Time() ))
   {
     frame->last_update_ = ros::Time::now();
     frame->last_time_to_fixed_ = latest_time;


### PR DESCRIPTION
#888 

The tf plugin is not written using tf2. It was not display static tf frame collectly.
To fix this problem, treat ros::Time(0) which return from getLatestCommonTime() as static frame.

test
-----

1. publish static and dynamic frames.

```
$ rosrun tf2_ros static_transform_publisher 0 0 1 0 0 0 1 map frame_static
```

```
$ rosrun tf static_transform_publisher 0 1 0 0 0 0 1 frame_static frame_dynamic 20000
```

2. Check it in rviz. 
Map frame and frame_static will not be vanished.
