### PR TITLE
visualize labeled points in point cloud with different colors

### DIFF
--- a/src/rviz/default_plugin/point_cloud_transformers.h
+++ b/src/rviz/default_plugin/point_cloud_transformers.h
@@ -134,6 +134,7 @@ private:
   ColorProperty* max_color_property_;
   BoolProperty* auto_compute_intensity_bounds_property_;
   BoolProperty* use_rainbow_property_;
+  BoolProperty* use_labeled_pc_property_;
   BoolProperty* invert_rainbow_property_;
   FloatProperty* min_intensity_property_;
   FloatProperty* max_intensity_property_;


### PR DESCRIPTION
Added a small piece of code to visualize points with different labels in the point cloud with different colors (10 for now, can be increased).

To use it, in the PointCloud2 plugin in RVIZ, set ColorTransformer to Intensity and then change Channel Name to label. Note this requires that label is added as an entry in the PointField[] in the sensor_msgs/PointCloud2 entry. All the points with the same label are assigned the same color. This is useful to visualize point clusters representing objects, ground plane with the same color.