### PR TITLE
bugfix in float_edit for non-english locales 

### DIFF
--- a/src/rviz/properties/float_edit.cpp
+++ b/src/rviz/properties/float_edit.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <QDoubleValidator>
+#include <QLocale>
 
 #include "rviz/properties/float_edit.h"
 
@@ -46,12 +47,13 @@ void FloatEdit::setValue( float new_value )
 {
   if( value_ != new_value )
   {
+    QLocale locale;
     value_ = new_value;
     bool ok = true;
-    float existing_text_value = text().toFloat( &ok );
+    float existing_text_value = locale.toDouble(text(), &ok );
     if( !ok || existing_text_value != new_value )
     {
-      setText( QString::number( (double) value_ ));
+      setText( locale.toString((double) value_ ));
     }
   }
 }
@@ -61,7 +63,7 @@ void FloatEdit::updateValue()
   if( hasAcceptableInput() )
   {
     bool ok = true;
-    float new_value = text().toFloat( &ok );
+    float new_value = QLocale().toDouble(text(), &ok );
     if( ok )
     {
       setValue( new_value );

--- a/src/rviz/properties/float_edit.cpp
+++ b/src/rviz/properties/float_edit.cpp
@@ -50,7 +50,7 @@ void FloatEdit::setValue( float new_value )
     QLocale locale;
     value_ = new_value;
     bool ok = true;
-    float existing_text_value = locale.toDouble(text(), &ok );
+    float existing_text_value = locale.toFloat(text(), &ok );
     if( !ok || existing_text_value != new_value )
     {
       setText( locale.toString((double) value_ ));
@@ -63,7 +63,7 @@ void FloatEdit::updateValue()
   if( hasAcceptableInput() )
   {
     bool ok = true;
-    float new_value = QLocale().toDouble(text(), &ok );
+    float new_value = QLocale().toFloat(text(), &ok );
     if( ok )
     {
       setValue( new_value );


### PR DESCRIPTION
Hi,

The float property line edit doesn't work on systems with a decimal comma separator locale. For example on Ubuntu 16.04, with ros kinetic and a french locale, it is impossible to enter a decimal value.
This pull requested fixes the problem.


Another possible fix would be to force the QDoubleValidator to use the "C" locale : 

> QDoubleValidator *validator = new QDoubleValidator(this);
> validator->setLocale(QLocale::c());
> setValidator(validator);
