### PR TITLE
indigo-devel backports from kinetic-devel (1.12.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(Boost REQUIRED
   thread
 )
 
+find_package(urdfdom_headers REQUIRED)
+
 find_package(PkgConfig REQUIRED)
 
 find_package(ASSIMP QUIET)
@@ -129,6 +131,7 @@ find_package(catkin REQUIRED
   tf
   urdf
   visualization_msgs
+  urdfdom_headers
 )
 
 if(${tf_VERSION} VERSION_LESS "1.11.3")
@@ -210,6 +213,7 @@ include_directories(SYSTEM
   ${OGRE_OV_INCLUDE_DIRS}
   ${OPENGL_INCLUDE_DIR}
   ${PYTHON_INCLUDE_PATH}
+  ${urdfdom_headers_INCLUDE_DIRS}
 )
 include_directories(src ${catkin_INCLUDE_DIRS})
 

--- a/package.xml
+++ b/package.xml
@@ -49,6 +49,7 @@
   <build_depend>visualization_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
   <build_depend>opengl</build_depend>
+  <build_depend>liburdfdom-headers-dev</build_depend>
 
   <run_depend>assimp</run_depend>
   <run_depend>eigen</run_depend>
@@ -81,6 +82,7 @@
   <run_depend>visualization_msgs</run_depend>
   <run_depend>yaml-cpp</run_depend>
   <run_depend>opengl</run_depend>
+  <run_depend>liburdfdom-headers-dev</run_depend>
 
   <export>
     <rviz plugin="${prefix}/plugin_description.xml"/>

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -208,11 +208,11 @@ namespace rviz
 	    return;
 	}
         setStatus(rviz::StatusProperty::Ok, "URDF", "Robot model parserd Ok");
