### PR TITLE
Add fullscreen option.

### DIFF
--- a/src/rviz/panel_dock_widget.cpp
+++ b/src/rviz/panel_dock_widget.cpp
@@ -100,13 +100,13 @@ void PanelDockWidget::setCollapsed( bool collapse )
   {
     if ( isVisible() )
     {
-      QDockWidget::setVisible( false );
+      PanelDockWidget::setVisible( false );
       collapsed_ = collapse;
     }
   }
   else
   {
-    QDockWidget::setVisible( true );
+    PanelDockWidget::setVisible( true );
     collapsed_ = collapse;
   }
 }
@@ -142,6 +142,18 @@ void PanelDockWidget::save( Config config )
 void PanelDockWidget::load( Config config )
 {
   config.mapGetBool( "collapsed", &collapsed_ );
+}
+
+void PanelDockWidget::setVisible( bool visible )
+{
+  requested_visibility_ = visible;
+  QDockWidget::setVisible(requested_visibility_ && !forced_hidden_);
+}
+
+void PanelDockWidget::overrideVisibility( bool hidden )
+{
+  forced_hidden_ = hidden;
+  setVisible(requested_visibility_);
 }
 
 } // end namespace rviz

--- a/src/rviz/panel_dock_widget.h
+++ b/src/rviz/panel_dock_widget.h
@@ -58,6 +58,9 @@ public:
   virtual void save( Config config );
   virtual void load( Config config );
 
+  /** @brief Override setVisible to respect the visibility override, */
+  virtual void setVisible( bool visible );
+
 protected:
 
   virtual void closeEvent ( QCloseEvent * event );
@@ -65,6 +68,9 @@ protected:
 public Q_SLOTS:
 
   void setWindowTitle( QString title );
+
+  /** @ Override the visibility of the widget. **/
+  virtual void overrideVisibility( bool hide );
 
 private Q_SLOTS:
   void onChildDestroyed( QObject* );
@@ -76,6 +82,8 @@ Q_SIGNALS:
 private:
   // set to true if this panel was collapsed
   bool collapsed_;
+  bool requested_visibility_;
+  bool forced_hidden_;
   QLabel *icon_label_;
   QLabel *title_label_;
 };

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -168,6 +168,9 @@ Q_SIGNALS:
   /** @brief Emitted during file-loading and initialization to indicate progress. */
   void statusUpdate( const QString& message );
 
+  /** @brief Emitted when the interface enters or leaves full screen mode. */
+  void fullScreenChange( bool hidden );
+
 protected Q_SLOTS:
   void onOpen();
   void onSave();
@@ -218,6 +221,12 @@ protected Q_SLOTS:
    * The sender() of the signal should be a QAction whose text() is
    * the name of the panel. */
   void onDeletePanel();
+
+  /** @brief Set full screen mode. */
+  void setFullScreen( bool full_screen );
+
+  /** @brief Exit full screen mode. */
+  void exitFullScreen();
 
 protected Q_SLOTS:
   /** @brief Set loading_ to false. */
@@ -299,7 +308,6 @@ protected:
   QMenu* view_menu_;
   QMenu* delete_view_menu_;
   QMenu* plugins_menu_;
-  QList<QAction*> view_menu_actions_;
 
   QToolBar* toolbar_;
 
@@ -350,6 +358,9 @@ protected:
   ros::WallTime last_fps_calc_time_;
 
   QString error_message_; ///< Error message (if any) from most recent saveDisplayConfig() call.
+
+  /// Indicates if the toolbar should be visible outside of fullscreen mode.
+  bool toolbar_visible_;
 };
 
 }


### PR DESCRIPTION
This PR adds an option to enter fullscreen mode, hiding all interface elements and showing nothing but the rendered view. It makes rviz much nicer to use for showing information in demo setups.

I added the option under the `view_menu_` in code, but it turns out it's actually called "Panels" in the GUI. That might make it the wrong place for this option. Alternatively the menu could be renamed to view, or a new view menu could be added.

F11 also works, and is the only way other than restarting rviz to leave fullscreen mode. Might make sense to also use Escape for that?

One point of note: I'm using `setHideButtonVisibility(bool)` which is a public member of `VisualizationFrame`. I couldn't find anything actually calling the member, but if it is exposed to plugins they could potentially interact badly with the fullscreen option. It seems unlikely though, so maybe it's better to make that member private?
