### PR TITLE
Prevent format sring being interpreted as user-defined string literal.

### DIFF
--- a/src/rviz/default_plugin/effort_display.h
+++ b/src/rviz/default_plugin/effort_display.h
@@ -36,13 +36,13 @@ namespace tf
 # undef TF_MESSAGEFILTER_DEBUG
 #endif
 #define TF_MESSAGEFILTER_DEBUG(fmt, ...) \
-  ROS_DEBUG_NAMED("message_filter", "MessageFilter [target=%s]: "fmt, getTargetFramesString().c_str(), __VA_ARGS__)
+  ROS_DEBUG_NAMED("message_filter", "MessageFilter [target=%s]: " fmt, getTargetFramesString().c_str(), __VA_ARGS__)
 
 #ifdef TF_MESSAGEFILTER_WARN
 # undef TF_MESSAGEFILTER_WARN
 #endif
 #define TF_MESSAGEFILTER_WARN(fmt, ...) \
-  ROS_WARN_NAMED("message_filter", "MessageFilter [target=%s]: "fmt, getTargetFramesString().c_str(), __VA_ARGS__)
+  ROS_WARN_NAMED("message_filter", "MessageFilter [target=%s]: " fmt, getTargetFramesString().c_str(), __VA_ARGS__)
 
     class MessageFilterJointState : public MessageFilter<sensor_msgs::JointState>
     {


### PR DESCRIPTION
C++11 introduced user defined string literals, and one of the macros used by the `effort_display` plugin is now getting parsed as one. The fix is easy: separate the offending string literal and identifier with a space.

GCC 6 compiled with C++11 support on by default, which means that this is not just an improvement for the future but a requirement to compile from source on for example Arch Linux. This is also true when compiling the indigo version, so back-porting to indigo-devel would be prudent I think (I tried a simple cherry pick, it applies without problems).