-	for (std::map<std::string, boost::shared_ptr<urdf::Joint> >::iterator it = robot_model_->joints_.begin(); it != robot_model_->joints_.end(); it ++ ) {
-            boost::shared_ptr<urdf::Joint> joint = it->second;
+    for (std::map<std::string, urdf::JointSharedPtr >::iterator it = robot_model_->joints_.begin(); it != robot_model_->joints_.end(); it ++ ) {
+        urdf::JointSharedPtr joint = it->second;
 	    if ( joint->type == urdf::Joint::REVOLUTE ) {
                 std::string joint_name = it->first;
-		boost::shared_ptr<urdf::JointLimits> limit = joint->limits;
+                urdf::JointLimitsSharedPtr limit = joint->limits;
                 joints_[joint_name] = createJoint(joint_name);
                 //joints_[joint_name]->max_effort_property_->setFloat(limit->effort);
                 //joints_[joint_name]->max_effort_property_->setReadOnly( true );

--- a/src/rviz/default_plugin/effort_visual.cpp
+++ b/src/rviz/default_plugin/effort_visual.cpp
@@ -31,7 +31,7 @@ namespace rviz
 
 	// We create the arrow object within the frame node so that we can
 	// set its position and direction relative to its header frame.
-	for (std::map<std::string, boost::shared_ptr<urdf::Joint> >::iterator it = urdf_model_->joints_.begin(); it != urdf_model_->joints_.end(); it ++ ) {
+	for (std::map<std::string, urdf::JointSharedPtr >::iterator it = urdf_model_->joints_.begin(); it != urdf_model_->joints_.end(); it ++ ) {
 	    if ( it->second->type == urdf::Joint::REVOLUTE ) {
                 std::string joint_name = it->first;
                 effort_enabled_[joint_name] = true;
@@ -103,7 +103,7 @@ namespace rviz
                 if ( ! effort_enabled_[joint_name] ) continue;
 
 		//tf::Transform offset = poseFromJoint(joint);
-		boost::shared_ptr<urdf::JointLimits> limit = joint->limits;
+		urdf::JointLimitsSharedPtr limit = joint->limits;
 		double max_effort = limit->effort, effort_value = 0.05;
 
 		if ( max_effort != 0.0 )

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -96,7 +96,7 @@ PathDisplay::PathDisplay()
                                                         "Radius of the axes.",
                                                         this, SLOT(updatePoseAxisGeometry()) );
 
-  pose_arrow_color_property_ = new ColorProperty( "Color",
+  pose_arrow_color_property_ = new ColorProperty( "Pose Color",
                                                   QColor( 255, 85, 255 ),
                                                   "Color to draw the poses.",
                                                   this, SLOT(updatePoseArrowColor()));

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sstream>
+
 #include <QMetaType>
 
 // This is required for QT_MAC_USE_COCOA to be set
@@ -372,7 +374,11 @@ Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned
 #else
   params["macAPI"] = "carbon";
 #endif
-  params["contentScalingFactor"] = std::to_string(pixel_ratio);
+  {
+    std::stringstream ss;
+    ss << pixel_ratio;
+    params["contentScalingFactor"] = ss.str();
+  }
 
   std::ostringstream stream;
   stream << "OgreWindow(" << windowCounter++ << ")";

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -342,7 +342,7 @@ int checkBadDrawable( Display* display, XErrorEvent* error )
 }
 #endif // Q_WS_X11
 
-Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned int width, unsigned int height )
+Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned int width, unsigned int height, double pixel_ratio )
 {
   static int windowCounter = 0; // Every RenderWindow needs a unique name, oy.
 
@@ -372,6 +372,7 @@ Ogre::RenderWindow* RenderSystem::makeRenderWindow( intptr_t window_id, unsigned
 #else
   params["macAPI"] = "carbon";
 #endif
+  params["contentScalingFactor"] = std::to_string(pixel_ratio);
 
   std::ostringstream stream;
   stream << "OgreWindow(" << windowCounter++ << ")";

--- a/src/rviz/ogre_helpers/render_system.h
+++ b/src/rviz/ogre_helpers/render_system.h
@@ -46,7 +46,7 @@ class RenderSystem
 public:
   static RenderSystem* get();
 
-  Ogre::RenderWindow* makeRenderWindow( intptr_t window_id, unsigned int width, unsigned int height );
+  Ogre::RenderWindow* makeRenderWindow( intptr_t window_id, unsigned int width, unsigned int height, double pixel_ratio = 1.0 );
 
   Ogre::Root* root() { return ogre_root_; }
 

--- a/src/rviz/ogre_helpers/render_widget.cpp
+++ b/src/rviz/ogre_helpers/render_widget.cpp
@@ -38,6 +38,9 @@
 #include <QPaintEvent>
 #include <QShowEvent>
 #include <QVBoxLayout>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QWindow>
+#endif
 
 namespace rviz
 {
@@ -83,8 +86,12 @@ RenderWidget::RenderWidget( RenderSystem* render_system, QWidget *parent )
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   QApplication::syncX();
+  double pixel_ratio = 1.0;
+#else
+  QWindow* window = windowHandle();
+  double pixel_ratio = window ? window->devicePixelRatio() : 1.0;
 #endif
-  render_window_ = render_system_->makeRenderWindow( win_id, width(), height() );
+  render_window_ = render_system_->makeRenderWindow( win_id, width(), height(), pixel_ratio );
 }
 
 RenderWidget::~RenderWidget()

--- a/src/rviz/panel_dock_widget.cpp
+++ b/src/rviz/panel_dock_widget.cpp
@@ -100,13 +100,13 @@ void PanelDockWidget::setCollapsed( bool collapse )
   {
     if ( isVisible() )
     {
-      QDockWidget::setVisible( false );
+      PanelDockWidget::setVisible( false );
       collapsed_ = collapse;
     }
   }
   else
   {
-    QDockWidget::setVisible( true );
+    PanelDockWidget::setVisible( true );
     collapsed_ = collapse;
   }
 }
@@ -142,6 +142,18 @@ void PanelDockWidget::save( Config config )
 void PanelDockWidget::load( Config config )
 {
   config.mapGetBool( "collapsed", &collapsed_ );
+}
+
+void PanelDockWidget::setVisible( bool visible )
+{
+  requested_visibility_ = visible;
+  QDockWidget::setVisible(requested_visibility_ && !forced_hidden_);
+}
+
+void PanelDockWidget::overrideVisibility( bool hidden )
+{
+  forced_hidden_ = hidden;
+  setVisible(requested_visibility_);
 }
 
 } // end namespace rviz

--- a/src/rviz/panel_dock_widget.h
+++ b/src/rviz/panel_dock_widget.h
@@ -58,6 +58,9 @@ public:
   virtual void save( Config config );
   virtual void load( Config config );
 
+  /** @brief Override setVisible to respect the visibility override, */
+  virtual void setVisible( bool visible );
+
 protected:
 
   virtual void closeEvent ( QCloseEvent * event );
@@ -65,6 +68,9 @@ protected:
 public Q_SLOTS:
 
   void setWindowTitle( QString title );
+
+  /** @ Override the visibility of the widget. **/
+  virtual void overrideVisibility( bool hide );
 
 private Q_SLOTS:
   void onChildDestroyed( QObject* );
@@ -76,6 +82,8 @@ Q_SIGNALS:
 private:
   // set to true if this panel was collapsed
   bool collapsed_;
+  bool requested_visibility_;
+  bool forced_hidden_;
   QLabel *icon_label_;
   QLabel *title_label_;
 };

--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -236,7 +236,7 @@ void Robot::clear()
 
 RobotLink* Robot::LinkFactory::createLink(
     Robot* robot,
-    const boost::shared_ptr<const urdf::Link>& link,
+    const urdf::LinkConstSharedPtr& link,
     const std::string& parent_joint_name,
     bool visual,
     bool collision)
@@ -246,7 +246,7 @@ RobotLink* Robot::LinkFactory::createLink(
 
 RobotJoint* Robot::LinkFactory::createJoint(
     Robot* robot,
-    const boost::shared_ptr<const urdf::Joint>& joint)
+    const urdf::JointConstSharedPtr& joint)
 {
   return new RobotJoint(robot, joint);
 }
@@ -265,12 +265,12 @@ void Robot::load( const urdf::ModelInterface &urdf, bool visual, bool collision 
   // Create properties for each link.
   // Properties are not added to display until changedLinkTreeStyle() is called (below).
   {
-    typedef std::map<std::string, boost::shared_ptr<urdf::Link> > M_NameToUrdfLink;
+    typedef std::map<std::string, urdf::LinkSharedPtr > M_NameToUrdfLink;
     M_NameToUrdfLink::const_iterator link_it = urdf.links_.begin();
     M_NameToUrdfLink::const_iterator link_end = urdf.links_.end();
     for( ; link_it != link_end; ++link_it )
     {
-      const boost::shared_ptr<const urdf::Link>& urdf_link = link_it->second;
+      const urdf::LinkConstSharedPtr& urdf_link = link_it->second;
       std::string parent_joint_name;
 
       if (urdf_link != urdf.getRoot() && urdf_link->parent_joint)
@@ -298,12 +298,12 @@ void Robot::load( const urdf::ModelInterface &urdf, bool visual, bool collision 
   // Create properties for each joint.
   // Properties are not added to display until changedLinkTreeStyle() is called (below).
   {
-    typedef std::map<std::string, boost::shared_ptr<urdf::Joint> > M_NameToUrdfJoint;
+    typedef std::map<std::string, urdf::JointSharedPtr > M_NameToUrdfJoint;
     M_NameToUrdfJoint::const_iterator joint_it = urdf.joints_.begin();
     M_NameToUrdfJoint::const_iterator joint_end = urdf.joints_.end();
     for( ; joint_it != joint_end; ++joint_it )
     {
-      const boost::shared_ptr<const urdf::Joint>& urdf_joint = joint_it->second;
+      const urdf::JointConstSharedPtr& urdf_joint = joint_it->second;
       RobotJoint* joint = link_factory_->createJoint( this, urdf_joint );
 
       joints_[urdf_joint->name] = joint;

--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -39,6 +39,8 @@
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 
+#include <urdf/model.h> // can be replaced later by urdf_model/types.h
+
 namespace Ogre
 {
 class SceneManager;
@@ -60,13 +62,6 @@ class Axes;
 namespace tf
 {
 class TransformListener;
-}
-
-namespace urdf
-{
-class ModelInterface;
-class Link;
-class Joint;
 }
 
 namespace rviz
@@ -173,12 +168,12 @@ public:
   {
   public:
     virtual RobotLink* createLink( Robot* robot,
-                                   const boost::shared_ptr<const urdf::Link>& link,
+                                   const urdf::LinkConstSharedPtr& link,
                                    const std::string& parent_joint_name,
                                    bool visual,
                                    bool collision);
     virtual RobotJoint* createJoint( Robot* robot,
-                                     const boost::shared_ptr<const urdf::Joint>& joint);
+                                     const urdf::JointConstSharedPtr& joint);
   };
 
   /** Call this before load() to subclass the RobotLink or RobotJoint class used in the link property.

--- a/src/rviz/robot/robot_joint.cpp
+++ b/src/rviz/robot/robot_joint.cpp
@@ -38,15 +38,10 @@
 #include "rviz/ogre_helpers/axes.h"
 #include "rviz/load_resource.h"
 
-#include <urdf_model/model.h>
-#include <urdf_model/link.h>
-#include <urdf_model/joint.h>
-
-
 namespace rviz
 {
 
-RobotJoint::RobotJoint( Robot* robot, const boost::shared_ptr<const urdf::Joint>& joint )
+RobotJoint::RobotJoint( Robot* robot, const urdf::JointConstSharedPtr& joint )
   : robot_( robot )
   , name_( joint->name )
   , child_link_name_( joint->child_link_name )

--- a/src/rviz/robot/robot_joint.h
+++ b/src/rviz/robot/robot_joint.h
@@ -42,6 +42,9 @@
 #include <OgreMaterial.h>
 #endif
 
+#include <urdf/model.h>
+#include <urdf_model/pose.h>
+
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"
 
@@ -55,15 +58,6 @@ class Vector3;
 class Quaternion;
 class Any;
 class RibbonTrail;
-}
-
-namespace urdf
-{
-class ModelInterface;
-class Link;
-class Joint;
-class Geometry;
-class Pose;
 }
 
 namespace rviz
@@ -89,7 +83,7 @@ class RobotJoint: public QObject
 {
 Q_OBJECT
 public:
-  RobotJoint( Robot* robot, const boost::shared_ptr<const urdf::Joint>& joint );
+  RobotJoint( Robot* robot, const urdf::JointConstSharedPtr& joint );
   virtual ~RobotJoint();
 
 

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -457,7 +457,7 @@ Ogre::MaterialPtr RobotLink::getMaterialForLink( const urdf::LinkConstSharedPtr&
   mat->getTechnique(0)->setLightingEnabled(true);
 
   boost::shared_ptr<urdf::Visual> visual = link->visual;
-  std::vector<boost::shared_ptr<urdf::Visual> >::const_iterator vi;
+  std::vector<urdf::VisualSharedPtr>::const_iterator vi;
   for( vi = link->visual_array.begin(); vi != link->visual_array.end(); vi++ )
   {
     if( (*vi) && material_name != "" && (*vi)->material_name  == material_name) {

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -155,7 +155,7 @@ void RobotLinkSelectionHandler::postRenderPass(uint32_t pass)
 
 
 RobotLink::RobotLink( Robot* robot,
-                      const urdf::LinkConstPtr& link,
+                      const urdf::LinkConstSharedPtr& link,
                       const std::string& parent_joint_name,
                       bool visual,
                       bool collision)
@@ -262,8 +262,8 @@ RobotLink::RobotLink( Robot* robot,
       desc << " child joint: ";
     }
 
-    std::vector<boost::shared_ptr<urdf::Joint> >::const_iterator child_it = link->child_joints.begin();
-    std::vector<boost::shared_ptr<urdf::Joint> >::const_iterator child_end = link->child_joints.end();
+    std::vector<urdf::JointSharedPtr >::const_iterator child_it = link->child_joints.begin();
+    std::vector<urdf::JointSharedPtr >::const_iterator child_end = link->child_joints.end();
     for ( ; child_it != child_end ; ++child_it )
     {
       urdf::Joint *child_joint = child_it->get();
@@ -442,7 +442,7 @@ void RobotLink::updateVisibility()
   }
 }
 
-Ogre::MaterialPtr RobotLink::getMaterialForLink( const urdf::LinkConstPtr& link, const std::string material_name)
+Ogre::MaterialPtr RobotLink::getMaterialForLink( const urdf::LinkConstSharedPtr& link, const std::string material_name)
 {
   if (!link->visual || !link->visual->material)
   {
@@ -524,7 +524,7 @@ Ogre::MaterialPtr RobotLink::getMaterialForLink( const urdf::LinkConstPtr& link,
   return mat;
 }
 
-void RobotLink::createEntityForGeometryElement(const urdf::LinkConstPtr& link, const urdf::Geometry& geom, const urdf::Pose& origin, const std::string material_name, Ogre::SceneNode* scene_node, Ogre::Entity*& entity)
+void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& link, const urdf::Geometry& geom, const urdf::Pose& origin, const std::string material_name, Ogre::SceneNode* scene_node, Ogre::Entity*& entity)
 {
   entity = NULL; // default in case nothing works.
   Ogre::SceneNode* offset_node = scene_node->createChildSceneNode();
@@ -671,19 +671,19 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstPtr& link, c
   }
 }
 
-void RobotLink::createCollision(const urdf::LinkConstPtr& link)
+void RobotLink::createCollision(const urdf::LinkConstSharedPtr& link)
 {
   bool valid_collision_found = false;
 #if URDF_MAJOR_VERSION == 0 && URDF_MINOR_VERSION == 2
-  std::map<std::string, boost::shared_ptr<std::vector<boost::shared_ptr<urdf::Collision> > > >::const_iterator mi;
+  std::map<std::string, boost::shared_ptr<std::vector<urdf::CollisionSharedPtr > > >::const_iterator mi;
   for( mi = link->collision_groups.begin(); mi != link->collision_groups.end(); mi++ )
   {
     if( mi->second )
     {
-      std::vector<boost::shared_ptr<urdf::Collision> >::const_iterator vi;
+      std::vector<urdf::CollisionSharedPtr >::const_iterator vi;
       for( vi = mi->second->begin(); vi != mi->second->end(); vi++ )
       {
-        boost::shared_ptr<urdf::Collision> collision = *vi;
+        urdf::CollisionSharedPtr collision = *vi;
         if( collision && collision->geometry )
         {
           Ogre::Entity* collision_mesh = NULL;
@@ -698,10 +698,10 @@ void RobotLink::createCollision(const urdf::LinkConstPtr& link)
     }
   }
 #else
-  std::vector<boost::shared_ptr<urdf::Collision> >::const_iterator vi;
+  std::vector<urdf::CollisionSharedPtr >::const_iterator vi;
   for( vi = link->collision_array.begin(); vi != link->collision_array.end(); vi++ )
   {
-    boost::shared_ptr<urdf::Collision> collision = *vi;
+    urdf::CollisionSharedPtr collision = *vi;
     if( collision && collision->geometry )
     {
       Ogre::Entity* collision_mesh = NULL;
@@ -728,19 +728,19 @@ void RobotLink::createCollision(const urdf::LinkConstPtr& link)
   collision_node_->setVisible( getEnabled() );
 }
 
-void RobotLink::createVisual(const urdf::LinkConstPtr& link )
+void RobotLink::createVisual(const urdf::LinkConstSharedPtr& link )
 {
   bool valid_visual_found = false;
 #if URDF_MAJOR_VERSION == 0 && URDF_MINOR_VERSION == 2
-  std::map<std::string, boost::shared_ptr<std::vector<boost::shared_ptr<urdf::Visual> > > >::const_iterator mi;
+  std::map<std::string, boost::shared_ptr<std::vector<urdf::VisualSharedPtr > > >::const_iterator mi;
   for( mi = link->visual_groups.begin(); mi != link->visual_groups.end(); mi++ )
   {
     if( mi->second )
     {
-      std::vector<boost::shared_ptr<urdf::Visual> >::const_iterator vi;
+      std::vector<urdf::VisualSharedPtr >::const_iterator vi;
       for( vi = mi->second->begin(); vi != mi->second->end(); vi++ )
       {
-        boost::shared_ptr<urdf::Visual> visual = *vi;
+        urdf::VisualSharedPtr visual = *vi;
         if( visual && visual->geometry )
         {
           Ogre::Entity* visual_mesh = NULL;
@@ -755,10 +755,10 @@ void RobotLink::createVisual(const urdf::LinkConstPtr& link )
     }
   }
 #else
-  std::vector<boost::shared_ptr<urdf::Visual> >::const_iterator vi;
+  std::vector<urdf::VisualSharedPtr >::const_iterator vi;
   for( vi = link->visual_array.begin(); vi != link->visual_array.end(); vi++ )
   {
-    boost::shared_ptr<urdf::Visual> visual = *vi;
+    urdf::VisualSharedPtr visual = *vi;
     if( visual && visual->geometry )
     {
       Ogre::Entity* visual_mesh = NULL;

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -209,7 +209,7 @@ RobotLink::RobotLink( Robot* robot,
   // create material for coloring links
   std::stringstream ss;
   static int count = 1;
-  ss << "robot link color material " << count;
+  ss << "robot link color material " << count++;
   color_material_ = Ogre::MaterialManager::getSingleton().create( ss.str(), ROS_PACKAGE_NAME );
   color_material_->setReceiveShadows(false);
   color_material_->getTechnique(0)->setLightingEnabled(true);
@@ -451,7 +451,7 @@ Ogre::MaterialPtr RobotLink::getMaterialForLink( const urdf::LinkConstSharedPtr&
 
   static int count = 0;
   std::stringstream ss;
-  ss << "Robot Link Material" << count;
+  ss << "Robot Link Material" << count++;
 
   Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(ss.str(), ROS_PACKAGE_NAME);
   mat->getTechnique(0)->setLightingEnabled(true);

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -456,7 +456,7 @@ Ogre::MaterialPtr RobotLink::getMaterialForLink( const urdf::LinkConstSharedPtr&
   Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(ss.str(), ROS_PACKAGE_NAME);
   mat->getTechnique(0)->setLightingEnabled(true);
 
-  boost::shared_ptr<urdf::Visual> visual = link->visual;
+  urdf::VisualSharedPtr visual = link->visual;
   std::vector<urdf::VisualSharedPtr>::const_iterator vi;
   for( vi = link->visual_array.begin(); vi != link->visual_array.end(); vi++ )
   {

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -43,6 +43,9 @@
 #include <OgreSharedPtr.h>
 #endif
 
+#include <urdf/model.h> // can be replaced later by urdf_model/types.h
+#include <urdf_model/pose.h>
+
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"
 
@@ -56,16 +59,6 @@ class Vector3;
 class Quaternion;
 class Any;
 class RibbonTrail;
-}
-
-namespace urdf
-{
-class ModelInterface;
-class Link;
-typedef boost::shared_ptr<const Link> LinkConstPtr;
-class Geometry;
-typedef boost::shared_ptr<const Geometry> GeometryConstPtr;
-class Pose;
 }
 
 namespace rviz
@@ -93,7 +86,7 @@ class RobotLink: public QObject
 Q_OBJECT
 public:
   RobotLink( Robot* robot,
-             const urdf::LinkConstPtr& link,
+             const urdf::LinkConstSharedPtr& link,
              const std::string& parent_joint_name,
              bool visual,
              bool collision);
@@ -162,12 +155,12 @@ private Q_SLOTS:
 private:
   void setRenderQueueGroup( Ogre::uint8 group );
   bool getEnabled() const;
-  void createEntityForGeometryElement( const urdf::LinkConstPtr& link, const urdf::Geometry& geom, const urdf::Pose& origin, const std::string material_name, Ogre::SceneNode* scene_node, Ogre::Entity*& entity );
+  void createEntityForGeometryElement( const urdf::LinkConstSharedPtr& link, const urdf::Geometry& geom, const urdf::Pose& origin, const std::string material_name, Ogre::SceneNode* scene_node, Ogre::Entity*& entity );
 
-  void createVisual( const urdf::LinkConstPtr& link);
-  void createCollision( const urdf::LinkConstPtr& link);
+  void createVisual( const urdf::LinkConstSharedPtr& link);
+  void createCollision( const urdf::LinkConstSharedPtr& link);
   void createSelection();
-  Ogre::MaterialPtr getMaterialForLink( const urdf::LinkConstPtr& link, const std::string material_name = "" );
+  Ogre::MaterialPtr getMaterialForLink( const urdf::LinkConstSharedPtr& link, const std::string material_name = "" );
 
 
 protected:

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -168,6 +168,9 @@ Q_SIGNALS:
   /** @brief Emitted during file-loading and initialization to indicate progress. */
   void statusUpdate( const QString& message );
 
+  /** @brief Emitted when the interface enters or leaves full screen mode. */
+  void fullScreenChange( bool hidden );
+
 protected Q_SLOTS:
   void onOpen();
   void onSave();
@@ -218,6 +221,12 @@ protected Q_SLOTS:
    * The sender() of the signal should be a QAction whose text() is
    * the name of the panel. */
   void onDeletePanel();
+
+  /** @brief Set full screen mode. */
+  void setFullScreen( bool full_screen );
+
+  /** @brief Exit full screen mode. */
+  void exitFullScreen();
 
 protected Q_SLOTS:
   /** @brief Set loading_ to false. */
@@ -299,7 +308,6 @@ protected:
   QMenu* view_menu_;
   QMenu* delete_view_menu_;
   QMenu* plugins_menu_;
-  QList<QAction*> view_menu_actions_;
 
   QToolBar* toolbar_;
 
@@ -350,6 +358,9 @@ protected:
   ros::WallTime last_fps_calc_time_;
 
   QString error_message_; ///< Error message (if any) from most recent saveDisplayConfig() call.
+
+  /// Indicates if the toolbar should be visible outside of fullscreen mode.
+  bool toolbar_visible_;
 };
 
 }

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -33,6 +33,9 @@
 #include <QCursor>
 #include <QPixmap>
 #include <QTimer>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QWindow>
+#endif
 
 #include <boost/bind.hpp>
 
@@ -149,7 +152,7 @@ VisualizationManager::VisualizationManager( RenderPanel* render_panel, WindowMan
   display_property_tree_model_ = new PropertyTreeModel( root_display_group_ );
   display_property_tree_model_->setDragDropClass( "display" );
   connect( display_property_tree_model_, SIGNAL( configChanged() ), this, SIGNAL( configChanged() ));
-  
+
   tool_manager_ = new ToolManager( this );
   connect( tool_manager_, SIGNAL( configChanged() ), this, SIGNAL( configChanged() ));
   connect( tool_manager_, SIGNAL( toolChanged( Tool* ) ), this, SLOT( onToolChanged( Tool* ) ));
@@ -524,6 +527,17 @@ void VisualizationManager::handleMouseEvent( const ViewportMouseEvent& vme )
   if( current_tool )
   {
     ViewportMouseEvent _vme = vme;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    QWindow* window = vme.panel->windowHandle();
+    if (window)
+    {
+        double pixel_ratio = window->devicePixelRatio();
+        _vme.x = static_cast<int>(pixel_ratio * _vme.x);
+        _vme.y = static_cast<int>(pixel_ratio * _vme.y);
+        _vme.last_x = static_cast<int>(pixel_ratio * _vme.last_x);
+        _vme.last_y = static_cast<int>(pixel_ratio * _vme.last_y);
+    }
+#endif
     flags = current_tool->processMouseEvent( _vme );
     vme.panel->setCursor( current_tool->getCursor() );
   }


### PR DESCRIPTION
In preparation for the next Indigo release (last jade release of rviz).

In this backport:

- Support later versions of urdfdom: https://github.com/ros-visualization/rviz/pull/1064
- Fix rendering of point cloud when empty point cloud is received: https://github.com/ros-visualization/rviz/pull/1073
- Fix scaling of render area on high resolution displays: https://github.com/ros-visualization/rviz/pull/1078
- Support multiple material names in urdf: https://github.com/ros-visualization/rviz/pull/1079
- Fix bug in path display which prevented saving path color in config files: https://github.com/ros-visualization/rviz/pull/1089
- Fix to urdf type being used: https://github.com/ros-visualization/rviz/pull/1098
- Fix for supporting multiple material names in urdf: https://github.com/ros-visualization/rviz/pull/1102
- Added fullscreen option: https://github.com/ros-visualization/rviz/pull/1017