### PR TITLE
Fix for chainIndex out of bounds in BillboardChain::addChainElement

### DIFF
--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -149,7 +149,16 @@ void BillboardLine::setupChains()
     if (it + 1 == end)
     {
       uint32_t lines_left = num_lines_ % lines_per_chain_;
-      (*it)->setNumberOfChains(lines_left);
+
+      // Handle the case where there are exactly the number of lines
+      // per chain remaining
+      if (lines_left == 0) {
+          (*it)->setNumberOfChains(lines_per_chain_);
+      }
+      else
+      {
+          (*it)->setNumberOfChains(lines_left);
+      }
     }
     else
     {
@@ -287,5 +296,3 @@ const Ogre::Quaternion& BillboardLine::getOrientation()
 }
 
 } // namespace rviz
-
-

--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -150,8 +150,7 @@ void BillboardLine::setupChains()
     {
       uint32_t lines_left = num_lines_ % lines_per_chain_;
 
-      // Handle the case where there are exactly the number of lines
-      // per chain remaining
+      // Handle the case where num_lines_ is a multiple of lines_per_chain
       if (lines_left == 0) {
           (*it)->setNumberOfChains(lines_per_chain_);
       }


### PR DESCRIPTION
Fixing a bug in the BillboardLine class when setting up the chains. The case where the number of points is an exact multiple of 16384 (MAX_ELEMENTS) was not being handled and resulted in the number of chains being set to 0 which results in ogre throwing the following exception:

    terminate called after throwing an instance of 'Ogre::ItemIdentityException'
      what():  OGRE EXCEPTION(5:ItemIdentityException): chainIndex out of bounds in BillboardChain::addChainElement at /build/buildd/ogre-1.8-1.8.1+dfsg/OgreMain/src/OgreBillboardChain.cpp (line 243)

This issue has been mentioned in: [ORB_SLAM issue 60](https://github.com/raulmur/ORB_SLAM/issues/60), [ORB_SLAM issue 21](https://github.com/raulmur/ORB_SLAM/issues/21), [hratc2015_framework issue 4](https://github.com/ras-sight/hratc2015_framework/issues/4), and [here](http://answers.ros.org/question/192272/possible-limitation-of-points-in-markerline_strip-and-rviz/)

This issue is easy to reproduce using the following steps:

1. Open rviz
2. Set the fixed frame to "map"
3. Add a "Marker" display to rviz
4. Make sure the marker is subscribed to "visualization_marker" topic (this should be the default) 
5. Publish a Marker with an exact multiple of 16384 points in it
6. rviz will crash due to chainIndex out of bounds (see the script in [test-break-rviz.zip](https://github.com/ros-visualization/rviz/files/51372/test-break-rviz.zip))
