### PR TITLE
Support 3D arrows and axes for visualizing PoseArrays.

### DIFF
--- a/src/rviz/default_plugin/pose_array_display.cpp
+++ b/src/rviz/default_plugin/pose_array_display.cpp
@@ -33,20 +33,79 @@
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
+#include "rviz/properties/enum_property.h"
 #include "rviz/properties/color_property.h"
 #include "rviz/properties/float_property.h"
 #include "rviz/validate_floats.h"
+#include "rviz/ogre_helpers/arrow.h"
+#include "rviz/ogre_helpers/axes.h"
 
 #include "rviz/default_plugin/pose_array_display.h"
 
 namespace rviz
 {
 
+namespace
+{
+  struct ShapeType
+  {
+    enum
+    {
+      Arrow2d,
+      Arrow3d,
+      Axes,
+    };
+  };
+
+  Ogre::Vector3 vectorRosToOgre( geometry_msgs::Point const & point )
+  {
+    return Ogre::Vector3( point.x, point.y, point.z );
+  }
+
+  Ogre::Quaternion quaternionRosToOgre( geometry_msgs::Quaternion const & quaternion )
+  {
+    return Ogre::Quaternion( quaternion.w, quaternion.x, quaternion.y, quaternion.z );
+  }
+}
+
 PoseArrayDisplay::PoseArrayDisplay()
   : manual_object_( NULL )
 {
-  color_property_ = new ColorProperty( "Color", QColor( 255, 25, 0 ), "Color to draw the arrows.", this );
-  length_property_ = new FloatProperty( "Arrow Length", 0.3, "Length of the arrows.", this );
+  shape_property_ = new EnumProperty( "Shape", "Arrow (Flat)", "Shape to display the pose as.",
+                                       this, SLOT( updateShapeChoice() ) );
+
+  arrow_color_property_  = new ColorProperty(  "Color", QColor( 255, 25, 0 ), "Color to draw the arrows.",
+                                                this, SLOT( updateArrowColor() ) );
+
+  arrow_alpha_property_ = new FloatProperty( "Alpha", 1, "Amount of transparency to apply to the displayed poses.",
+                                             this, SLOT( updateArrowColor() ) );
+
+  arrow2d_length_property_ = new FloatProperty( "Arrow Length", 0.3, "Length of the arrows.",
+                                                 this, SLOT( updateArrow2dGeometry() ) );
+
+  arrow3d_head_radius_property_ = new FloatProperty( "Head Radius", 0.03, "Radius of the arrow's head, in meters.",
+                                                     this, SLOT( updateArrow3dGeometry() ) );
+
+  arrow3d_head_length_property_ = new FloatProperty( "Head Length", 0.07, "Length of the arrow's head, in meters.",
+                                                     this, SLOT( updateArrow3dGeometry() ) );
+
+  arrow3d_shaft_radius_property_ = new FloatProperty( "Shaft Radius", 0.01, "Radius of the arrow's shaft, in meters.",
+                                                      this, SLOT( updateArrow3dGeometry() ) );
+
+  arrow3d_shaft_length_property_ = new FloatProperty( "Shaft Length", 0.23, "Length of the arrow's shaft, in meters.",
+                                                      this, SLOT( updateArrow3dGeometry() ) );
+
+  axes_length_property_ = new FloatProperty( "Axes Length", 0.3, "Length of each axis, in meters.",
+                                             this, SLOT( updateAxesGeometry() ) );
+
+  axes_radius_property_ = new FloatProperty( "Axes Radius", 0.01, "Radius of each axis, in meters.",
+                                             this, SLOT( updateAxesGeometry() ) );
+
+  shape_property_->addOption( "Arrow (Flat)", ShapeType::Arrow2d );
+  shape_property_->addOption( "Arrow (3D)", ShapeType::Arrow3d );
+  shape_property_->addOption( "Axes", ShapeType::Axes );
+  arrow_alpha_property_->setMin( 0 );
+  arrow_alpha_property_->setMax( 1 );
 }
 
 PoseArrayDisplay::~PoseArrayDisplay()
@@ -63,6 +122,9 @@ void PoseArrayDisplay::onInitialize()
   manual_object_ = scene_manager_->createManualObject();
   manual_object_->setDynamic( true );
   scene_node_->attachObject( manual_object_ );
+  arrow_node_ = scene_node_->createChildSceneNode();
+  axes_node_ = scene_node_->createChildSceneNode();
+  updateShapeChoice();
 }
 
 bool validateFloats( const geometry_msgs::PoseArray& msg )
