### PR TITLE
Update variable name

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -367,8 +367,8 @@ Ogre::RenderWindow* RenderSystem::makeRenderWindow(
 
 // Set the macAPI for Ogre based on the Qt implementation
 #if defined(Q_OS_MAC)
-	parameters["macAPI"] = "cocoa";
-	parameters["macAPICocoaUseNSView"] = "true";
+	params["macAPI"] = "cocoa";
+	params["macAPICocoaUseNSView"] = "true";
 #endif
   params["contentScalingFactor"] = std::to_string(pixel_ratio);
 


### PR DESCRIPTION
Somehow, variable names got out of sync. Lines 370 and 371 refer to "parameters" but it is "params" everywhere else.

Thanks for the Retina fixes! Just tested on Sierra and they work great.