### PR TITLE
map_display: don't ignore resolution changes in OccupancyGrid maps

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -675,10 +675,11 @@ void MapDisplay::showMap()
   int width = current_map_.info.width;
   int height = current_map_.info.height;
 
-  if(width != width_ || height != height_){
+  if(width != width_ || height != height_ || resolution_ != resolution){
     createSwatches();
     width_ = width;
     height_ = height;
+    resolution_ = resolution;
   }
 
   Ogre::Vector3 position( current_map_.info.origin.position.x,


### PR DESCRIPTION
Hi all,

I've noticed that changes of resolution to an occupancy grid map are not correctly reflected in RViz. I've investigated the `map_display` plugin code and noticed that `createSwatches()` in `MapDisplay::showMap()` is only called when the width or height changes, but not the resolution. I therefore extended the `if(width != width_ || height != height_){ ...` accordingly. Note that changing resolutions are (still) correctly reflected in RViz' UI panel.

I've tested this in ROS Kinetic and it works like a charm. Would be great if you merge my PR upstream. Thank you!