### PR TITLE
Fixed billboard line generation for zero key points

### DIFF
--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -137,7 +137,7 @@ void BillboardLine::setupChains()
     createChain();
   }
 
-  lines_per_chain_ = MAX_ELEMENTS / max_points_per_line_;
+  lines_per_chain_ = max_points_per_line_ > 0 ? MAX_ELEMENTS / max_points_per_line_ : 1;
 
   V_Chain::iterator it = chains_.begin();
   V_Chain::iterator end = chains_.end();


### PR DESCRIPTION
Fix for https://github.com/ros-visualization/rviz/issues/941