### PR TITLE
Change costmap lethal color different from illegal values.

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -182,10 +182,10 @@ unsigned char* makeCostmapPalette()
   *palette_ptr++ = 255; // green
   *palette_ptr++ = 255; // blue
   *palette_ptr++ = 255; // alpha
-  // lethal obstacle values (100) in yellow
+  // lethal obstacle values (100) in purple
   *palette_ptr++ = 255; // red
-  *palette_ptr++ = 255; // green
-  *palette_ptr++ = 0; // blue
+  *palette_ptr++ = 0; // green
+  *palette_ptr++ = 255; // blue
   *palette_ptr++ = 255; // alpha
   // illegal positive values in green
   for( int i = 101; i <= 127; i++ )


### PR DESCRIPTION
Lethal obstacles are now purple to make them different from illegal negative values that might also have been yellow.

Note that this reverts the previous commit that changed the comment from purple to yellow and instead changes the implementation. If there is a concern that the display is changed, I could also do this the other way around and make negative values in purple, but I believe that this is how it was intended originally.