### PR TITLE
add qt-moc safeguard in config.h

### DIFF
--- a/src/rviz/config.h
+++ b/src/rviz/config.h
@@ -33,7 +33,9 @@
 
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>
+#endif
 
 #include <QMap>
 #include <QString>


### PR DESCRIPTION
Without this patch, qt4's moc fails for classes
that use rviz headers if boost is at version >= 1.64.

The error message looks like this:

```
Generating MOC source moc_trajectory_panel.cpp
/usr/include/boost/predef/language/stdc.h:52: Parse error at "defined"
AutoMoc: Error: moc process for moc_trajectory_panel.cpp failed:
/usr/include/boost/predef/language/stdc.h:52: Parse error at "defined"
```