### PR TITLE
fixed SplitterHandle of PropertyTreeWidget

### DIFF
--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -65,8 +65,8 @@ void SplitterHandle::updateGeometry()
   int content_width = parent_->contentsRect().width();
   int new_column_width = int( first_column_size_ratio_ * content_width );
   if ( new_column_width != parent_->columnWidth(0) ) {
-   parent_->setColumnWidth( 0, new_column_width );
-   parent_->setColumnWidth( 1, content_width - new_column_width );
+    parent_->setColumnWidth( 0, new_column_width );
+    parent_->setColumnWidth( 1, content_width - new_column_width );
   }
   int new_x = new_column_width - w / 2 + parent_->columnViewportPosition(0);
   if ( new_x != x() || parent_->height() != height() )

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -45,14 +45,13 @@ SplitterHandle::SplitterHandle( QTreeView* parent )
   , color_( 128, 128, 128, 64 )
 {
   setCursor( Qt::SplitHCursor );
-  int w = 7;
-  setGeometry( parent_->width() / 2 - w/2, 0, w, parent_->height() );
+  updateGeometry();
   parent_->installEventFilter( this );
 }
 
 bool SplitterHandle::eventFilter( QObject* event_target, QEvent* event )
 {
-  if( event_target == parent_ && event->type() == QEvent::Resize )
+  if( event_target == parent_ && event->type() == QEvent::UpdateRequest )
   {
     updateGeometry();
   }
@@ -61,11 +60,12 @@ bool SplitterHandle::eventFilter( QObject* event_target, QEvent* event )
 
 void SplitterHandle::updateGeometry()
 {
+  int w = 7;
   int content_width = parent_->contentsRect().width();
   int new_column_width = int( first_column_size_ratio_ * content_width );
   parent_->setColumnWidth( 0, new_column_width );
   parent_->setColumnWidth( 1, content_width - new_column_width );
-  setGeometry( new_column_width - width() / 2, 0, width(), parent_->height() );
+  setGeometry( new_column_width - w / 2 + parent_->columnViewportPosition(0), 0, w, parent_->height() );
 }
 
 void SplitterHandle::setRatio( float ratio )
@@ -83,6 +83,7 @@ void SplitterHandle::mousePressEvent( QMouseEvent* event )
 {
   if( event->button() == Qt::LeftButton )
   {
+    // position of mouse press inside this QWidget
     x_press_offset_ = event->x();
   }
 }
@@ -95,7 +96,7 @@ void SplitterHandle::mouseMoveEvent( QMouseEvent* event )
   {
     QPoint pos_rel_parent = parent_->mapFromGlobal( event->globalPos() );
 
-    int new_x = pos_rel_parent.x() - x_press_offset_;
+    int new_x = pos_rel_parent.x() - x_press_offset_ - parent_->columnViewportPosition(0);
 
     if( new_x > parent_->width() - width() - padding )
     {
@@ -120,7 +121,7 @@ void SplitterHandle::paintEvent( QPaintEvent* event )
 {
   QPainter painter( this );
   painter.setPen( color_ );
-  painter.drawLine( width() / 2, 0, width() / 2, height() );
+  painter.drawLine( 1+width() / 2, 0, 1+width() / 2, height() );
 }
 
 } // end namespace rviz

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -63,9 +63,13 @@ void SplitterHandle::updateGeometry()
   int w = 7;
   int content_width = parent_->contentsRect().width();
   int new_column_width = int( first_column_size_ratio_ * content_width );
-  parent_->setColumnWidth( 0, new_column_width );
-  parent_->setColumnWidth( 1, content_width - new_column_width );
-  setGeometry( new_column_width - w / 2 + parent_->columnViewportPosition(0), 0, w, parent_->height() );
+  if ( new_column_width != parent_->columnWidth(0) ) {
+   parent_->setColumnWidth( 0, new_column_width );
+   parent_->setColumnWidth( 1, content_width - new_column_width );
+  }
+  int new_x = new_column_width - w / 2 + parent_->columnViewportPosition(0);
+  if ( new_x != x() || parent_->height() != height() )
+    setGeometry( new_x, 0, w, parent_->height() );
 }
 
 void SplitterHandle::setRatio( float ratio )

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -51,7 +51,8 @@ SplitterHandle::SplitterHandle( QTreeView* parent )
 
 bool SplitterHandle::eventFilter( QObject* event_target, QEvent* event )
 {
-  if( event_target == parent_ && event->type() == QEvent::UpdateRequest )
+  if( event_target == parent_ && (event->type() == QEvent::Resize ||
+                                  event->type() == QEvent::Paint))
   {
     updateGeometry();
   }


### PR DESCRIPTION
SplitterHandle (for PropertyTreeWidget) only reacted on `resize` events. However, when
the columns where resized externally or scrolling happened (e.g. in MoveIt's MotionPlanning display)
the splitter wasn't correctly shifted.
Intercepting all `Paint` events, one can react to those situations as well.
Further, I use `updateGeometry()` in constructor too, thus having a single location calling `setGeometry()`.
Finally, `paintEvent` adds an additional offset of 1 to deal with QTreeView's `viewport margin`, thus now perfectly matching the cell boundary.

The new code was thoroughly tested with the following simple main.cpp:
```cpp
#include <QTreeView>
#include <QStandardItemModel>
#include <QStyledItemDelegate>
#include <QPainter>
#include <QApplication>
#include <splitter_handle.h>

class GridDelegate : public QStyledItemDelegate
{
public:
	explicit GridDelegate(QObject * parent = 0) : QStyledItemDelegate(parent) { }

	void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index ) const
	{
		QStyledItemDelegate::paint(painter, option, index);
		painter->save();
		painter->setPen(QColor(Qt::blue));
		painter->drawRect(option.rect);
		painter->restore();
	}
};

int main(int argc, char ** argv)
{
	QApplication app(argc, argv);

	QStandardItemModel model;
	model.setRowCount(15);
	model.setColumnCount(5);

	for(int r = 0; r < model.rowCount(); r++)
		for(int c = 0; c < model.columnCount(); c++)
			model.setItem(r, c, new QStandardItem(QString("Item %1, %2").arg(r).arg(c)));

	QTreeView treeView;
	treeView.setModel(&model);
	treeView.setItemDelegate(new GridDelegate(&treeView));
	treeView.setHeaderHidden(true);
	treeView.setRootIsDecorated(false);

	rviz::SplitterHandle splitter (&treeView);
	splitter.setRatio(0.3);
	treeView.show();

	return app.exec();
}
```
