### PR TITLE
Use unique material names for robot links.

### DIFF
--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -208,7 +208,7 @@ RobotLink::RobotLink( Robot* robot,
   // create material for coloring links
   std::stringstream ss;
   static int count = 1;
-  ss << "robot link color material " << count;
+  ss << "robot link color material " << count++;
   color_material_ = Ogre::MaterialManager::getSingleton().create( ss.str(), ROS_PACKAGE_NAME );
   color_material_->setReceiveShadows(false);
   color_material_->getTechnique(0)->setLightingEnabled(true);
@@ -450,7 +450,7 @@ Ogre::MaterialPtr RobotLink::getMaterialForLink( const urdf::LinkConstSharedPtr&
 
   static int count = 0;
   std::stringstream ss;
-  ss << "Robot Link Material" << count;
+  ss << "Robot Link Material" << count++;
 
   Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(ss.str(), ROS_PACKAGE_NAME);
   mat->getTechnique(0)->setLightingEnabled(true);


### PR DESCRIPTION
Two places in `robot_link.cpp` forgot to increment the static counter for creating unique material names. Since Ogre 1.10 this is not just a possible visual glitch but also an error resulting in an `Ogre::ItemIdentityException`:

```
terminate called after throwing an instance of 'Ogre::ItemIdentityException'
  what():  ItemIdentityException: Resource with the name robot link color material 1 already exists. in ResourceManager::add at /build/ogre/src/ogre/OgreMain/src/OgreResourceManager.cpp (line 150)
```

This PR increments the counter, and RViz no longer crashes when attempting to visualize a robot.