### PR TITLE
Updated warning message to indicate triangle count is 32bits

### DIFF
--- a/src/rviz/ogre_helpers/stl_loader.cpp
+++ b/src/rviz/ogre_helpers/stl_loader.cpp
@@ -125,7 +125,7 @@ bool STLLoader::load(uint8_t* buffer, const size_t num_bytes, const std::string&
   {
     ROS_ERROR_STREAM("The STL file '" << origin <<"' is malformed. It "
                      "appears to be a binary STL file but does not contain "
-                     "enough data for the 80 byte header and 16-bit integer "
+                     "enough data for the 80 byte header and 32-bit integer "
                      "triangle count.");
     return false;
   }


### PR DESCRIPTION
As a follow up to #920, this PR adds a small change to one of the printed messages that displays when a file contains less data than is suggested by its triangle count. The message now correctly indicates that the triangle count is a 32 bit integer.