@@ -74,41 +136,58 @@ void PoseArrayDisplay::processMessage( const geometry_msgs::PoseArray::ConstPtr&
 {
   if( !validateFloats( *msg ))
   {
-    setStatus( StatusProperty::Error, "Topic", "Message contained invalid floating point values (nans or infs)" );
+    setStatus( StatusProperty::Error, "Topic",
+               "Message contained invalid floating point values (nans or infs)" );
     return;
   }
 
-  manual_object_->clear();
-
-  Ogre::Vector3 position;
-  Ogre::Quaternion orientation;
-  if( !context_->getFrameManager()->getTransform( msg->header, position, orientation ))
+  if( !setTransform( msg->header ) )
   {
-    ROS_DEBUG( "Error transforming from frame '%s' to frame '%s'", msg->header.frame_id.c_str(), qPrintable( fixed_frame_ ));
+    setStatus( StatusProperty::Error, "Topic", "Failed to look up transform" );
+    return;
   }
 
+  poses_.resize( msg->poses.size() );
+  for (std::size_t i = 0; i < msg->poses.size(); ++i)
+  {
+    poses_[i].position = vectorRosToOgre( msg->poses[i].position );
+    poses_[i].orientation = quaternionRosToOgre( msg->poses[i].orientation );
+  }
+
+  updateDisplay();
+  context_->queueRender();
+}
+
+bool PoseArrayDisplay::setTransform( std_msgs::Header const & header )
+{
+  Ogre::Vector3 position;
+  Ogre::Quaternion orientation;
+  if( !context_->getFrameManager()->getTransform( header, position, orientation ) )
+  {
+    ROS_ERROR( "Error transforming pose '%s' from frame '%s' to frame '%s'",
+               qPrintable( getName() ), header.frame_id.c_str(),
+               qPrintable( fixed_frame_ ) );
+    return false;
+  }
   scene_node_->setPosition( position );
   scene_node_->setOrientation( orientation );
+  return true;
+}
 
+void PoseArrayDisplay::updateArrows2d()
+{
   manual_object_->clear();
 
-  Ogre::ColourValue color = color_property_->getOgreColor();
-  float length = length_property_->getFloat();
-  size_t num_poses = msg->poses.size();
+  Ogre::ColourValue color = arrow_color_property_->getOgreColor();
+  color.a                 = arrow_alpha_property_->getFloat();
+  float length = arrow2d_length_property_->getFloat();
+  size_t num_poses = poses_.size();
   manual_object_->estimateVertexCount( num_poses * 6 );
   manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_LIST );
   for( size_t i=0; i < num_poses; ++i )
   {
-    Ogre::Vector3 pos( msg->poses[i].position.x,
-                       msg->poses[i].position.y,
-                       msg->poses[i].position.z );
-    Ogre::Quaternion orient( msg->poses[i].orientation.w,
-                             msg->poses[i].orientation.x,
-                             msg->poses[i].orientation.y,
-                             msg->poses[i].orientation.z );
-    // orient here is not normalized, so the scale of the quaternion
-    // will affect the scale of the arrow.
-
+    const Ogre::Vector3 & pos = poses_[i].position;
+    const Ogre::Quaternion & orient = poses_[i].orientation;
     Ogre::Vector3 vertices[6];
     vertices[0] = pos; // back of arrow
     vertices[1] = pos + orient * Ogre::Vector3( length, 0, 0 ); // tip of arrow
@@ -124,8 +203,84 @@ void PoseArrayDisplay::processMessage( const geometry_msgs::PoseArray::ConstPtr&
     }
   }
   manual_object_->end();
+}
 
