### PR TITLE
Updated moveViewPlane in interactive_marker_control.cpp

### DIFF
--- a/src/rviz/default_plugin/interactive_markers/interactive_marker_control.cpp
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker_control.cpp
@@ -618,8 +618,9 @@ void InteractiveMarkerControl::moveZAxisWheel( const ViewportMouseEvent& event )
 void InteractiveMarkerControl::moveViewPlane( Ogre::Ray &mouse_ray, const ViewportMouseEvent& event )
 {
   // find plane on which mouse is moving
-  Ogre::Plane plane( event.viewport->getCamera()->getRealDirection(),
-                     parent_position_at_mouse_down_ + parent_to_grab_position_);
+  Ogre::Vector3 camera_direction_ = event.viewport->getCamera()->getRealDirection();
+  Ogre::Plane plane( reference_node_->getOrientation().Inverse()*camera_direction_,
+                       parent_position_at_mouse_down_);
 
   // find intersection of mouse with the plane
   std::pair<bool, Ogre::Real> intersection = mouse_ray.intersects(plane);
@@ -628,7 +629,7 @@ void InteractiveMarkerControl::moveViewPlane( Ogre::Ray &mouse_ray, const Viewpo
   Ogre::Vector3 mouse_position_on_plane = mouse_ray.getPoint(intersection.second);
 
   // move parent so grab position relative to parent coincides with new mouse position.
-  parent_->setPose( mouse_position_on_plane - parent_to_grab_position_,
+  parent_->setPose( mouse_position_on_plane,
                     parent_->getOrientation(),
                     name_ );
 }


### PR DESCRIPTION
As I have reported in #935 in Issues, there seem to be two issues using MOVE_3D option with interactive markers when the marker is attached to a local coordinate frame. One is the marker jumps when clicked when the local coordinate frame is different from Fixed Frame in rviz. The other issue is that the direction of the maker becomes unintuitive when the local frame is rotated relative to the Fixed Frame.

In this update, I tried to fix these issues by modifying moveViewPlane function in interactive_marker_control.cpp by

1) removing parent_to_grab_position_, and
2) rotate the plane associated with the camera view.