### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/rviz/display.h
+++ b/src/rviz/display.h
@@ -113,7 +113,11 @@ public:
    *  @param topic The published topic to be visualized.
    *  @param datatype The datatype of the topic.
    */
-  virtual void setTopic( const QString &topic, const QString &datatype ) { }
+  virtual void setTopic( const QString &topic, const QString &datatype )
+  {
+    (void) topic;
+    (void) datatype;
+  }
 
   /** @brief Return true if this Display is enabled, false if not. */
   bool isEnabled() const;
@@ -124,7 +128,11 @@ public:
   /** @brief Called periodically by the visualization manager.
    * @param wall_dt Wall-clock time, in seconds, since the last time the update list was run through.
    * @param ros_dt ROS time, in seconds, since the last time the update list was run through. */
-  virtual void update( float wall_dt, float ros_dt ) {}
+  virtual void update( float wall_dt, float ros_dt )
+  {
+    (void) wall_dt;
+    (void) ros_dt;
+  }
 
   /** @brief Called to tell the display to clear its state */
   virtual void reset();

--- a/src/rviz/external/resource_retriever.h
+++ b/src/rviz/external/resource_retriever.h
@@ -1,0 +1,7 @@
+#ifndef RVIZ_EXTERNAL_RESOURCE_RETRIEVER_H
+#define RVIZ_EXTERNAL_RESOURCE_RETRIEVER_H
+
+#pragma GCC system_header
+#include <resource_retriever/retriever.h>
+
+#endif

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "mesh_loader.h"
-#include <resource_retriever/retriever.h>
+#include "external/resource_retriever.h"
 
 #include <boost/filesystem.hpp>
 

--- a/src/rviz/ogre_helpers/grid.cpp
+++ b/src/rviz/ogre_helpers/grid.cpp
@@ -240,7 +240,7 @@ void Grid::create()
 
 void Grid::setUserData( const Ogre::Any& data )
 {
-  manual_object_->setUserAny( data );
+  manual_object_->getUserObjectBindings().setUserAny( data );
 }
 
 } // namespace rviz

--- a/src/rviz/ogre_helpers/line.cpp
+++ b/src/rviz/ogre_helpers/line.cpp
@@ -145,7 +145,7 @@ const Ogre::Quaternion& Line::getOrientation()
 
 void Line::setUserData( const Ogre::Any& data )
 {
-  manual_object_->setUserAny( data );
+  manual_object_->getUserObjectBindings().setUserAny( data );
 }
 
 

--- a/src/rviz/ogre_helpers/shape.cpp
+++ b/src/rviz/ogre_helpers/shape.cpp
@@ -177,7 +177,7 @@ const Ogre::Quaternion& Shape::getOrientation()
 void Shape::setUserData( const Ogre::Any& data )
 {
   if (entity_)
-    entity_->setUserAny( data );
+    entity_->getUserObjectBindings().setUserAny( data );
   else
     ROS_ERROR("Shape not yet fully constructed. Cannot set user data. Did you add triangles to the mesh already?");
 }

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -273,8 +273,12 @@ public:
    * this function to do the painting and return true.
    *
    * If this function returns false, a QStyledItemDelegate will do the painting. */
-  virtual bool paint( QPainter* painter,
-                      const QStyleOptionViewItem& option ) const { return false; }
+  virtual bool paint( QPainter* painter, const QStyleOptionViewItem& option ) const
+  {
+    (void) painter;
+    (void) option;
+    return false;
+  }
 
 
   /** @brief Create an editor widget to edit the value of this property.

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -42,12 +42,11 @@
 
 #include <ros/console.h>
 
-#include <resource_retriever/retriever.h>
-
 #include <urdf_model/model.h>
 #include <urdf_model/link.h>
 
 #include "rviz/mesh_loader.h"
+#include "rviz/external/resource_retriever.h"
 #include "rviz/ogre_helpers/axes.h"
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/ogre_helpers/shape.h"

--- a/src/rviz/tool.h
+++ b/src/rviz/tool.h
@@ -81,7 +81,11 @@ public:
   virtual void activate() = 0;
   virtual void deactivate() = 0;
 
-  virtual void update(float wall_dt, float ros_dt) {}
+  virtual void update(float wall_dt, float ros_dt)
+  {
+    (void) wall_dt;
+    (void) ros_dt;
+  }
 
   enum {
     Render = 1,
@@ -90,12 +94,21 @@ public:
 
   /** Process a mouse event.  This is the central function of all the
    * tools, as it defines how the mouse is used. */
-  virtual int processMouseEvent( ViewportMouseEvent& event ) { return 0; }
+  virtual int processMouseEvent( ViewportMouseEvent& event )
+  {
+    (void) event;
+    return 0;
+  }
 
   /** Process a key event.  Override if your tool should handle any
       other keypresses than the tool shortcuts, which are handled
       separately. */
-  virtual int processKeyEvent( QKeyEvent* event, RenderPanel* panel ) { return 0; }
+  virtual int processKeyEvent( QKeyEvent* event, RenderPanel* panel )
+  {
+    (void) event;
+    (void) panel;
+    return 0;
+  }
 
   QString getName() const { return name_; }
 

--- a/src/rviz/view_controller.h
+++ b/src/rviz/view_controller.h
@@ -86,9 +86,16 @@ public:
 
   /** @brief Called at 30Hz by ViewManager::update() while this view
    * is active. Override with code that needs to run repeatedly. */
-  virtual void update(float dt, float ros_dt) {}
+  virtual void update(float dt, float ros_dt)
+  {
+    (void) dt;
+    (void) ros_dt;
+  }
 
-  virtual void handleMouseEvent(ViewportMouseEvent& evt) {}
+  virtual void handleMouseEvent(ViewportMouseEvent& evt)
+  {
+    (void) evt;
+  }
 
   /** @brief Called by MoveTool and InteractionTool when keyboard events are passed to them.
    *
@@ -102,7 +109,10 @@ public:
   /** @brief This should be implemented in each subclass to aim the
    * camera at the given point in space (relative to the fixed
    * frame). */
-  virtual void lookAt( const Ogre::Vector3& point ) {}
+  virtual void lookAt( const Ogre::Vector3& point )
+  {
+    (void) point;
+  }
 
   /** Reset the view controller to some sane initial state, like
    * looking at 0,0,0 from a few meters away. */
@@ -115,7 +125,10 @@ public:
    * @a source_view must return a valid @c Ogre::Camera* from getCamera().
    *
    * This base class implementation does nothing. */
-  virtual void mimic( ViewController* source_view ) {}
+  virtual void mimic( ViewController* source_view )
+  {
+    (void) source_view;
+  }
 
   /** @brief Called by ViewManager when this ViewController is being made current.
    * @param previous_view is the previous "current" view, and will not be NULL.
@@ -125,7 +138,10 @@ public:
    * viewpoint.
    *
    * This base class implementation does nothing. */
-  virtual void transitionFrom( ViewController* previous_view ) {}
+  virtual void transitionFrom( ViewController* previous_view )
+  {
+    (void) previous_view;
+  }
 
   /** @brief Subclasses should call this whenever a change is made which would change the results of toString(). */
   void emitConfigChanged();


### PR DESCRIPTION
This PR fixes compilation warnings (all of them with gcc 6.1.1 20160501).

I was a bit confused by the existence of `setUserData` but the absence of `getUserData`. It seems like a pointless member functions without a matching getter. I changed `setUserData` to not use the deprecated `Ogre::MoveableObject::SetUserAny`, and when I wanted to update the getter I noticed it wasn't there.