### PR TITLE
update the plugin_description.xml to reflect the new default plugin library name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ endif()
 # This variable controls the target name of the default plugin library.
 # It is used in the extras file (processed in caktin_package(...)) and the
 # cmake code for the default plugin.
+# There is a matching instance of this in the plugin_description.xml.
 set(rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME rviz_default_plugin)
 
 catkin_package(

--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="libdefault_plugin">
+<library path="librviz_default_plugin">
   <class name="rviz/Axes" type="rviz::AxesDisplay" base_class_type="rviz::Display">
     <description>
       Displays an axis at the Target Frame's origin.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Axes"&gt;More Information&lt;/a&gt;.


### PR DESCRIPTION
Fixes https://github.com/ros-visualization/rviz/issues/1003