### PR TITLE
Correctly scale the render panel on high resolution displays

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -342,7 +342,7 @@ int checkBadDrawable( Display* display, XErrorEvent* error )
 }
 #endif // Q_WS_X11
 
-Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned int width, unsigned int height )
+Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned int width, unsigned int height, double pixel_ratio )
 {
   static int windowCounter = 0; // Every RenderWindow needs a unique name, oy.
 
@@ -372,6 +372,7 @@ Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned
 #else
   params["macAPI"] = "carbon";
 #endif
+  params["contentScalingFactor"] = std::to_string(pixel_ratio);
 
   std::ostringstream stream;
   stream << "OgreWindow(" << windowCounter++ << ")";

--- a/src/rviz/ogre_helpers/render_system.h
+++ b/src/rviz/ogre_helpers/render_system.h
@@ -46,7 +46,7 @@ class RenderSystem
 public:
   static RenderSystem* get();
 
-  Ogre::RenderWindow* makeRenderWindow( intptr_t window_id, unsigned int width, unsigned int height );
+  Ogre::RenderWindow* makeRenderWindow( intptr_t window_id, unsigned int width, unsigned int height, double pixel_ratio = 1.0 );
 
   Ogre::Root* root() { return ogre_root_; }
 

--- a/src/rviz/ogre_helpers/render_widget.cpp
+++ b/src/rviz/ogre_helpers/render_widget.cpp
@@ -38,6 +38,9 @@
 #include <QPaintEvent>
 #include <QShowEvent>
 #include <QVBoxLayout>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QWindow>
+#endif
 
 namespace rviz
 {
@@ -83,8 +86,12 @@ RenderWidget::RenderWidget( RenderSystem* render_system, QWidget *parent )
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   QApplication::syncX();
+  double pixel_ratio = 1.0;
+#else
+  QWindow* window = windowHandle();
+  double pixel_ratio = window ? window->devicePixelRatio() : 1.0;
 #endif
-  render_window_ = render_system_->makeRenderWindow( win_id, width(), height() );
+  render_window_ = render_system_->makeRenderWindow( win_id, width(), height(), pixel_ratio );
 }
 
 RenderWidget::~RenderWidget()

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -33,6 +33,9 @@
 #include <QCursor>
 #include <QPixmap>
 #include <QTimer>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QWindow>
+#endif
 
 #include <boost/bind.hpp>
 
@@ -149,7 +152,7 @@ VisualizationManager::VisualizationManager( RenderPanel* render_panel, WindowMan
   display_property_tree_model_ = new PropertyTreeModel( root_display_group_ );
   display_property_tree_model_->setDragDropClass( "display" );
   connect( display_property_tree_model_, SIGNAL( configChanged() ), this, SIGNAL( configChanged() ));
-  
+
   tool_manager_ = new ToolManager( this );
   connect( tool_manager_, SIGNAL( configChanged() ), this, SIGNAL( configChanged() ));
   connect( tool_manager_, SIGNAL( toolChanged( Tool* ) ), this, SLOT( onToolChanged( Tool* ) ));
@@ -524,6 +527,17 @@ void VisualizationManager::handleMouseEvent( const ViewportMouseEvent& vme )
   if( current_tool )
   {
     ViewportMouseEvent _vme = vme;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    QWindow* window = vme.panel->windowHandle();
+    if (window)
+    {
+        double pixel_ratio = window->devicePixelRatio();
+        _vme.x = static_cast<int>(pixel_ratio * _vme.x);
+        _vme.y = static_cast<int>(pixel_ratio * _vme.y);
+        _vme.last_x = static_cast<int>(pixel_ratio * _vme.last_x);
+        _vme.last_y = static_cast<int>(pixel_ratio * _vme.last_y);
+    }
+#endif
     flags = current_tool->processMouseEvent( _vme );
     vme.panel->setCursor( current_tool->getCursor() );
   }


### PR DESCRIPTION
On Apple retina displays, the render widget only occupies a quarter of the available screen estate due to the higher DPI resolution. This PR fixes the problem for the render display and the mouse events.
