### PR TITLE
Don't attempt to `transformMap` until one is actually received.

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -668,6 +668,11 @@ void MapDisplay::updatePalette()
 
 void MapDisplay::transformMap()
 {
+  if (!loaded_)
+  {
+    return;
+  }
+
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
   if (!context_->getFrameManager()->transform(frame_, ros::Time(), current_map_.info.origin, position, orientation))


### PR DESCRIPTION
Without this patch, the map display shows frame transformation errors
from with an empty frame_id, since it attempts to transform the 
default-initialized occupancy grid variable.