### PR TITLE
Add checkbox to hint for unreliable (UDP) topic transport for DisplayFilter based plugins.

### DIFF
--- a/src/rviz/message_filter_display.h
+++ b/src/rviz/message_filter_display.h
@@ -142,15 +142,11 @@ protected:
 
       try
       {
-        ros::TransportHints transport_hint;
+        ros::TransportHints transport_hint = ros::TransportHints().reliable();
         // Determine UDP vs TCP transport for user selection.
         if (unreliable_property_->getBool())
         {
           transport_hint = ros::TransportHints().unreliable();
-        }
-        else
-        {
-          transport_hint = ros::TransportHints().reliable();
         }
         sub_.subscribe( update_nh_, topic_property_->getTopicStd(), 10, transport_hint);
         setStatus( StatusProperty::Ok, "Topic", "OK" );

--- a/src/rviz/message_filter_display.h
+++ b/src/rviz/message_filter_display.h
@@ -58,6 +58,10 @@ public:
       topic_property_ = new RosTopicProperty( "Topic", "",
                                               "", "",
                                               this, SLOT( updateTopic() ));
+      unreliable_property_ = new BoolProperty( "Unreliable", false,
+                                               "Prefer UDP topic transport",
+                                               this,
+                                               SLOT( updateTopic() ));
     }
 
 protected Q_SLOTS:
@@ -65,6 +69,7 @@ protected Q_SLOTS:
 
 protected:
   RosTopicProperty* topic_property_;
+  BoolProperty* unreliable_property_;
 };
 
 /** @brief Display subclass using a tf::MessageFilter, templated on the ROS message type.
@@ -137,7 +142,17 @@ protected:
 
       try
       {
-        sub_.subscribe( update_nh_, topic_property_->getTopicStd(), 10 );
+        ros::TransportHints transport_hint;
+        // Determine UDP vs TCP transport for user selection.
+        if (unreliable_property_->getBool())
+        {
+          transport_hint = ros::TransportHints().unreliable();
+        }
+        else
+        {
+          transport_hint = ros::TransportHints().reliable();
+        }
+        sub_.subscribe( update_nh_, topic_property_->getTopicStd(), 10, transport_hint);
         setStatus( StatusProperty::Ok, "Topic", "OK" );
       }
       catch( ros::Exception& e )


### PR DESCRIPTION
Added "Unreliable hint" option to base MessageFilterDisplay template
class.

This allows the user to choose the option to use UDP unreliable [TransportHints](http://docs.ros.org/hydro/api/roscpp/html/classros_1_1TransportHints.html) for high throughput topics in a bandwidth constrained environment where TCP retransmits cause more congestion.

![screenshot from 2016-02-19 19 41 23](https://cloud.githubusercontent.com/assets/61757/13193060/d4a0960e-d740-11e5-8ecb-084607d5fb6b.png)

Verified that saving the rviz config shows `Unreliable: true` for topics selected with the option.
Also verified in wireshark that UDP is correctly used for topics selected and publishers that support it.