### PR TITLE
ogre 1.10: prevent loading resource under same name twice

### DIFF
--- a/ogre_media/materials/glsl120/nogp/nogp.program
+++ b/ogre_media/materials/glsl120/nogp/nogp.program
@@ -4,7 +4,7 @@
 // and each one is offset according to its texture coords.
 
 //includes:
-vertex_program rviz/glsl120/include/pass_depth.vert glsl { source ../include/pass_depth.vert }
+vertex_program rviz/glsl120/include/nogp_pass_depth.vert glsl { source ../include/pass_depth.vert }
 
 vertex_program rviz/glsl120/nogp/billboard_tile.vert glsl
 {
@@ -21,7 +21,7 @@ vertex_program rviz/glsl120/nogp/billboard_tile.vert(with_depth) glsl
 {
   source billboard_tile.vert
   preprocessor_defines WITH_DEPTH=1
-  attach rviz/glsl120/include/pass_depth.vert
+  attach rviz/glsl120/include/nogp_pass_depth.vert
   default_params
   {
     param_named_auto worldviewproj_matrix worldviewproj_matrix
@@ -47,7 +47,7 @@ vertex_program rviz/glsl120/nogp/billboard.vert(with_depth) glsl
 {
   source billboard.vert
   preprocessor_defines WITH_DEPTH=1
-  attach rviz/glsl120/include/pass_depth.vert
+  attach rviz/glsl120/include/nogp_pass_depth.vert
   default_params {
     param_named_auto worldviewproj_matrix worldviewproj_matrix
     param_named_auto worldview_matrix     worldview_matrix
@@ -71,7 +71,7 @@ vertex_program rviz/glsl120/nogp/box.vert(with_depth) glsl
 {
   source box.vert
   preprocessor_defines WITH_DEPTH=1
-  attach rviz/glsl120/include/pass_depth.vert
+  attach rviz/glsl120/include/nogp_pass_depth.vert
   default_params {
     param_named_auto worldviewproj_matrix worldviewproj_matrix
     param_named_auto worldview_matrix     worldview_matrix


### PR DESCRIPTION
In Ogre 1.10 it is now an error to load a resource under the same name twice, even when it is the same resource.

This seems a bit odd when resources are automatically loaded from shader programs, considering they are supposed to be able to re-use functions from other files. That's exactly what was happening with some shaders included with rviz, as also described in #1049.

This PR applies the fix described there by @phil0stine.