### PR TITLE
port rviz to Qt5 with continued support for Qt4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(rviz)
 
 if (POLICY CMP0042)
@@ -91,7 +91,18 @@ endif()
 
 find_package(OpenGL REQUIRED)
 
-find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+option(UseQt5 "UseQt5" OFF)
+if (UseQt5)
+  find_package(Qt5Widgets REQUIRED)
+  find_package(Qt5Core REQUIRED)
+  find_package(Qt5OpenGL REQUIRED)
+else (UseQt5)
+  find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+endif(UseQt5)
+  
 
 find_package(catkin REQUIRED
   COMPONENTS
@@ -186,7 +197,9 @@ include_directories(SYSTEM
 )
 include_directories(src ${catkin_INCLUDE_DIRS})
 
-include(${QT_USE_FILE})
+if (NOT UseQt5)
+  include(${QT_USE_FILE})
+endif (NOT UseQt5)
 add_definitions(-DQT_NO_KEYWORDS)
 
 #### If gtk ends up being the best way to get the correct window

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,10 +99,9 @@ if (UseQt5)
   find_package(Qt5Widgets REQUIRED)
   find_package(Qt5Core REQUIRED)
   find_package(Qt5OpenGL REQUIRED)
-else (UseQt5)
+else()
   find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
-endif(UseQt5)
-  
+endif()
 
 find_package(catkin REQUIRED
   COMPONENTS
@@ -199,7 +198,7 @@ include_directories(src ${catkin_INCLUDE_DIRS})
 
 if (NOT UseQt5)
   include(${QT_USE_FILE})
-endif (NOT UseQt5)
+endif()
 add_definitions(-DQT_NO_KEYWORDS)
 
 #### If gtk ends up being the best way to get the correct window

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,4 +3,8 @@ add_subdirectory(image_view)
 if (CATKIN_ENABLE_TESTING)
   add_subdirectory(test)
 endif()
-add_subdirectory(python_bindings)
+# Disable Python bindings when using Qt5.
+# Will be re-enabled in Kinetic where our Qt Python packages will support Qt5.
+if (NOT UseQt5)
+  add_subdirectory(python_bindings)
+endif()

--- a/src/image_view/CMakeLists.txt
+++ b/src/image_view/CMakeLists.txt
@@ -1,8 +1,4 @@
 
-qt4_wrap_cpp(MOC_FILES
-  image_view.h
-)
-
 add_executable(rviz_image_view
   image_view.cpp
   main.cpp

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -19,76 +19,12 @@ configure_file(env_config.cpp.in ${ENV_CONFIG_FILE} @ONLY)
 
 # We create one lib with the C++...
 
-qt4_wrap_cpp(MOC_FILES
-  display_context.h
-  display_group.h
-  display.h
-  displays_panel.h
-  failed_panel.h
-  frame_manager.h
-  frame_position_tracking_view_controller.h
-  help_panel.h
-  image/image_display_base.h
-  loading_dialog.h
-  message_filter_display.h
-  new_object_dialog.h
-  add_display_dialog.h
-  panel_dock_widget.h
-  panel.h
-  properties/bool_property.h
-  properties/color_editor.h
-  properties/color_property.h
-  properties/combo_box.h
-  properties/display_visibility_property.h
-  properties/display_group_visibility_property.h
-  properties/editable_combo_box.h
-  properties/editable_enum_property.h
-  properties/enum_property.h
-  properties/float_edit.h
-  properties/float_property.h
-  properties/int_property.h
-  properties/line_edit_with_button.h
-  properties/property.h
-  properties/property_tree_delegate.h
-  properties/property_tree_model.h
-  properties/property_tree_widget.h
-  properties/property_tree_with_help.h
-  properties/quaternion_property.h
-  properties/ros_topic_property.h
-  properties/splitter_handle.h
-  properties/status_list.h
-  properties/status_property.h
-  properties/string_property.h
-  properties/tf_frame_property.h
-  properties/vector_property.h
-  render_panel.h
-  robot/robot.h
-  robot/robot_link.h
-  robot/robot_joint.h
-  scaled_image_widget.h
-  screenshot_dialog.h
-  selection/selection_manager.h
-  splash_screen.h
-  time_panel.h
-  tool_manager.h
-  tool.h
-  view_controller.h
-  view_manager.h
-  views_panel.h
-  visualization_frame.h
-  visualization_manager.h
-  visualizer_app.h
-  wait_for_master_dialog.h
-  widget_geometry_change_detector.h
-  selection_panel.h
-  tool_properties_panel.h
-)
-
 add_library( ${PROJECT_NAME}
   bit_allocator.cpp
   config.cpp
   display.cpp
   display.cpp
+  display_context.h
   display_factory.cpp
   display_group.cpp
   displays_panel.cpp
@@ -104,6 +40,7 @@ add_library( ${PROJECT_NAME}
   image/ros_image_texture.cpp
   image/image_display_base.cpp
   loading_dialog.cpp
+  message_filter_display.h
   mesh_loader.cpp
   new_object_dialog.cpp
   add_display_dialog.cpp
@@ -198,6 +135,10 @@ target_link_libraries(${PROJECT_NAME}
   assimp
   yaml-cpp
 )
+if (UseQt5)
+  target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
+endif (UseQt5)
+
 
 if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
@@ -207,6 +148,10 @@ endif(APPLE)
 add_executable(executable main.cpp)
 
 target_link_libraries(executable ${PROJECT_NAME} ${QT_LIBRARIES} ${OGRE_OV_LIBRARIES_ABS})
+if (UseQt5)
+  target_link_libraries(executable Qt5::Widgets)
+endif (UseQt5)
+
 set_target_properties(executable
                       PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -137,7 +137,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 if (UseQt5)
   target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
-endif (UseQt5)
+endif()
 
 
 if(APPLE)
@@ -150,7 +150,7 @@ add_executable(executable main.cpp)
 target_link_libraries(executable ${PROJECT_NAME} ${QT_LIBRARIES} ${OGRE_OV_LIBRARIES_ABS})
 if (UseQt5)
   target_link_libraries(executable Qt5::Widgets)
-endif (UseQt5)
+endif()
 
 set_target_properties(executable
                       PROPERTIES OUTPUT_NAME ${PROJECT_NAME})

--- a/src/rviz/add_display_dialog.cpp
+++ b/src/rviz/add_display_dialog.cpp
@@ -435,7 +435,11 @@ TopicDisplayWidget::TopicDisplayWidget()
   tree_->setColumnCount( 2 );
 
   tree_->header()->setStretchLastSection( false );
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   tree_->header()->setResizeMode( 0, QHeaderView::Stretch );
+#else
+  tree_->header()->setSectionResizeMode(0, QHeaderView::Stretch);
+#endif
 
   enable_hidden_box_ = new QCheckBox( "Show unvisualizable topics" );
   enable_hidden_box_->setCheckState( Qt::Unchecked );

--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -1,50 +1,5 @@
 include_directories(.)
 
-qt4_wrap_cpp(MOC_FILES
-  axes_display.h
-  camera_display.h
-  depth_cloud_display.h
-  effort_display.h
-  fluid_pressure_display.h
-  grid_cells_display.h
-  grid_display.h
-  illuminance_display.h
-  image_display.h
-  interactive_marker_display.h
-  interactive_markers/integer_action.h
-  interactive_markers/interactive_marker.h
-  laser_scan_display.h
-  map_display.h
-  marker_display.h
-  marker_array_display.h
-  odometry_display.h
-  path_display.h
-  point_display.h
-  point_cloud_common.h
-  point_cloud_display.h
-  point_cloud_transformer.h
-  point_cloud_transformers.h
-  point_cloud2_display.h
-  polygon_display.h
-  pose_array_display.h
-  pose_display.h
-  range_display.h
-  relative_humidity_display.h
-  robot_model_display.h
-  temperature_display.h
-  tf_display.h
-  tools/goal_tool.h
-  tools/initial_pose_tool.h
-  tools/interaction_tool.h
-  tools/point_tool.h
-  view_controllers/orbit_view_controller.h
-  view_controllers/xy_orbit_view_controller.h
-  view_controllers/third_person_follower_view_controller.h
-  view_controllers/fixed_orientation_ortho_view_controller.h
-  view_controllers/fps_view_controller.h
-  wrench_display.h
-)
-
 set(SOURCE_FILES
   axes_display.cpp
   camera_display.cpp
@@ -82,6 +37,7 @@ set(SOURCE_FILES
   point_cloud2_display.cpp
   point_cloud_common.cpp
   point_cloud_display.cpp
+  point_cloud_transformer.h
   point_cloud_transformers.cpp
   polygon_display.cpp
   pose_array_display.cpp

--- a/src/rviz/display_factory.cpp
+++ b/src/rviz/display_factory.cpp
@@ -125,7 +125,11 @@ QSet<QString> DisplayFactory::getMessageTypes( const QString& class_id )
           {
             const char* message_type_str = message_type->GetText();
             ROS_DEBUG_STREAM(current_class_id << " supports message type " << message_type_str );
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
             message_types.insert( QString::fromAscii( message_type_str ) );
+#else
+            message_types.insert( QString(message_type_str) );
+#endif
           }
           message_type = message_type->NextSiblingElement("message_type");
         }

--- a/src/rviz/main.cpp
+++ b/src/rviz/main.cpp
@@ -36,6 +36,7 @@ int main( int argc, char** argv )
   QApplication qapp( argc, argv );
 
   rviz::VisualizerApp vapp;
+  vapp.setApp( &qapp );
   if( vapp.init( argc, argv ))
   {
     return qapp.exec();

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <QMetaType>
+
 // This is required for QT_MAC_USE_COCOA to be set
 #include <QtCore/qglobal.h>
 

--- a/src/rviz/ogre_helpers/render_widget.cpp
+++ b/src/rviz/ogre_helpers/render_widget.cpp
@@ -50,6 +50,7 @@ RenderWidget::RenderWidget( RenderSystem* render_system, QWidget *parent )
   setAttribute(Qt::WA_OpaquePaintEvent,true);
   setAttribute(Qt::WA_PaintOnScreen,true);
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   // It is not clear to me why, but having this frame sub-widget
   // inside the main widget makes an important difference (under X at
   // least).  Without the frame and using this widget's winId() 
@@ -66,14 +67,23 @@ RenderWidget::RenderWidget( RenderSystem* render_system, QWidget *parent )
   mainLayout->setContentsMargins( 0, 0, 0, 0 );
   mainLayout->addWidget(this->renderFrame);
   this->setLayout(mainLayout);
+#endif
 
 #ifdef Q_OS_MAC
   uintptr_t win_id = winId();
 #else
+  #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   unsigned int win_id = renderFrame->winId();
-#endif  
+  #else
+  unsigned int win_id = winId();
+  #endif
+#endif
+
   QApplication::flush();
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   QApplication::syncX();
+#endif
   render_window_ = render_system_->makeRenderWindow( win_id, width(), height() );
 }
 

--- a/src/rviz/ogre_helpers/render_widget.cpp
+++ b/src/rviz/ogre_helpers/render_widget.cpp
@@ -53,7 +53,7 @@ RenderWidget::RenderWidget( RenderSystem* render_system, QWidget *parent )
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   // It is not clear to me why, but having this frame sub-widget
   // inside the main widget makes an important difference (under X at
-  // least).  Without the frame and using this widget's winId() 
+  // least).  Without the frame and using this widget's winId()
   // below causes trouble when using RenderWidget as a child
   // widget.  The frame graphics are completely covered up by the 3D
   // render, so using it does not affect the appearance at all.
@@ -72,11 +72,11 @@ RenderWidget::RenderWidget( RenderSystem* render_system, QWidget *parent )
 #ifdef Q_OS_MAC
   uintptr_t win_id = winId();
 #else
-  #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+# if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   unsigned int win_id = renderFrame->winId();
-  #else
+# else
   unsigned int win_id = winId();
-  #endif
+# endif
 #endif
 
   QApplication::flush();

--- a/src/rviz/ogre_helpers/render_widget.h
+++ b/src/rviz/ogre_helpers/render_widget.h
@@ -54,6 +54,10 @@ protected:
   virtual void paintEvent(QPaintEvent *e);
   virtual void resizeEvent(QResizeEvent *e);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+  QPaintEngine *paintEngine() const { return 0; }
+#endif
+
   RenderSystem* render_system_;
   Ogre::RenderWindow* render_window_;
 

--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -238,7 +238,11 @@ QVariant Property::getViewData( int column, int role ) const
   if ( role == Qt::TextColorRole &&
        ( parent_ && parent_->getDisableChildren() ) )
   {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     return Qt::gray;
+#else
+    return QColor(Qt::gray);
+#endif
   }
 
   switch( column )

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1162,10 +1162,13 @@ void VisualizationFrame::onHelpAbout()
   QString about_text = QString(
     "This is RViz version %1 (%2).\n"
     "\n"
-    "Compiled against OGRE version %3.%4.%5%6 (%7)."
+    "Compiled against Qt version %3."
+    "\n"
+    "Compiled against OGRE version %4.%5.%6%7 (%8)."
   )
   .arg(get_version().c_str())
   .arg(get_distro().c_str())
+  .arg(QT_VERSION_STR)
   .arg(OGRE_VERSION_MAJOR)
   .arg(OGRE_VERSION_MINOR)
   .arg(OGRE_VERSION_PATCH)

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -91,7 +91,7 @@
 namespace fs = boost::filesystem;
 
 #define CONFIG_EXTENSION "rviz"
-#define CONFIG_EXTENSION_WILDCARD "*."CONFIG_EXTENSION
+#define CONFIG_EXTENSION_WILDCARD "*." CONFIG_EXTENSION
 #define RECENT_CONFIG_COUNT 10
 
 #if BOOST_FILESYSTEM_VERSION == 3
@@ -341,7 +341,7 @@ void VisualizationFrame::initConfigs()
 
   config_dir_ = (fs::path(home_dir_) / ".rviz").BOOST_FILE_STRING();
   persistent_settings_file_ = (fs::path(config_dir_) / "persistent_settings").BOOST_FILE_STRING();
-  default_display_config_file_ = (fs::path(config_dir_) / "default."CONFIG_EXTENSION).BOOST_FILE_STRING();
+  default_display_config_file_ = (fs::path(config_dir_) / "default." CONFIG_EXTENSION).BOOST_FILE_STRING();
 
   if( fs::is_regular_file( config_dir_ ))
   {
@@ -972,9 +972,9 @@ void VisualizationFrame::onSaveAs()
   {
     std::string filename = q_filename.toStdString();
     fs::path path( filename );
-    if( path.extension() != "."CONFIG_EXTENSION )
+    if( path.extension() != "." CONFIG_EXTENSION )
     {
-      filename += "."CONFIG_EXTENSION;
+      filename += "." CONFIG_EXTENSION;
     }
 
     if( !saveDisplayConfig( QString::fromStdString( filename )))

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -107,6 +107,7 @@ namespace rviz
 
 VisualizationFrame::VisualizationFrame( QWidget* parent )
   : QMainWindow( parent )
+  , app_(NULL)
   , render_panel_(NULL)
   , show_help_action_(NULL)
   , file_menu_(NULL)
@@ -166,6 +167,11 @@ VisualizationFrame::~VisualizationFrame()
   }
 
   delete panel_factory_;
+}
+
+void VisualizationFrame::setApp( QApplication * app )
+{
+  app_ = app;
 }
 
 void VisualizationFrame::setStatus( const QString & message )
@@ -255,11 +261,18 @@ void VisualizationFrame::initialize(const QString& display_config_file )
   }
   Q_EMIT statusUpdate( "Initializing" );
 
+  // Periodically process events for the splash screen.
+  // See: http://doc.qt.io/qt-5/qsplashscreen.html#details
+  if (app_) app_->processEvents();
+
   if( !ros::isInitialized() )
   {
     int argc = 0;
     ros::init( argc, 0, "rviz", ros::init_options::AnonymousName );
   }
+
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
 
   QWidget* central_widget = new QWidget(this);
   QHBoxLayout* central_layout = new QHBoxLayout;
@@ -294,16 +307,34 @@ void VisualizationFrame::initialize(const QString& display_config_file )
 
   central_widget->setLayout( central_layout );
 
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
+
   initMenus();
+
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
 
   initToolbars();
 
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
+
   setCentralWidget( central_widget );
+
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
 
   manager_ = new VisualizationManager( render_panel_, this );
   manager_->setHelpPath( help_path_ );
 
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
+
   render_panel_->initialize( manager_->getSceneManager(), manager_ );
+
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
 
   ToolManager* tool_man = manager_->getToolManager();
 
@@ -315,6 +346,9 @@ void VisualizationFrame::initialize(const QString& display_config_file )
 
   manager_->initialize();
 
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
+
   if( display_config_file != "" )
   {
     loadDisplayConfig( display_config_file );
@@ -323,6 +357,9 @@ void VisualizationFrame::initialize(const QString& display_config_file )
   {
     loadDisplayConfig( QString::fromStdString( default_display_config_file_ ));
   }
+
+  // Periodically process events for the splash screen.
+  if (app_) app_->processEvents();
 
   delete splash_;
   splash_ = 0;

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -75,6 +75,8 @@ public:
   VisualizationFrame( QWidget* parent = 0 );
   ~VisualizationFrame();
 
+  void setApp( QApplication * app );
+
   /** @brief Call this @e before initialize() to have it take effect. */
   void setShowChooseNewMaster( bool show );
 
@@ -277,6 +279,8 @@ protected:
   void setDisplayConfigFile( const std::string& path );
 
   void hideDockImpl( Qt::DockWidgetArea area, bool hide );
+
+  QApplication* app_;
 
   RenderPanel* render_panel_;
 

--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2008, Willow Garage, Inc.
  * All rights reserved.
  *
@@ -39,7 +39,7 @@
 
 #ifdef Q_OS_MAC
 #include <ApplicationServices/ApplicationServices.h>
-// Apparently OSX #defines 'check' to be an empty string somewhere.  
+// Apparently OSX #defines 'check' to be an empty string somewhere.
 // That was fun to figure out.
 #undef check
 #endif
@@ -97,9 +97,15 @@ bool reloadShaders(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
 }
 
 VisualizerApp::VisualizerApp()
-  : continue_timer_( 0 )
+  : app_( 0 )
+  , continue_timer_( 0 )
   , frame_( 0 )
 {
+}
+
+void VisualizerApp::setApp( QApplication * app )
+{
+  app_ = app;
 }
 
 bool VisualizerApp::init( int argc, char** argv )
@@ -260,7 +266,8 @@ bool VisualizerApp::init( int argc, char** argv )
       RenderSystem::forceNoStereo();
     }
 
-    frame_ = new VisualizationFrame;
+    frame_ = new VisualizationFrame();
+    frame_->setApp( this->app_ );
     if( help_path != "" )
     {
       frame_->setHelpPath( QString::fromStdString( help_path ));

--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -111,6 +111,7 @@ void VisualizerApp::setApp( QApplication * app )
 bool VisualizerApp::init( int argc, char** argv )
 {
   ROS_INFO( "rviz version %s", get_version().c_str() );
+  ROS_INFO( "compiled against Qt version " QT_VERSION_STR );
   ROS_INFO( "compiled against OGRE version %d.%d.%d%s (%s)",
             OGRE_VERSION_MAJOR, OGRE_VERSION_MINOR, OGRE_VERSION_PATCH,
             OGRE_VERSION_SUFFIX, OGRE_VERSION_NAME );

--- a/src/rviz/visualizer_app.h
+++ b/src/rviz/visualizer_app.h
@@ -29,6 +29,7 @@
 #ifndef RVIZ_VISUALIZER_APP_H
 #define RVIZ_VISUALIZER_APP_H
 
+#include <QApplication>
 #include <QObject>
 
 #ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
@@ -49,6 +50,8 @@ public:
   VisualizerApp();
   virtual ~VisualizerApp();
 
+  void setApp( QApplication * app );
+
   /** Start everything.  Pass in command line arguments.
    * @return false on failure, true on success. */
   bool init( int argc, char** argv );
@@ -60,6 +63,7 @@ private Q_SLOTS:
 private:
   void startContinueChecker();
 
+  QApplication* app_;
   QTimer* continue_timer_;
   VisualizationFrame* frame_;
   ros::NodeHandlePtr nh_;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -17,13 +17,15 @@ target_link_libraries(mesh_marker_test ${catkin_LIBRARIES})
 add_dependencies(tests mesh_marker_test)
 
 # This is a GTest which tests the different types of primitive display properties.
-qt4_wrap_cpp(MOC_MOCK_PROPERTY_CHANGE_RECEIVER mock_property_change_receiver.h)
 catkin_add_gtest(property_test
   property_test.cpp
   mock_property_change_receiver.cpp
   ${MOC_MOCK_PROPERTY_CHANGE_RECEIVER}
 )
 target_link_libraries(property_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(property_test Qt5::Widgets)
+endif (UseQt5)
 
 # TODO(wjwwood): Fix this test, it used to use a set of Mock classes, but
 #                has since undergone a lot of changes and it no longer works.
@@ -84,22 +86,28 @@ add_dependencies(tests send_grid_cells)
 # This is a test program that uses the rviz panel interface.
 add_executable(render_panel_test render_panel_test.cpp)
 target_link_libraries(render_panel_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(render_panel_test Qt5::Widgets)
+endif (UseQt5)
 add_dependencies(tests render_panel_test)
 
 # This is an executable which uses the rviz new display diaglog interface.
 add_executable(new_display_dialog_test new_display_dialog_test.cpp)
 target_link_libraries(new_display_dialog_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(new_display_dialog_test Qt5::Widgets)
+endif (UseQt5)
 add_dependencies(tests new_display_dialog_test)
 
 # This is an executable which uses the rviz color editor test.
 add_executable(color_editor_test color_editor_test.cpp)
 target_link_libraries(color_editor_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(color_editor_test Qt5::Widgets)
+endif (UseQt5)
 add_dependencies(tests color_editor_test)
 
 # This is a modified version of the property test.
-qt4_wrap_cpp(PROPERTY_TEST_MOC_FILES
-  ros_spinner.h
-)
 catkin_add_gtest(property_with_ros_spinner_test
   property_test.cpp
   ros_spinner.cpp
@@ -108,40 +116,52 @@ catkin_add_gtest(property_with_ros_spinner_test
   ${MOC_MOCK_PROPERTY_CHANGE_RECEIVER}
 )
 target_link_libraries(property_with_ros_spinner_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(property_with_ros_spinner_test Qt5::Widgets)
+endif (UseQt5)
 add_dependencies(tests property_with_ros_spinner_test)
 
 # This is an executable that uses the line_edit_with_button property interface.
 add_executable(line_edit_with_button_test line_edit_with_button_test.cpp)
 target_link_libraries(line_edit_with_button_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(line_edit_with_button_test Qt5::Widgets)
+endif (UseQt5)
 add_dependencies(tests line_edit_with_button_test)
 
 # This is an executable which tests the connect/disconnect behavior of signals and slots in Qt.
-qt4_wrap_cpp(MOC_FILES
-  connect_test.h
-)
 add_executable(connect_test connect_test.cpp ${MOC_FILES})
 target_link_libraries(connect_test ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(connect_test Qt5::Widgets)
+endif (UseQt5)
 add_dependencies(tests connect_test)
 
 # This is a GTest which tests the display configuration.
 catkin_add_gtest(config_test config_test.cpp ../rviz/uniform_string_stream.cpp ../rviz/config.cpp)
+if (UseQt5)
+  target_link_libraries(config_test Qt5::Widgets)
+endif (UseQt5)
 target_link_libraries(config_test ${QT_LIBRARIES})
 
 # This is an acceptance test executable which renders points.
-qt4_wrap_cpp(RENDER_POINTS_TEST_MOC_FILES
-  render_points_test.h
-)
 add_executable(render_points_test
   render_points_test.cpp
   ../rviz/ogre_helpers/orbit_camera.cpp
   ${RENDER_POINTS_TEST_MOC_FILES}
 )
 target_link_libraries(render_points_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(render_points_test Qt5::Widgets)
+endif (UseQt5)
 add_dependencies(tests render_points_test)
 
 # This is an example application which creates two ogre render windows.
 add_executable(two_render_widgets two_render_widgets.cpp)
 target_link_libraries(two_render_widgets rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
+if (UseQt5)
+  target_link_libraries(two_render_widgets Qt5::Widgets)
+endif (UseQt5)
 add_dependencies(tests two_render_widgets)
 
 # This is a GTest which tests the STL loader

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -25,7 +25,7 @@ catkin_add_gtest(property_test
 target_link_libraries(property_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(property_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 
 # TODO(wjwwood): Fix this test, it used to use a set of Mock classes, but
 #                has since undergone a lot of changes and it no longer works.
@@ -88,7 +88,7 @@ add_executable(render_panel_test render_panel_test.cpp)
 target_link_libraries(render_panel_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(render_panel_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 add_dependencies(tests render_panel_test)
 
 # This is an executable which uses the rviz new display diaglog interface.
@@ -96,7 +96,7 @@ add_executable(new_display_dialog_test new_display_dialog_test.cpp)
 target_link_libraries(new_display_dialog_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(new_display_dialog_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 add_dependencies(tests new_display_dialog_test)
 
 # This is an executable which uses the rviz color editor test.
@@ -104,7 +104,7 @@ add_executable(color_editor_test color_editor_test.cpp)
 target_link_libraries(color_editor_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(color_editor_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 add_dependencies(tests color_editor_test)
 
 # This is a modified version of the property test.
@@ -118,7 +118,7 @@ catkin_add_gtest(property_with_ros_spinner_test
 target_link_libraries(property_with_ros_spinner_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(property_with_ros_spinner_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 add_dependencies(tests property_with_ros_spinner_test)
 
 # This is an executable that uses the line_edit_with_button property interface.
@@ -126,7 +126,7 @@ add_executable(line_edit_with_button_test line_edit_with_button_test.cpp)
 target_link_libraries(line_edit_with_button_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(line_edit_with_button_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 add_dependencies(tests line_edit_with_button_test)
 
 # This is an executable which tests the connect/disconnect behavior of signals and slots in Qt.
@@ -134,14 +134,14 @@ add_executable(connect_test connect_test.cpp ${MOC_FILES})
 target_link_libraries(connect_test ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(connect_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 add_dependencies(tests connect_test)
 
 # This is a GTest which tests the display configuration.
 catkin_add_gtest(config_test config_test.cpp ../rviz/uniform_string_stream.cpp ../rviz/config.cpp)
 if (UseQt5)
   target_link_libraries(config_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 target_link_libraries(config_test ${QT_LIBRARIES})
 
 # This is an acceptance test executable which renders points.
@@ -153,7 +153,7 @@ add_executable(render_points_test
 target_link_libraries(render_points_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(render_points_test Qt5::Widgets)
-endif (UseQt5)
+endif()
 add_dependencies(tests render_points_test)
 
 # This is an example application which creates two ogre render windows.
@@ -161,7 +161,7 @@ add_executable(two_render_widgets two_render_widgets.cpp)
 target_link_libraries(two_render_widgets rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 if (UseQt5)
   target_link_libraries(two_render_widgets Qt5::Widgets)
-endif (UseQt5)
+endif()
 add_dependencies(tests two_render_widgets)
 
 # This is a GTest which tests the STL loader

--- a/src/test/color_editor_test.cpp
+++ b/src/test/color_editor_test.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <QtGui/QApplication>
+#include <QApplication>
 
 #include "rviz/properties/color_editor.h"
 

--- a/src/test/line_edit_with_button_test.cpp
+++ b/src/test/line_edit_with_button_test.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <QtGui/QApplication>
+#include <QApplication>
 
 #include "rviz/properties/line_edit_with_button.h"
 


### PR DESCRIPTION
I rebased and squashed @simonschmeisser's commits in https://github.com/ros-visualization/rviz/pull/909. I'll also be cherry-picking over my fixes for the splash screen and stuff like that.

This will replace https://github.com/ros-visualization/rviz/pull/909.