### PR TITLE
Only update window title if necessary

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -735,7 +735,10 @@ void VisualizationFrame::setDisplayConfigModified()
 {
   if( !loading_ )
   {
-    setWindowModified( true );
+    if( !isWindowModified() )
+    {
+      setWindowModified( true );
+    }
   }
 }
 


### PR DESCRIPTION
Hi,
On Ubuntu 16.04 (with the kde desktop environment from the kde backports ppa), moving the camera makes the taskbar freeze for several minutes (while using 100% CPU).
This happens because : 
When the user does move/rotate the camera
-> the pitch/yaw/... properties are updated
-> setWindowModified( true ) is called to notify the qwidget some modifications are pending
-> in setWindowModified() Qt will update the title bar of the rviz window, to add the ' * '
The problem is that kde's task manager has a hard time processing "new window title" events at several hundred times per second, thus freezes.

This pull request fixes the issue on my system