-  context_->queueRender();
+void PoseArrayDisplay::updateDisplay()
+{
+  int shape = shape_property_->getOptionInt();
+  switch (shape) {
+  case ShapeType::Arrow2d:
+    updateArrows2d();
+    arrows3d_.clear();
+    axes_.clear();
+    break;
+  case ShapeType::Arrow3d:
+    updateArrows3d();
+    manual_object_->clear();
+    axes_.clear();
+    break;
+  case ShapeType::Axes:
+    updateAxes();
+    manual_object_->clear();
+    arrows3d_.clear();
+    break;
+  }
+}
+
+void PoseArrayDisplay::updateArrows3d()
+{
+  while (arrows3d_.size() < poses_.size())
+    arrows3d_.push_back(makeArrow3d());
+  while (arrows3d_.size() > poses_.size())
+    arrows3d_.pop_back();
+
+  Ogre::Quaternion adjust_orientation( Ogre::Degree(-90), Ogre::Vector3::UNIT_Y );
+  for (std::size_t i = 0; i < poses_.size(); ++i)
+  {
+    arrows3d_[i].setPosition( poses_[i].position );
+    arrows3d_[i].setOrientation( poses_[i].orientation * adjust_orientation );
+  }
+}
+
+void PoseArrayDisplay::updateAxes()
+{
+  while (axes_.size() < poses_.size())
+    axes_.push_back(makeAxes());
+  while (axes_.size() > poses_.size())
+    axes_.pop_back();
+  for (std::size_t i = 0; i < poses_.size(); ++i)
+  {
+    axes_[i].setPosition( poses_[i].position );
+    axes_[i].setOrientation( poses_[i].orientation );
+  }
+}
+
+Arrow * PoseArrayDisplay::makeArrow3d()
+{
+  Ogre::ColourValue color = arrow_color_property_->getOgreColor();
+  color.a                 = arrow_alpha_property_->getFloat();
+
+  Arrow * arrow = new Arrow(
+    scene_manager_,
+    arrow_node_,
+    arrow3d_shaft_length_property_->getFloat(),
+    arrow3d_shaft_radius_property_->getFloat(),
+    arrow3d_head_length_property_->getFloat(),
+    arrow3d_head_radius_property_->getFloat()
+  );
+
+  arrow->setColor(color);
+  return arrow;
+}
+
+Axes * PoseArrayDisplay::makeAxes()
+{
+  return new Axes(
+    scene_manager_,
+    axes_node_,
+    axes_length_property_->getFloat(),
+    axes_radius_property_->getFloat()
+  );
 }
 
 void PoseArrayDisplay::reset()
@@ -135,6 +290,85 @@ void PoseArrayDisplay::reset()
   {
     manual_object_->clear();
   }
+  arrows3d_.clear();
+  axes_.clear();
+}
+
+void PoseArrayDisplay::updateShapeChoice()
+{
+  int shape = shape_property_->getOptionInt();
+  bool use_arrow2d = shape == ShapeType::Arrow2d;
+  bool use_arrow3d = shape == ShapeType::Arrow3d;
+  bool use_arrow   = use_arrow2d || use_arrow3d;
+  bool use_axes    = shape == ShapeType::Axes;
+
+  arrow_color_property_->setHidden( !use_arrow );
+  arrow_alpha_property_->setHidden( !use_arrow );
+
+  arrow2d_length_property_->setHidden(!use_arrow2d);
+
+  arrow3d_shaft_length_property_->setHidden( !use_arrow3d );
+  arrow3d_shaft_radius_property_->setHidden( !use_arrow3d );
+  arrow3d_head_length_property_->setHidden( !use_arrow3d );
+  arrow3d_head_radius_property_->setHidden( !use_arrow3d );
+
+  axes_length_property_->setHidden( !use_axes );
+  axes_radius_property_->setHidden( !use_axes );
+
+  if (initialized())
+    updateDisplay();
+}
+
+void PoseArrayDisplay::updateArrowColor()
+{
+  int shape = shape_property_->getOptionInt();
+  Ogre::ColourValue color = arrow_color_property_->getOgreColor();
+  color.a                 = arrow_alpha_property_->getFloat();
+
+  if (shape == ShapeType::Arrow2d)
+  {
+    updateArrows2d();
+  }
+  else if (shape == ShapeType::Arrow3d)
+  {
+    for (std::size_t i = 0; i < arrows3d_.size(); ++i)
+    {
+      arrows3d_[i].setColor( color );
+    }
+  }
+  context_->queueRender();
+}
+
+void PoseArrayDisplay::updateArrow2dGeometry()
+{
+  updateArrows2d();
+  context_->queueRender();
+}
+
+void PoseArrayDisplay::updateArrow3dGeometry()
+{
+  for (std::size_t i = 0; i < poses_.size(); ++i)
+  {
+    arrows3d_[i].set(
+      arrow3d_shaft_length_property_->getFloat(),
+      arrow3d_shaft_radius_property_->getFloat(),
+      arrow3d_head_length_property_->getFloat(),
+      arrow3d_head_radius_property_->getFloat()
+    );
+  }
+  context_->queueRender();
+}
+
+void PoseArrayDisplay::updateAxesGeometry()
+{
+  for (std::size_t i = 0; i < poses_.size(); ++i)
+  {
+    axes_[i].set(
+      axes_length_property_->getFloat(),
+      axes_radius_property_->getFloat()
+    );
+  }
+  context_->queueRender();
 }
 
 } // namespace rviz

