### PR TITLE
Updated the marker display to allow namespaces to be enabled/disabled from the config

### DIFF
--- a/src/rviz/default_plugin/marker_display.h
+++ b/src/rviz/default_plugin/marker_display.h
@@ -95,6 +95,8 @@ protected:
   virtual void onEnable();
   virtual void onDisable();
 
+  virtual void load( const Config& config);
+
   /** @brief Subscribes to the "visualization_marker" and
    * "visualization_marker_array" topics. */
   virtual void subscribe();
@@ -164,6 +166,9 @@ private:
   M_Namespace namespaces_;
 
   Property* namespaces_category_;
+
+  typedef std::map<QString, bool> M_EnabledState;
+  M_EnabledState namespace_config_enabled_state_;
 
   friend class MarkerNamespace;
 };


### PR DESCRIPTION
The marker display does not currently load the enabled/disabled state of namespaces from its config. Those values are simply not used. These changes load the enabled/disabled state of namespaces from the config into a map which gets used to disable namespaces when they are added.

This is essentially the same fix as commit 0baa9f351cb73f880141ecfabd61aaa224de7458 but applied to the marker display instead of the tf display.