### PR TITLE
Add option to invert Z axis for orbit-based view controllers

### DIFF
--- a/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.cpp
@@ -37,6 +37,7 @@
 #include "rviz/display_context.h"
 #include "rviz/ogre_helpers/orthographic.h"
 #include "rviz/ogre_helpers/shape.h"
+#include "rviz/properties/bool_property.h"
 #include "rviz/properties/float_property.h"
 #include "rviz/viewport_mouse_event.h"
 
@@ -64,6 +65,7 @@ void FixedOrientationOrthoViewController::onInitialize()
 
   camera_->setProjectionType( Ogre::PT_ORTHOGRAPHIC );
   camera_->setFixedYawAxis( false );
+  invert_z_->hide();
 }
 
 void FixedOrientationOrthoViewController::reset()

--- a/src/rviz/default_plugin/view_controllers/fps_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/fps_view_controller.cpp
@@ -39,6 +39,7 @@
 #include "rviz/viewport_mouse_event.h"
 #include "rviz/geometry.h"
 #include "rviz/ogre_helpers/shape.h"
+#include "rviz/properties/bool_property.h"
 #include "rviz/properties/float_property.h"
 #include "rviz/properties/vector_property.h"
 
@@ -73,6 +74,7 @@ void FPSViewController::onInitialize()
 {
   FramePositionTrackingViewController::onInitialize();
   camera_->setProjectionType( Ogre::PT_PERSPECTIVE );
+  invert_z_->hide();
 }
 
 void FPSViewController::reset()

--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
@@ -260,8 +260,17 @@ void OrbitViewController::onTargetFrameChanged(const Ogre::Vector3& old_referenc
 void OrbitViewController::updateCamera()
 {
   float distance = distance_property_->getFloat();
-  float yaw = -yaw_property_->getFloat();
-  float pitch = -pitch_property_->getFloat();
+  float yaw = yaw_property_->getFloat();
+  float pitch = pitch_property_->getFloat();
+  Ogre::Vector3 camera_z = Ogre::Vector3::UNIT_Z;
+
+  // If requested, turn the world upside down.
+  if(this->invert_z_->getBool())
+  {
+    yaw = -yaw;
+    pitch = -pitch;
+    camera_z = -camera_z;
+  }
 
   Ogre::Vector3 focal_point = focal_point_property_->getVector();
 
@@ -273,7 +282,7 @@ void OrbitViewController::updateCamera()
   Ogre::Vector3 pos( x, y, z );
 
   camera_->setPosition(pos);
-  camera_->setFixedYawAxis(true, target_scene_node_->getOrientation() * -Ogre::Vector3::UNIT_Z);
+  camera_->setFixedYawAxis(true, target_scene_node_->getOrientation() * camera_z);
   camera_->setDirection(target_scene_node_->getOrientation() * (focal_point - pos));
 
   focal_shape_->setPosition( focal_point );

--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
@@ -260,8 +260,8 @@ void OrbitViewController::onTargetFrameChanged(const Ogre::Vector3& old_referenc
 void OrbitViewController::updateCamera()
 {
   float distance = distance_property_->getFloat();
-  float yaw = yaw_property_->getFloat();
-  float pitch = pitch_property_->getFloat();
+  float yaw = -yaw_property_->getFloat();
+  float pitch = -pitch_property_->getFloat();
 
   Ogre::Vector3 focal_point = focal_point_property_->getVector();
 
@@ -273,7 +273,7 @@ void OrbitViewController::updateCamera()
   Ogre::Vector3 pos( x, y, z );
 
   camera_->setPosition(pos);
-  camera_->setFixedYawAxis(true, target_scene_node_->getOrientation() * Ogre::Vector3::UNIT_Z);
+  camera_->setFixedYawAxis(true, target_scene_node_->getOrientation() * -Ogre::Vector3::UNIT_Z);
   camera_->setDirection(target_scene_node_->getOrientation() * (focal_point - pos));
 
   focal_shape_->setPosition( focal_point );

--- a/src/rviz/view_controller.cpp
+++ b/src/rviz/view_controller.cpp
@@ -79,6 +79,9 @@ ViewController::ViewController()
   stereo_focal_distance_ = new FloatProperty( "Stereo Focal Distance", 1.0f,
                                       "Distance from eyes to screen.  For stereo rendering.",
                                       stereo_enable_, SLOT( updateStereoProperties() ), this );
+  invert_z_ = new BoolProperty( "Invert Z Axis", false,
+                                      "Invert camera's Z axis for Z-down environments/models.",
+                                      this, SLOT( updateStereoProperties() ) );
 }
 
 void ViewController::initialize( DisplayContext* context )
@@ -278,5 +281,9 @@ void ViewController::updateStereoProperties()
   }
 }
 
+void ViewController::updateInvertZAxis()
+{
+  // We don't seem to need to do anything here.
+}
 
 } // end namespace rviz

--- a/src/rviz/view_controller.h
+++ b/src/rviz/view_controller.h
@@ -172,6 +172,7 @@ private Q_SLOTS:
 
   void updateNearClipDistance();
   void updateStereoProperties();
+  void updateInvertZAxis();
 
 protected:
   /** @brief Do subclass-specific initialization.  Called by
@@ -207,6 +208,7 @@ protected:
   BoolProperty* stereo_eye_swap_;
   FloatProperty* stereo_eye_separation_;
   FloatProperty* stereo_focal_distance_;
+  BoolProperty* invert_z_;
 
   void setStatus( const QString & message );
 


### PR DESCRIPTION
It's common in certain domains (e.g., aerospace) to construct models and environments with a Z-down coordinate system (it's still right-handed). When visualizing data from such environments, rviz is difficult to use because its camera controls are designed to prefer the ROS-standard Z-up convention. In particular, when working with a Z-down robot model, it's impossible to get an "over-the-shoulder" view of the robot.

This PR adds an orbit view controller option to invert the Z axis to make it easier to work with Z-down environments. To minimize confusion, the option is hidden by the non-orbit based view controllers that don't support it.