### PR TITLE
Include missing headers for ogre 1.10.

### DIFF
--- a/src/rviz/ogre_helpers/mesh_shape.cpp
+++ b/src/rviz/ogre_helpers/mesh_shape.cpp
@@ -29,6 +29,7 @@
 
 #include "mesh_shape.h"
 
+#include <OgreMesh.h>
 #include <OgreMeshManager.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>

--- a/src/test/render_points_test.cpp
+++ b/src/test/render_points_test.cpp
@@ -34,6 +34,9 @@
 #include <QApplication>
 #include <QVBoxLayout>
 
+#include <OgreCamera.h>
+#include <OgreSceneNode.h>
+
 using namespace rviz;
 
 MyFrame::MyFrame( QWidget* parent )

--- a/src/test/two_render_widgets.cpp
+++ b/src/test/two_render_widgets.cpp
@@ -35,8 +35,11 @@
 #include <QVBoxLayout>
 #include <QPushButton>
 
-#include <OgreRenderWindow.h>
+#include <OgreCamera.h>
 #include <OgreEntity.h>
+#include <OgreRenderWindow.h>
+#include <OgreSceneNode.h>
+#include <OgreViewport.h>
 
 using namespace rviz;
 


### PR DESCRIPTION
This PR adds a few `include` statements that are required to build with Ogre 1.10. In Ogre 1.10 a few number of classes are now only forward declared by the headers RViz used. I tried to find something in the Ogre changelog about it, but I couldn't. They are not new headers in 1.10 though, so there should be no backwards incompatibilities.

There is also a large number of deprecation warnings now. I may have a go at those later, but these changes are really required to build with Ogre 1.10.