### PR TITLE
Fix double free in display dialog

### DIFF
--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -131,6 +131,7 @@ void DisplaysPanel::onNewDisplay()
   }
   vis_manager_->startUpdate();
   activateWindow(); // Force keyboard focus back on main window.
+  delete dialog;
 }
 
 void DisplaysPanel::onDuplicateDisplay()


### PR DESCRIPTION
This commit deletes the `AddDisplayDialog` object after use.

Copy operator of `QString` in `rviz::AddDisplayDialog::updateDisplay()` causes double free AFTER CLOSING THE DIALOG.
Since `AddDisplayDialog` object created in `DisplaysPanel::onNewDisplay` never deleted, local variable `topic_output` could be overwritten after leaving local scope.
This seems to have occurred especially in many-core (16-physical-core in my case) environments.