### PR TITLE
Make read-only properties read-only

### DIFF
--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -282,7 +282,7 @@ Qt::ItemFlags Property::getViewFlags( int column ) const
 {
   // if the parent propery is a disabled bool property or
   // has its own enabled view flag not set, disable this property as well
-  Qt::ItemFlags enabled_flag = ( parent_ && parent_->getDisableChildren() ) ? Qt::NoItemFlags : Qt::ItemIsEnabled;  // || is_read_only_
+  Qt::ItemFlags enabled_flag = ( parent_ && parent_->getDisableChildren() ) ? Qt::NoItemFlags : Qt::ItemIsEnabled;
 
   if( column == 0 )
   {

--- a/src/rviz/properties/property_tree_delegate.cpp
+++ b/src/rviz/properties/property_tree_delegate.cpp
@@ -58,7 +58,7 @@ QWidget *PropertyTreeDelegate::createEditor( QWidget *parent,
                                              const QModelIndex &index ) const
 {
   Property* prop = static_cast<Property*>( index.internalPointer() );
-  if( !prop )
+  if( !prop || prop->getReadOnly())
   {
     return 0;
   }


### PR DESCRIPTION
A read-only property shouldn't be allowed to be edited ;-)
Fixed by not creating an editor in that case.

Related #654 which attempted to solve that issue by disabling the property,
which in turn was reverted in #679 due to its side effects.