### PR TITLE
always (re)create default_plugin_location.cmake

### DIFF
--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -74,16 +74,12 @@ install(TARGETS default_plugin
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 # Generate to the devel space so the extras file can include it from the devel space.
-add_custom_command(
-  OUTPUT ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/default_plugin_location.cmake
+add_custom_target(create_default_plugin_location_file ALL
   COMMAND
     ${CMAKE_COMMAND}
     -DPATH_TO_FILE="${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/default_plugin_location.cmake"
     -DDEFAULT_PLUGIN_FILE_NAME=$<TARGET_FILE_NAME:default_plugin>
     -P ${CMAKE_CURRENT_SOURCE_DIR}/file_generate_helper.cmake
-)
-add_custom_target(create_default_plugin_location_file ALL
-  DEPENDS ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/default_plugin_location.cmake
 )
 # TODO(wjwwood): remove the solution above (including the file_generate_helper.cmake file) when we can
 # depend on cmake >= 2.8.12 (after dropping Saucy) and use the snippet below.


### PR DESCRIPTION
I had some issues switching between `kinetic` and `indigo` branch in my workspace: Both use different names of the `default_plugin` lib, written by the custom target `create_default_plugin_location_file`.
However, cmake's `add_custom_command` only evokes the file-writing command if the output file to be created is not yet there (or older than dependencies). So, it's never rewritten as there is no dependency.
Using `COMMAND` directly in `add_custom_target` solves that issue.
The same patch should be applied to `kinetic`.