### PR TITLE
find tinyxml and link against it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,8 @@ else()
   set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 endif()
 
+find_package(TinyXML REQUIRED)
+
 catkin_python_setup()
 
 if(NOT OGRE_OV_LIBRARIES_ABS)
@@ -206,6 +208,7 @@ include_directories(SYSTEM
   ${OGRE_OV_INCLUDE_DIRS}
   ${OPENGL_INCLUDE_DIR}
   ${PYTHON_INCLUDE_PATH}
+  ${TinyXML_INCLUDE_DIRS}
   ${urdfdom_headers_INCLUDE_DIRS}
 )
 include_directories(src ${catkin_INCLUDE_DIRS})

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -139,6 +139,7 @@ target_link_libraries(${PROJECT_NAME}
   ${OGRE_OV_LIBRARIES_ABS}
   ${OPENGL_LIBRARIES}
   ${rviz_ADDITIONAL_LIBRARIES}
+  ${TinyXML_LIBRARIES}
   ${X11_X11_LIB}
   assimp
   yaml-cpp

--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -30,6 +30,7 @@
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 
+#include <tinyxml.h>
 #include <urdf/model.h>
 
 #include <tf/transform_listener.h>


### PR DESCRIPTION
Since https://github.com/ros/pluginlib/pull/59 pluginlib doesnt find_package tinyXML anymore. So downstream packages using tinyxml have to find it themselves.

This builds and passes the tests locally but I didn't run prerelease jobs or run nany manual test for it.

Note @wjwwood & @dhood this will require a new lunar release