### PR TITLE
Tweak focal shape size marker depending on focal distance

### DIFF
--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.h
@@ -38,6 +38,7 @@
 
 namespace rviz
 {
+class BoolProperty;
 class FloatProperty;
 class Shape;
 class SceneNode;
@@ -101,12 +102,19 @@ protected:
    */
   void calculatePitchYawFromPosition( const Ogre::Vector3& position );
 
+  /**
+   * \brief Calculates the focal shape size and update it's geometry
+   */
+  void updateFocalShapeSize();
+
   virtual void updateCamera();
 
   FloatProperty* yaw_property_;                         ///< The camera's yaw (rotation around the y-axis), in radians
   FloatProperty* pitch_property_;                       ///< The camera's pitch (rotation around the x-axis), in radians
   FloatProperty* distance_property_;                    ///< The camera's distance from the focal point
   VectorProperty* focal_point_property_; ///< The point around which the camera "orbits".
+  BoolProperty* focal_shape_fixed_size_property_;       ///< Whether the focal shape size is fixed or not
+  FloatProperty* focal_shape_size_property_;            ///< The focal shape size
 
   Shape* focal_shape_;
   bool dragging_;


### PR DESCRIPTION
Fixes #1020 

This PR adds two options:
- Setting the focal shape size.
- A zoom invariant mode so that the focal shape size does not change when zooming in/out.

~~The only problem with this PR is the initial shape size; I found no way of knowing the focal distance before the user interacts (zooms in or out) so the shape size at the start is a little bit arbitrary.~~

Fixed size:
---
![old](https://cloud.githubusercontent.com/assets/100427/15951816/662ea440-2e70-11e6-98db-49d00413f19c.gif)

Zoom invariant:
---
![new](https://cloud.githubusercontent.com/assets/100427/15951787/3acf1d98-2e70-11e6-874b-99d75124f38d.gif)
