### PR TITLE
Smooth updates for map display plugin

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -706,6 +706,10 @@ void MapDisplay::setTopic( const QString &topic, const QString &datatype )
   topic_property_->setString( topic );
 }
 
+void MapDisplay::update( float wall_dt, float ros_dt ) {
+  transformMap();
+}
+
 } // namespace rviz
 
 #include <pluginlib/class_list_macros.h>

--- a/src/rviz/default_plugin/map_display.h
+++ b/src/rviz/default_plugin/map_display.h
@@ -104,6 +104,7 @@ protected:
 
   virtual void subscribe();
   virtual void unsubscribe();
+  virtual void update( float wall_dt, float ros_dt );
 
   /** @brief Copy msg into current_map_ and call showMap(). */ 
   void incomingMap(const nav_msgs::OccupancyGrid::ConstPtr& msg);


### PR DESCRIPTION
Map displays previously only updated when receiving a message. This means that
if your fixed frame was base_link, the costmaps would not move appropriately
around the robot unless a message was received in order to update the transform
that should be applied to the scene. For global costmaps, this is a slow
update and for static maps, this never happened.

This fixes that by hooking into rviz' periodic call to continuously update the
transform to be applied to the scene.