### PR TITLE
Avoid unnecessary addPoints in PointCloudCommon::update

### DIFF
--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -590,8 +590,8 @@ void PointCloudCommon::update(float wall_dt, float ros_dt)
         bool per_point_alpha = findChannelIndex(cloud_info->message_, "rgba") != -1;
 
         cloud_info->cloud_.reset( new PointCloud() );
-        cloud_info->cloud_->addPoints( &(cloud_info->transformed_points_.front()), cloud_info->transformed_points_.size() );
         cloud_info->cloud_->setRenderMode( mode );
+        cloud_info->cloud_->addPoints( &(cloud_info->transformed_points_.front()), cloud_info->transformed_points_.size() );
         cloud_info->cloud_->setAlpha( alpha_property_->getFloat(), per_point_alpha);
         cloud_info->cloud_->setDimensions( size, size, size );
         cloud_info->cloud_->setAutoSize(auto_size_);


### PR DESCRIPTION
After adding new points to the PointCloud, setRenderMode call regenerateAll which remove all points and add then again (to apply the new render mode). 
As the PointCloud is just created, it is empty. So calling setRenderMode before addPoints  avoid the regeneration and improve performance.

This is an easy performance improvement, there a lot a copying in this plugin that hurt perf, with patterns like allocating a lot of memory to throw it right away from each new incoming pointcloud (or depth_cloud). I might find some time to dig more deeply into it.