### PR TITLE
Allow disabling RViz splash-screen

### DIFF
--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -274,7 +274,7 @@ bool VisualizerApp::init( int argc, char** argv )
       frame_->setHelpPath( QString::fromStdString( help_path ));
     }
     frame_->setShowChooseNewMaster( in_mc_wrapper );
-    if( splash_path != "" )
+    if( vm.count("splash-screen") )
     {
       frame_->setSplashPath( QString::fromStdString( splash_path ));
     }


### PR DESCRIPTION
I hate splash screens.

`setSplashPath` explains that the user can disable the splash screen by setting an empty path:
https://github.com/ros-visualization/rviz/blob/kinetic-devel/src/rviz/visualization_frame.h#L87-L91

But the user can't because if the splash screen path argument is empty, the function is not called:
https://github.com/ros-visualization/rviz/blob/kinetic-devel/src/rviz/visualizer_app.cpp#L277-L280

This PR fixes the behavior:
```
rosrun rviz rviz -s ""
```