--- a/src/rviz/default_plugin/pose_array_display.h
+++ b/src/rviz/default_plugin/pose_array_display.h
@@ -34,6 +34,8 @@
 
 #include "rviz/message_filter_display.h"
 
+#include <boost/ptr_container/ptr_vector.hpp>
+
 namespace Ogre
 {
 class ManualObject;
@@ -41,8 +43,12 @@ class ManualObject;
 
 namespace rviz
 {
+
+class EnumProperty;
 class ColorProperty;
 class FloatProperty;
+class Arrow;
+class Axes;
 
 /** @brief Displays a geometry_msgs/PoseArray message as a bunch of line-drawn arrows. */
 class PoseArrayDisplay: public MessageFilterDisplay<geometry_msgs::PoseArray>
@@ -58,10 +64,56 @@ protected:
   virtual void processMessage( const geometry_msgs::PoseArray::ConstPtr& msg );
 
 private:
+  bool setTransform(std_msgs::Header const & header);
+  void updateArrows2d();
+  void updateArrows3d();
+  void updateAxes();
+  void updateDisplay();
+  Axes * makeAxes();
+  Arrow * makeArrow3d();
+
+  struct OgrePose {
+    Ogre::Vector3 position;
+    Ogre::Quaternion orientation;
+  };
+
+  std::vector<OgrePose> poses_;
+  boost::ptr_vector<Arrow> arrows3d_;
+  boost::ptr_vector<Axes> axes_;
+
+  Ogre::SceneNode * arrow_node_;
+  Ogre::SceneNode * axes_node_;
   Ogre::ManualObject* manual_object_;
 
-  ColorProperty* color_property_;
-  FloatProperty* length_property_;
+  EnumProperty* shape_property_;
+  ColorProperty* arrow_color_property_;
+  FloatProperty* arrow_alpha_property_;
+
+  FloatProperty* arrow2d_length_property_;
+
+  FloatProperty* arrow3d_head_radius_property_;
+  FloatProperty* arrow3d_head_length_property_;
+  FloatProperty* arrow3d_shaft_radius_property_;
+  FloatProperty* arrow3d_shaft_length_property_;
+
+  FloatProperty* axes_length_property_;
+  FloatProperty* axes_radius_property_;
+
+private Q_SLOTS:
+  /// Update the interface and visible shapes based on the selected shape type.
+  void updateShapeChoice();
+
+  /// Update the arrow color.
+  void updateArrowColor();
+
+  /// Update the flat arrow geometry.
+  void updateArrow2dGeometry();
+
+  /// Update the 3D arrow geometry.
+  void updateArrow3dGeometry();
+
+  /// Update the axes geometry.
+  void updateAxesGeometry();
 };
 
 } // namespace rviz


### PR DESCRIPTION
This PR adds support for visualizing poses as 3D axes and arrows to the `PoseArrayDisplay` plugin, same as the `PoseDisplay` plugin. The previous 2D arrows in a single `Ogre::ManualObject` are still supported. That option will probably be more performant with very large numbers of poses.

However, the 3D axes are the only option that visualize the full pose, so it is still useful to have those as an option. The 3D arrows are there for consistency with the `PoseDisplay` plugin.

Should fix #869