### PR TITLE
Fix compile error due to the user-defined string literals feature

### DIFF
--- a/src/rviz/default_plugin/effort_display.h
+++ b/src/rviz/default_plugin/effort_display.h
@@ -36,13 +36,13 @@ namespace tf
 # undef TF_MESSAGEFILTER_DEBUG
 #endif
 #define TF_MESSAGEFILTER_DEBUG(fmt, ...) \
-  ROS_DEBUG_NAMED("message_filter", "MessageFilter [target=%s]: "fmt, getTargetFramesString().c_str(), __VA_ARGS__)
+  ROS_DEBUG_NAMED("message_filter", "MessageFilter [target=%s]: " fmt, getTargetFramesString().c_str(), __VA_ARGS__)
 
 #ifdef TF_MESSAGEFILTER_WARN
 # undef TF_MESSAGEFILTER_WARN
 #endif
 #define TF_MESSAGEFILTER_WARN(fmt, ...) \
-  ROS_WARN_NAMED("message_filter", "MessageFilter [target=%s]: "fmt, getTargetFramesString().c_str(), __VA_ARGS__)
+  ROS_WARN_NAMED("message_filter", "MessageFilter [target=%s]: " fmt, getTargetFramesString().c_str(), __VA_ARGS__)
 
     class MessageFilterJointState : public MessageFilter<sensor_msgs::JointState>
     {
@@ -127,8 +127,8 @@ public:
 		clear();
 
 		TF_MESSAGEFILTER_DEBUG("Successful Transforms: %llu, Failed Transforms: %llu, Discarded due to age: %llu, Transform messages received: %llu, Messages received: %llu, Total dropped: %llu",
-				       (long long unsigned int)successful_transform_count_, (long long unsigned int)failed_transform_count_, 
-				       (long long unsigned int)failed_out_the_back_count_, (long long unsigned int)transform_message_count_, 
+				       (long long unsigned int)successful_transform_count_, (long long unsigned int)failed_transform_count_,
+				       (long long unsigned int)failed_out_the_back_count_, (long long unsigned int)transform_message_count_,
 				       (long long unsigned int)incoming_message_count_, (long long unsigned int)dropped_message_count_);
 
 	    }


### PR DESCRIPTION
While compiling rviz from source on Arch with gcc 6.1.1, got errors like the following:
```cpp
In file included from /opt/ros/kinetic/include/tf/transform_datatypes.h:44:0,
                 from /opt/ros/kinetic/include/tf/time_cache.h:38,
                 from /opt/ros/kinetic/include/tf/tf.h:43,
                 from /opt/ros/kinetic/include/tf/transform_listener.h:38,
                 from [..]/src/rviz/src/rviz/default_plugin/effort_display.cpp:4:
[..]/src/rviz/src/rviz/default_plugin/effort_display.h: In destructor ‘virtual tf::MessageFilterJointState::~MessageFilterJointState()’:
[..]/src/rviz/src/rviz/default_plugin/effort_display.h:39:37: error: unable to find string literal operator ‘operator""fmt’ with ‘const char [28]’, ‘long unsigned int’ arguments
   ROS_DEBUG_NAMED("message_filter", "MessageFilter [target=%s]: "fmt, getTargetFramesString().c_str(), __VA_ARGS__)
                                     ^
```
With the new C++11 user-defined string literals feature, there has to be a space between string concatenations like the ones used here. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51282.