### PR TITLE
Fix for tf display not loading frame config

### DIFF
--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -73,6 +73,7 @@ public:
 protected:
   // Overrides from Display
   virtual void onInitialize();
+  virtual void load(const Config& config);
   virtual void fixedFrameChanged();
   virtual void reset();
 
@@ -103,6 +104,9 @@ private:
 
   typedef std::map<std::string, FrameInfo*> M_FrameInfo;
   M_FrameInfo frames_;
+
+  typedef std::map<std::string, bool> M_EnabledState;
+  M_EnabledState frame_config_enabled_state_;
 
   float update_timer_;
 


### PR DESCRIPTION
This is a fix for issue [#834](https://github.com/ros-visualization/rviz/issues/834) using the changes from PR [#938](https://github.com/ros-visualization/rviz/pull/938) by @arntanguy with the following modifications:

1. Rather than adding a new frame and setting the enabled state of the frame immediately when reading the config, the enabled state for each specified frame is stored in a map.
2. Whenever a frame is being added to the display it looks up its enabled state in the map, and if it was configured as disabled the frame is set to be disabled.

Because no new frames are created when loading the config this properly handles the case where frames specified in the config file are not published at the time the config is read mentioned in PR [#938](https://github.com/ros-visualization/rviz/pull/938). 

This also handles the case (mentioned by @hersh) where the set of frames specified in the config file are different than the set of frames being actively published. Since no new frames are created based on the config file only the intersection of those two sets will have their enabled state modified, and only the frames being actively published will be added to the display.