### PR TITLE
fix for two valgrind-reported issues

### DIFF
--- a/src/rviz/display_group.cpp
+++ b/src/rviz/display_group.cpp
@@ -164,10 +164,11 @@ void DisplayGroup::removeAllDisplays()
   }
   for( int i = displays_.size() - 1; i >= 0; i-- )
   {
-//    printf("  displaygroup2 displays_.takeAt( %d )\n", i );
     Display* child = displays_.takeAt( i );
     Q_EMIT displayRemoved( child );
     child->setParent( NULL ); // prevent child destructor from calling getParent()->takeChild().
+    child->setModel( NULL );
+    child_indexes_valid_ = false;
     delete child;
   }
   if( model_ )
@@ -189,7 +190,6 @@ Display* DisplayGroup::takeDisplay( Display* child )
       {
         model_->beginRemove( this, Display::numChildren() + i, 1 );
       }
-//      printf("  displaygroup3 displays_.takeAt( %d )\n", i );
       result = displays_.takeAt( i );
       Q_EMIT displayRemoved( result );
       result->setParent( NULL );

--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -66,6 +66,10 @@ RenderPanel::~RenderPanel()
   {
     scene_manager_->destroyCamera( default_camera_ );
   }
+  if( scene_manager_ )
+  {
+    scene_manager_->removeListener( this );
+  }
 }
 
 void RenderPanel::initialize(Ogre::SceneManager* scene_manager, DisplayContext* context)

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -125,8 +125,10 @@ VisualizationManager::VisualizationManager( RenderPanel* render_panel, WindowMan
 , frame_count_(0)
 , window_manager_(wm)
 , private_( new VisualizationManagerPrivate )
-, default_visibility_bit_( visibility_bit_allocator_.allocBit() )
 {
+  // visibility_bit_allocator_ is listed after default_visibility_bit_ (and thus initialized later be default):
+  default_visibility_bit_ = visibility_bit_allocator_.allocBit();
+
   frame_manager_ = new FrameManager(tf);
 
   render_panel->setAutoRender(false);


### PR DESCRIPTION
there were 2 non-fatal issues reported by valgrind:

1. RenderPanel's virtual method `sceneManagerDestroyed()` was called after destruction, because RenderPanel wasn't unregistered from SceneManager.
2. VisualizationManager's `default_visibility_bit_` was initialized from not-yet-initialized `visibility_bit_allocator_`
