### PR TITLE
Add libX11 to librviz target_link_libraries

### DIFF
--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -4,6 +4,8 @@ if(NEW_YAMLCPP_FOUND)
   add_definitions(-DRVIZ_HAVE_YAMLCPP_05)
 endif(NEW_YAMLCPP_FOUND)
 
+find_package(X11 REQUIRED)
+
 add_subdirectory(default_plugin)
 
 include_directories(.)
@@ -131,6 +133,7 @@ target_link_libraries(${PROJECT_NAME}
   ${OGRE_OV_LIBRARIES_ABS}
   ${OPENGL_LIBRARIES}
   ${rviz_ADDITIONAL_LIBRARIES}
+  ${X11_X11_LIB}
   assimp
   yaml-cpp
 )

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -4,7 +4,9 @@ if(NEW_YAMLCPP_FOUND)
   add_definitions(-DRVIZ_HAVE_YAMLCPP_05)
 endif(NEW_YAMLCPP_FOUND)
 
-find_package(X11 REQUIRED)
+if(UNIX AND NOT APPLE)
+  find_package(X11 REQUIRED)
+endif()
 
 add_subdirectory(default_plugin)
 


### PR DESCRIPTION
With strict ld flags, I get the following errors:
```
render_system.cpp: undefined reference to `XOpenDisplay'
render_system.cpp: undefined reference to `XCreateSimpleWindow'
```
There is a dependency on libX11 in ogre_helpers/render_system.cpp.