### PR TITLE
Added close() signal to Tool class

### DIFF
--- a/src/rviz/tool.h
+++ b/src/rviz/tool.h
@@ -160,6 +160,9 @@ public:
   const QCursor& getCursor() { return cursor_; }
 
   void setStatus( const QString & message );
+  
+Q_SIGNALS:
+    void close();
 
 protected:
   /** Override onInitialize to do any setup needed after the

--- a/src/rviz/tool_manager.cpp
+++ b/src/rviz/tool_manager.cpp
@@ -220,6 +220,11 @@ void ToolManager::updatePropertyVisibility( Property* container )
   }
 }
 
+void rviz::ToolManager::closeTool()
+{
+  setCurrentTool( getDefaultTool() );
+}
+
 Tool* ToolManager::addTool( const QString& class_id )
 {
   QString error;
@@ -260,6 +265,9 @@ Tool* ToolManager::addTool( const QString& class_id )
     setDefaultTool( tool );
     setCurrentTool( tool );
   }
+  
+  QObject::connect(tool, SIGNAL(close()),
+                     this, SLOT(closeTool()));
 
   Q_EMIT configChanged();
 

--- a/src/rviz/tool_manager.h
+++ b/src/rviz/tool_manager.h
@@ -137,6 +137,9 @@ private Q_SLOTS:
   /** @brief If @a property has children, it is added to the tool
    * property tree, and if it does not, it is removed. */
   void updatePropertyVisibility( Property* property );
+  
+  /** @brief Deactivates the current tool and sets the default tool. */
+  void closeTool();
 
 private:
 


### PR DESCRIPTION
I added a QT signal to the base Tool class, which allows the tool to request deactivation programmatically. Upon creation of a Tool by the ToolManager, this signal is connected to a new closedTool() slot which deactivates the current tool and activates the default tool.

For example, I have a tool with an associated GUI window. When the user closes this window via the X button, the tool gets deactivated.