### PR TITLE
cmake qt5 cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 option(UseQt5 "UseQt5" ON)
 if (UseQt5)
   find_package(Qt5 REQUIRED COMPONENTS Core Widgets OpenGL)
+  # set variable names already used with Qt4
+  set(QT_LIBRARIES Qt5::Widgets)
+  set(QTVERSION ${Qt5Widgets_VERSION})
 else()
   find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+  include(${QT_USE_FILE})
 endif()
+add_definitions(-DQT_NO_KEYWORDS)
 
 find_package(catkin REQUIRED
   COMPONENTS
@@ -153,17 +158,8 @@ if(NOT OGRE_OV_LIBRARIES_ABS)
   set(OGRE_OV_LIBRARIES_ABS ${OGRE_OV_LIBRARIES})
 endif()
 
-if(NOT UseQt5)
-  include(${QT_USE_FILE})
-endif()
-add_definitions(-DQT_NO_KEYWORDS)
-
 # Set the Qt version for use in the extras file.
-if(UseQt5)
-  set(rviz_QT_VERSION ${Qt5Widgets_VERSION})
-else()
-  set(rviz_QT_VERSION ${QTVERSION})
-endif()
+set(rviz_QT_VERSION ${QTVERSION})
 
 # This variable controls the target name of the default plugin library.
 # It is used in the extras file (processed in caktin_package(...)) and the

--- a/src/image_view/CMakeLists.txt
+++ b/src/image_view/CMakeLists.txt
@@ -2,7 +2,6 @@
 add_executable(rviz_image_view
   image_view.cpp
   main.cpp
-  ${MOC_FILES}
 )
 
 target_link_libraries(rviz_image_view

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -122,7 +122,6 @@ add_library( ${PROJECT_NAME}
   yaml_config_writer.cpp
 
   ${ENV_CONFIG_FILE}
-  ${MOC_FILES}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -127,6 +127,7 @@ add_library( ${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
   ${Boost_LIBRARIES}
   ${catkin_LIBRARIES}
+  ${QT_LIBRARIES}
   ${OGRE_OV_LIBRARIES_ABS}
   ${OPENGL_LIBRARIES}
   ${rviz_ADDITIONAL_LIBRARIES}

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -134,11 +134,6 @@ target_link_libraries(${PROJECT_NAME}
   assimp
   yaml-cpp
 )
-if(UseQt5)
-  target_link_libraries(${PROJECT_NAME} Qt5::Widgets)
-else()
-  target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES})
-endif()
 
 
 if(APPLE)
@@ -148,12 +143,7 @@ endif(APPLE)
 ########### The rviz executable ###########
 add_executable(executable main.cpp)
 
-target_link_libraries(executable ${PROJECT_NAME} ${OGRE_OV_LIBRARIES_ABS})
-if(UseQt5)
-  target_link_libraries(executable Qt5::Widgets)
-else()
-  target_link_libraries(executable ${QT_LIBRARIES})
-endif()
+target_link_libraries(executable ${PROJECT_NAME} ${QT_LIBRARIES} ${OGRE_OV_LIBRARIES_ABS})
 
 set_target_properties(executable
                       PROPERTIES OUTPUT_NAME ${PROJECT_NAME})

--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -63,7 +63,6 @@ set(SOURCE_FILES
   view_controllers/fps_view_controller.cpp
   wrench_display.cpp
   wrench_visual.cpp
-  ${MOC_FILES}
 )
 
 add_library(${rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME} ${SOURCE_FILES})

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -100,7 +100,6 @@ catkin_add_gtest(property_with_ros_spinner_test
   property_test.cpp
   ros_spinner.cpp
   mock_property_change_receiver.cpp
-  ${PROPERTY_TEST_MOC_FILES}
   ${MOC_MOCK_PROPERTY_CHANGE_RECEIVER}
 )
 target_link_libraries(property_with_ros_spinner_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
@@ -112,7 +111,7 @@ target_link_libraries(line_edit_with_button_test rviz ${catkin_LIBRARIES} ${QT_L
 add_dependencies(tests line_edit_with_button_test)
 
 # This is an executable which tests the connect/disconnect behavior of signals and slots in Qt.
-add_executable(connect_test connect_test.cpp ${MOC_FILES})
+add_executable(connect_test connect_test.cpp)
 target_link_libraries(connect_test ${QT_LIBRARIES})
 add_dependencies(tests connect_test)
 
@@ -124,7 +123,6 @@ target_link_libraries(config_test ${QT_LIBRARIES})
 add_executable(render_points_test
   render_points_test.cpp
   ../rviz/ogre_helpers/orbit_camera.cpp
-  ${RENDER_POINTS_TEST_MOC_FILES}
 )
 target_link_libraries(render_points_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
 add_dependencies(tests render_points_test)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -23,9 +23,6 @@ catkin_add_gtest(property_test
   ${MOC_MOCK_PROPERTY_CHANGE_RECEIVER}
 )
 target_link_libraries(property_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(property_test Qt5::Widgets)
-endif()
 
 # TODO(wjwwood): Fix this test, it used to use a set of Mock classes, but
 #                has since undergone a lot of changes and it no longer works.
@@ -86,25 +83,16 @@ add_dependencies(tests send_grid_cells)
 # This is a test program that uses the rviz panel interface.
 add_executable(render_panel_test render_panel_test.cpp)
 target_link_libraries(render_panel_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(render_panel_test Qt5::Widgets)
-endif()
 add_dependencies(tests render_panel_test)
 
 # This is an executable which uses the rviz new display diaglog interface.
 add_executable(new_display_dialog_test new_display_dialog_test.cpp)
 target_link_libraries(new_display_dialog_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(new_display_dialog_test Qt5::Widgets)
-endif()
 add_dependencies(tests new_display_dialog_test)
 
 # This is an executable which uses the rviz color editor test.
 add_executable(color_editor_test color_editor_test.cpp)
 target_link_libraries(color_editor_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(color_editor_test Qt5::Widgets)
-endif()
 add_dependencies(tests color_editor_test)
 
 # This is a modified version of the property test.
@@ -116,32 +104,20 @@ catkin_add_gtest(property_with_ros_spinner_test
   ${MOC_MOCK_PROPERTY_CHANGE_RECEIVER}
 )
 target_link_libraries(property_with_ros_spinner_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(property_with_ros_spinner_test Qt5::Widgets)
-endif()
 add_dependencies(tests property_with_ros_spinner_test)
 
 # This is an executable that uses the line_edit_with_button property interface.
 add_executable(line_edit_with_button_test line_edit_with_button_test.cpp)
 target_link_libraries(line_edit_with_button_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(line_edit_with_button_test Qt5::Widgets)
-endif()
 add_dependencies(tests line_edit_with_button_test)
 
 # This is an executable which tests the connect/disconnect behavior of signals and slots in Qt.
 add_executable(connect_test connect_test.cpp ${MOC_FILES})
 target_link_libraries(connect_test ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(connect_test Qt5::Widgets)
-endif()
 add_dependencies(tests connect_test)
 
 # This is a GTest which tests the display configuration.
 catkin_add_gtest(config_test config_test.cpp ../rviz/uniform_string_stream.cpp ../rviz/config.cpp)
-if (UseQt5)
-  target_link_libraries(config_test Qt5::Widgets)
-endif()
 target_link_libraries(config_test ${QT_LIBRARIES})
 
 # This is an acceptance test executable which renders points.
@@ -151,17 +127,11 @@ add_executable(render_points_test
   ${RENDER_POINTS_TEST_MOC_FILES}
 )
 target_link_libraries(render_points_test rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(render_points_test Qt5::Widgets)
-endif()
 add_dependencies(tests render_points_test)
 
 # This is an example application which creates two ogre render windows.
 add_executable(two_render_widgets two_render_widgets.cpp)
 target_link_libraries(two_render_widgets rviz ${catkin_LIBRARIES} ${QT_LIBRARIES})
-if (UseQt5)
-  target_link_libraries(two_render_widgets Qt5::Widgets)
-endif()
 add_dependencies(tests two_render_widgets)
 
 # This is a GTest which tests the STL loader


### PR DESCRIPTION
Unify QT usage in cmake files for both Qt4 and Qt5 version by setting _common_ variables once.