### PR TITLE
Visualization collada texture in marker fix

### DIFF
--- a/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
@@ -194,8 +194,6 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
 
    
 
-    // always update color on resource change
-    update_color = true;
 
     handler_.reset(new MarkerSelectionHandler(this, MarkerID(new_message->ns, new_message->id), context_));
     handler_->addTrackedObject(entity_);
@@ -204,11 +202,13 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
   {
     // underlying mesh resource has not changed but if the color has
     //  then we need to update the materials color
-    if (!old_message
+    if (new_message->mesh_use_embedded_materials == false
+       && (!old_message
+        || old_message->mesh_use_embedded_materials == true
         || old_message->color.r != new_message->color.r
         || old_message->color.g != new_message->color.g
         || old_message->color.b != new_message->color.b
-        || old_message->color.a != new_message->color.a)
+        || old_message->color.a != new_message->color.a))
     {
       update_color = true;
     }


### PR DESCRIPTION
Fixes COLLADA mesh material colors as described in issue https://github.com/ros-visualization/rviz/issues/751. From the issue thread, it looks like this case has already been fixed by @wjwwood ([752](https://github.com/ros-visualization/rviz/pull/752)), but unfortunately it got unfixed by another PR ([893](https://github.com/ros-visualization/rviz/pull/893)).

- Tested locally with Collada file generated by Blender. Without the fix, this image would be plain white.
![image](https://cloud.githubusercontent.com/assets/8476868/23603890/2cf8890a-0257-11e7-99ec-d8ec14b82a3c.png)
- Tested with example by @garaemon: https://github.com/garaemon/rviz_collada_marker
- The fix implemented here was originally proposed by @brindza
