### PR TITLE
Unreliable option on image, camera and map

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -112,6 +112,11 @@ MapDisplay::MapDisplay()
                                                   "Orientation of the map. (not editable)",
                                                   this );
   orientation_property_->setReadOnly( true );
+
+  unreliable_property_ = new BoolProperty( "Unreliable", false,
+                                           "Prefer UDP topic transport",
+                                           this,
+                                           SLOT( updateTopic() ));
 }
 
 MapDisplay::~MapDisplay()
@@ -343,7 +348,12 @@ void MapDisplay::subscribe()
   {
     try
     {
-      map_sub_ = update_nh_.subscribe( topic_property_->getTopicStd(), 1, &MapDisplay::incomingMap, this );
+      if(unreliable_property_->getBool())
+      {
+        map_sub_ = update_nh_.subscribe( topic_property_->getTopicStd(), 1, &MapDisplay::incomingMap, this,  ros::TransportHints().unreliable());
+      }else{
+        map_sub_ = update_nh_.subscribe( topic_property_->getTopicStd(), 1, &MapDisplay::incomingMap, this, ros::TransportHints().reliable() );
+      }
       setStatus( StatusProperty::Ok, "Topic", "OK" );
     }
     catch( ros::Exception& e )

--- a/src/rviz/default_plugin/map_display.h
+++ b/src/rviz/default_plugin/map_display.h
@@ -142,6 +142,8 @@ protected:
   FloatProperty* alpha_property_;
   Property* draw_under_property_;
   EnumProperty* color_scheme_property_;
+
+  BoolProperty* unreliable_property_;
 };
 
 } // namespace rviz

--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -67,6 +67,11 @@ ImageDisplayBase::ImageDisplayBase() :
 
   transport_property_->setStdString("raw");
 
+  unreliable_property_ = new BoolProperty( "Unreliable", false,
+                                           "Prefer UDP topic transport",
+                                           this,
+                                           SLOT( updateTopic() ));
+
 }
 
 ImageDisplayBase::~ImageDisplayBase()
@@ -152,8 +157,18 @@ void ImageDisplayBase::subscribe()
 
     if (!topic_property_->getTopicStd().empty() && !transport_property_->getStdString().empty() )
     {
-      sub_->subscribe(*it_, topic_property_->getTopicStd(), (uint32_t)queue_size_property_->getInt(),
-                      image_transport::TransportHints(transport_property_->getStdString()));
+
+        // Determine UDP vs TCP transport for user selection.
+        if (unreliable_property_->getBool())
+        {
+            sub_->subscribe(*it_, topic_property_->getTopicStd(), (uint32_t)queue_size_property_->getInt(),
+                            image_transport::TransportHints(transport_property_->getStdString(), ros::TransportHints().unreliable()));
+        }
+        else{
+            sub_->subscribe(*it_, topic_property_->getTopicStd(), (uint32_t)queue_size_property_->getInt(),
+                            image_transport::TransportHints(transport_property_->getStdString()));
+        }
+
 
       if (targetFrame_.empty())
       {

--- a/src/rviz/image/image_display_base.h
+++ b/src/rviz/image/image_display_base.h
@@ -124,6 +124,8 @@ protected:
   std::string transport_;
 
   std::set<std::string> transport_plugin_types_;
+
+  BoolProperty* unreliable_property_;
 };
 
 } // end namespace rviz


### PR DESCRIPTION
When streaming videos it's usually a good idea to do it using UDP. This is specially true if we are connected through Wi-Fi or other "unreliable" connection.

Since we were having problems visualizing the streams coming from our robot over Wi-Fi, we decided to make the **Unreliable** (UDP) option also available for **Image** and **Camera** displays. We also made it available for Map.