### PR TITLE
Create multiple textures if map doesn't fit in a single texture

### DIFF
--- a/src/rviz/default_plugin/map_display.h
+++ b/src/rviz/default_plugin/map_display.h
@@ -71,6 +71,7 @@ class Swatch
 friend class MapDisplay;
   public:
     Swatch(MapDisplay* parent, unsigned int x, unsigned int y, unsigned int width, unsigned int height, float resolution);
+    ~Swatch();
     void updateAlpha(const Ogre::SceneBlendType sceneBlending, bool depthWrite, AlphaSetter* alpha_setter);
     void updateData();
 
@@ -139,7 +140,7 @@ protected:
   void transformMap();
   void createSwatches();
 
-  std::vector<Swatch> swatches;
+  std::vector<Swatch*> swatches;
   std::vector<Ogre::TexturePtr> palette_textures_;
   std::vector<bool> color_scheme_transparency_;
   bool loaded_;

--- a/src/rviz/default_plugin/map_display.h
+++ b/src/rviz/default_plugin/map_display.h
@@ -63,12 +63,34 @@ class QuaternionProperty;
 class RosTopicProperty;
 class VectorProperty;
 
+class MapDisplay;
+class AlphaSetter;
+
+class Swatch
+{
+friend class MapDisplay;
+  public:
+    Swatch(MapDisplay* parent, unsigned int x, unsigned int y, unsigned int width, unsigned int height, float resolution);
+    void updateAlpha(const Ogre::SceneBlendType sceneBlending, bool depthWrite, AlphaSetter* alpha_setter);
+    void updateData();
+
+  protected:
+    MapDisplay* parent_;
+    Ogre::ManualObject* manual_object_;
+    Ogre::TexturePtr texture_;
+    Ogre::MaterialPtr material_;
+    Ogre::SceneNode* scene_node_;
+    unsigned int x_,y_,width_,height_;
+};
+
+
 /**
  * \class MapDisplay
  * \brief Displays a map along the XY plane.
  */
 class MapDisplay: public Display
 {
+friend class Swatch;
 Q_OBJECT
 public:
   MapDisplay();
@@ -115,12 +137,11 @@ protected:
   void clear();
 
   void transformMap();
+  void createSwatches();
 
-  Ogre::ManualObject* manual_object_;
-  Ogre::TexturePtr texture_;
+  std::vector<Swatch> swatches;
   std::vector<Ogre::TexturePtr> palette_textures_;
   std::vector<bool> color_scheme_transparency_;
-  Ogre::MaterialPtr material_;
   bool loaded_;
 
   std::string topic_;


### PR DESCRIPTION
If you attempt to display a large `rviz::Map`, and your graphics card is not super-powerful, it will downsample your map. 
```
[ WARN] [1487954079.336034022]: OGRE EXCEPTION(3:RenderingAPIException): Zero sized texture surface on texture MapTexture0 face 0 mipmap 0. Probably, the GL driver refused to create the texture. in GLTexture::_createSurfaceList at /build/buildd/ogre-1.8-1.8.1+dfsg/RenderSystems/GL/src/OgreGLTexture.cpp (line 420)
[ WARN] [1487954079.336585615]: Failed to create full-size map texture, likely because your graphics card does not support textures of size > 2048.  Downsampling to [2048 x 1314]...
```
![world1](https://cloud.githubusercontent.com/assets/1016143/23311940/d3b92bf2-fa85-11e6-9414-93aa9d8abfc8.png)

You can get around the limitations of your graphics card by creating multiple objects, each with their own texture, which I call Swatches. The result:
![world2](https://cloud.githubusercontent.com/assets/1016143/23311978/0123c1d8-fa86-11e6-8ac2-bad5387e9fac.png)

Here is my sample data:
[the_world.png](https://cloud.githubusercontent.com/assets/1016143/23312007/20bec2d6-fa86-11e6-8683-2f760f0ea0ee.png)

[the_world.yaml.txt](https://github.com/ros-visualization/rviz/files/799934/the_world.yaml.txt)


