### PR TITLE
Remove default_plugin from exported libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,6 @@ catkin_package(
     ${OPENGL_INCLUDE_DIR}
   LIBRARIES
     rviz
-    default_plugin
     ${OGRE_OV_LIBRARIES_ABS}
     ${rviz_ADDITIONAL_LIBRARIES}
     ${OPENGL_LIBRARIES}


### PR DESCRIPTION
The plugin is handled by pluginlib. Exporting it creates an unneeded dependency in rvizConfig.cmake.