### PR TITLE
robot: check for root_link_ before use (kinetic port of #1039)

### DIFF
--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -682,7 +682,14 @@ void Robot::calculateJointCheckboxes()
 
   // check root link
   RobotLink *link = root_link_;
-  if (link && link->hasGeometry())
+
+  if(!link)
+  {
+    setEnableAllLinksCheckbox(QVariant());
+    return;
+  }
+
+  if (link->hasGeometry())
   {
     bool checked = link->getLinkProperty()->getValue().toBool();
     links_with_geom_checked += checked ? 1 : 0;


### PR DESCRIPTION
I noticed that @wjwwood added "needs forward port" to #1039.
If he'd just asked I would have provided the request directly...