### PR TITLE
robot: check for root_link_ before use

### DIFF
--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -682,7 +682,14 @@ void Robot::calculateJointCheckboxes()
 
   // check root link
   RobotLink *link = root_link_;
-  if (link && link->hasGeometry())
+
+  if(!link)
+  {
+    setEnableAllLinksCheckbox(QVariant());
+    return;
+  }
+
+  if (link->hasGeometry())
   {
     bool checked = link->getLinkProperty()->getValue().toBool();
     links_with_geom_checked += checked ? 1 : 0;


### PR DESCRIPTION
A couple of lines below the code accesses link->getChildJointNames() without
testing "link". The additional test guarantees the link is set before working
with it.

I noticed that when adding support to MoveIt to correctly initialize an empty
robot model after printing an error.