### PR TITLE
Fixed Qt assertions triggered in debug build of Qt.

### DIFF
--- a/src/rviz/display_group.cpp
+++ b/src/rviz/display_group.cpp
@@ -66,6 +66,9 @@ void DisplayGroup::load( const Config& config )
   Config display_list_config = config.mapGetChild( "Displays" );
   int num_displays = display_list_config.listLength();
 
+  if( num_displays == 0 )
+    return;
+
   if( model_ )
   {
     model_->beginInsert( this, Display::numChildren(), num_displays );
@@ -150,6 +153,9 @@ void DisplayGroup::save( Config config ) const
 
 void DisplayGroup::removeAllDisplays()
 {
+  if(displays_.size() == 0)
+    return;
+
   int num_non_display_children = Display::numChildren();
 
   if( model_ )

--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -104,6 +104,9 @@ void Property::removeChildren( int start_index, int count )
     count = children_.size() - start_index;
   }
 
+  if( count == 0 )
+    return;
+
   if( model_ )
   {
     model_->beginRemove( this, start_index, count );


### PR DESCRIPTION
I ran rviz with a debug build of Qt, and it crashed with an assertion failure.  This fixes that failure.

A normal (release) build of Qt has the assertions disabled, so this doesn't happen in normal use.

The assertion fails when any of these values are zero and the code continues.  You end up with a first = 5, last = 4 situation inside QAbstractItemModel::beginRemoveRows(), which triggers an assertion that first <= last.