### PR TITLE
Enable antialiasing

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -239,7 +239,7 @@ void RenderSystem::setupRenderSystem()
   //  renderSys->setConfigOption("RTT Preferred Mode", "FBO");
 
   // Set the Full Screen Anti-Aliasing factor.
-  renderSys->setConfigOption("FSAA", "2");
+  renderSys->setConfigOption("FSAA", "4");
 
   ogre_root_->setRenderSystem(renderSys);
 }
@@ -348,6 +348,9 @@ Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned
 #endif
 
   params["externalGLControl"] = true;
+
+  // Enable antialiasing
+  params["FSAA"] = "4";
 
 // Set the macAPI for Ogre based on the Qt implementation
 #ifdef QT_MAC_USE_COCOA


### PR DESCRIPTION
This PR is an attempt to truly enable antialiasing. The only piece of code that seemed related to it was [here](https://github.com/ros-visualization/rviz/blob/4abbbd9a413ee26942d1c7d838975d58b3cc0434/src/rviz/ogre_helpers/render_system.cpp#L241-L242), but changing the value did not seem to have any effect. I added the entry to the proper dictionary, and used a value of 4 which is quite common (cf. [Gazebo](https://bitbucket.org/osrf/gazebo/src/38fbac52640382b2f7ff749aca3580cca7fd7994/gazebo/rendering/WindowManager.cc?at=default&fileviewer=file-view-default#WindowManager.cc-91)). Talking about Gazebo, they also [added antialiasing to their `Camera` class](https://bitbucket.org/osrf/gazebo/src/38fbac52640382b2f7ff749aca3580cca7fd7994/gazebo/rendering/Camera.cc?at=default&fileviewer=file-view-default#Camera.cc-1234:1253), which for instance shares code similar to [`SelectionManager::setDepthTextureSize`](https://github.com/ros-visualization/rviz/blob/4abbbd9a413ee26942d1c7d838975d58b3cc0434/src/rviz/selection/selection_manager.cpp#L351-L357) for creating `Ogre::RenderTexture` objects. This may not be relevant at all to add FSAA here, but it may be the perfect time to check similar parts of the code where antialiasing could improve the rendering.

As for the previous `"FSAA"` key in the other dictionary, if it is in fact useless, it may be worth removing, but since Gazebo also has it, I only updated its value.

Comparison before/after:

* Without FSAA, full image:
![without_aa_full](https://cloud.githubusercontent.com/assets/2742231/10539149/a4f11606-7438-11e5-8708-1f311e3cdde9.png)

* With FSAA = 4, full image:
![with_aa_full](https://cloud.githubusercontent.com/assets/2742231/10539153/aab221a2-7438-11e5-8068-85e3c548e8ef.png)

* Without FSAA, zoomed:

![without_aa_zoom](https://cloud.githubusercontent.com/assets/2742231/10539196/df672a6e-7438-11e5-9689-36c92cb8fe18.png)

* With FSAA = 4, zoomed:

![with_aa_zoom](https://cloud.githubusercontent.com/assets/2742231/10539176/c7e77aba-7438-11e5-9bbf-63e35de962ba.png)

