### PR TITLE
On fixing TF loading

### DIFF
--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -213,6 +213,27 @@ void TFDisplay::onInitialize()
   axes_node_ = root_node_->createChildSceneNode();
 }
 
+void TFDisplay::load(const Config& config) {
+  // TODO parse config Tree
+  // FIXME deleteFrames deletes the tfs that are not published upon loading,
+  //       thus their state is never loaded correctly
+
+  Display::load(config);
+
+  Config c = config.mapGetChild("Frames");
+  for( Config::MapIterator iter = c.mapIterator(); iter.isValid(); iter.advance() )
+  {
+    QString key = iter.currentKey();
+    if(key != "All Enabled") {
+      const Config& child = iter.currentChild();
+      bool enabled = child.mapGetChild("Value").getValue().toBool();
+
+      FrameInfo * info = createFrame(key.toStdString());
+      info->enabled_property_->setBool(enabled);
+    }
+  }
+}
+
 void TFDisplay::clear()
 {
   // Clear the tree.

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -73,6 +73,7 @@ public:
 protected:
   // Overrides from Display
   virtual void onInitialize();
+  virtual void load(const Config& config);
   virtual void fixedFrameChanged();
   virtual void reset();
 


### PR DESCRIPTION
Hi, issue #834 reports that rviz does not correctly save/load the TFs in the configuration file.
This bug is rather annoying to me, as I'm dealing with loads of tfs being published in large clutters and starting to move instantly, so I don't have time to select which ones I'd like to see.

In its current state, the TF and TF tree are correctly saved into the configuration file. However, the 
tf plugin doesn't load them. So I attempted to solve it by loading from the configuration file, however,
there are some issues that require discussion:

- I read the tf configuration from the Config class. For each tf in the configuration file, I create the corresponding FrameInfo, and set whether it's enabled. This works well, provided that the tfs are being published prior to the configuration file loaded.
If the tf are not being published and the configuration file is loaded, then the continuous calls to updateFrames will cause calls to deleteFrame and the newly loaded configuration will be deleted for all frames that are not currently being published. Once the missing tfs get published, their enabled state will be the default one instead of the configuration one.
To deal with it, I see two options:
  - we'd have to never delete frames that have been stored in the configuration file. This of course is not optimal, as it would be impossible to delete frames from the configuration file without manually editing it. It, however, has a side advantage that I really like, it's that all tfs that have been saved will be displayed within the configuration tree, regardless of whether they are published or not. This would allow to preselect which tfs we'd like to see before having the whole clutter published (very useful when dealing with moving robots with loads of tfs)
  - or, instead of loading as in my commit, we could modify updateFrames to check whether a tf is within the configuration or not, and set the enabled state from the configuration if needed. This would of course implies that the configuration (Config class) has to be updated upon changing the enabled state of a tf from the interface. This has the drawback that the user can't start interacting with the TF configuration before they get published. 

- At the moment I do not load the hierarchical tf tree, for the same kind of reason.
A lot of overly complicated logic is happening in updateFrames, and some would contradict with loading from the configuration file.

Let me know what you think about how it ought to behave and be implemented.
Best regards,
Arnaud