### PR TITLE
build: Use PKG_CONFIG_EXECUTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ endif(NOT OGRE_OV_FOUND)
 
 ## Find OGRE Plugin path (not necessarily platform-independent, I guess)
 execute_process(COMMAND
-  pkg-config --variable=plugindir OGRE
+  ${PKG_CONFIG_EXECUTABLE} --variable=plugindir OGRE
   OUTPUT_VARIABLE OGRE_PLUGIN_PATH
   OUTPUT_STRIP_TRAILING_WHITESPACE
   )


### PR DESCRIPTION
... instead of using a hard-coded pkg-config to make cross-compiling
possible where the pkg-config binary is host-prefixed (e.g.
armv7-unknown-linux-pkg-config when cross-compiling for armv7)