### PR TITLE
change rviz to no longer use opencv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,6 @@ find_package(catkin REQUIRED
   angles
   cmake_modules
   geometry_msgs
-  image_geometry
   image_transport
   interactive_markers
   laser_geometry

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,6 @@ catkin_package(
     ${OPENGL_LIBRARIES}
   CATKIN_DEPENDS
     geometry_msgs
-    image_geometry
     image_transport
     interactive_markers
     laser_geometry

--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,6 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>image_geometry</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>interactive_markers</build_depend>
   <build_depend>laser_geometry</build_depend>
@@ -53,7 +52,6 @@
   <run_depend>assimp</run_depend>
   <run_depend>eigen</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>image_geometry</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>interactive_markers</run_depend>
   <run_depend>laser_geometry</run_depend>

--- a/src/rviz/default_plugin/depth_cloud_mld.cpp
+++ b/src/rviz/default_plugin/depth_cloud_mld.cpp
@@ -31,7 +31,7 @@
  *      Author: jkammerl
  */
 
-#include <image_geometry/pinhole_camera_model.h>
+#include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/image_encodings.h>
 
 #include <string.h>


### PR DESCRIPTION
This would avoid issues with linking against OpenCV on Jessie which uses Qt4. It looks like the process may have already been done, but the dependencies were never removed?:

From https://github.com/ros-visualization/rviz/blob/kinetic-devel/src/rviz/default_plugin/depth_cloud_mld.cpp#L137-L139:

>     // The following computation of center_x,y and fx,fy duplicates
    // code in the image_geometry package, but this avoids dependency
    // on OpenCV, which simplifies releasing rviz.