### PR TITLE
disable Display if associated Panel becomes invisible

### DIFF
--- a/src/rviz/display.cpp
+++ b/src/rviz/display.cpp
@@ -389,6 +389,10 @@ void Display::associatedPanelVisibilityChange( bool visible )
   {
     setEnabled( true );
   }
+  else
+  {
+    setEnabled( false );
+  }
 }
 
 void Display::setIcon( const QIcon& icon )


### PR DESCRIPTION
Otherwise the state between Panel & Display becomes inconsistent.

Fixed symptom: When loading a configuration that contains a disabled
CameraDisplay, during the configuration of the panel(the camera render
widget), the panel is set visible for a very short period of time. Because of
the missing logic, the CameraDisplay is enabled together with the panel, but
the Display remains enabled after the Panel is set invisible. One ends up with
an enabled
(and subscribed) CameraDisplay without the corresponding RenderWidget, even so
the configuration specified that the Display is _not_ enabled.