### PR TITLE
Convert to class

### DIFF
--- a/src/rviz/viewport_mouse_event.h
+++ b/src/rviz/viewport_mouse_event.h
@@ -43,8 +43,9 @@ namespace rviz
 
 class RenderPanel;
 
-struct ViewportMouseEvent
+class ViewportMouseEvent
 {
+ public:
   ViewportMouseEvent() {}
 
   /** Constructor for use with a QMouseEvent. */


### PR DESCRIPTION
ViewportMouseEvent is forward declared as a class in other headers, which causes warnings in clang with -Wmismatched-tags