### PR TITLE
WIP: Improve performance by reducing materials update rate

### DIFF
--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -733,8 +733,6 @@ void Robot::update(const LinkUpdater& updater)
   {
     RobotLink* link = link_it->second;
 
-    link->setToNormalMaterial();
-
     Ogre::Vector3 visual_position, collision_position;
     Ogre::Quaternion visual_orientation, collision_orientation;
     if( updater.getLinkTransforms( link->getName(),
@@ -791,6 +789,8 @@ void Robot::update(const LinkUpdater& updater)
           joint->setTransforms(visual_position, visual_orientation);
         }
       }
+
+     link->setToNormalMaterial();
     }
     else
     {


### PR DESCRIPTION
Two cases:
- `updater.getLinkTransforms` fails, it is useless to update the materials because we are going to set all materials to the error material (https://github.com/ros-visualization/rviz/blob/de1e8341cd0517bc1b28ebe11d3972cccd349ec1/src/rviz/robot/robot.cpp#L797)
- `updater.getLinkTransforms` suceed, then we can update the materials.

Ideally in case of success we should update the materials of only the links with an error material because there is no way that I know to dynamically change the materials during RViz execution appart from the alpha settings in the display panel but this already updates all the materials.

This should improve performance a little bit (less material updates)
