### PR TITLE
Fix CMake warning about FindEigen.cmake being deprecated. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ endif()
 
 find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 catkin_python_setup()
 


### PR DESCRIPTION
CMake prints the following warning:
```
-- checking for module 'eigen3'
--   found eigen3, version 3.2.0
CMake Warning at /opt/ros/jade/share/cmake_modules/cmake/Modules/FindEigen.cmake:62 (message):
  The FindEigen.cmake Module in the cmake_modules package is deprecated.

  Please use the FindEigen3.cmake Module provided with Eigen.  Change
  instances of find_package(Eigen) to find_package(Eigen3).  Check the
  FindEigen3.cmake Module for the resulting CMake variable names.

Call Stack (most recent call first):
  CMakeLists.txt:130 (find_package)


-- Found Eigen: /usr/include/eigen3  
-- Eigen found (include: /usr/include/eigen3)
```

Replacing `Eigen` with `Eigen3` as proposed by the warning message works for me (Ubuntu 14.04.3 LTS).