### PR TITLE
Fix moc error with Qt 4.8.7 and Boost 1.58 in xenial

### DIFF
--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -39,7 +39,9 @@
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 
+#ifndef Q_MOC_RUN
 #include <urdf/model.h> // can be replaced later by urdf_model/types.h
+#endif
 
 namespace Ogre
 {

--- a/src/rviz/robot/robot_joint.h
+++ b/src/rviz/robot/robot_joint.h
@@ -40,10 +40,10 @@
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 #include <OgreMaterial.h>
-#endif
 
 #include <urdf/model.h>
 #include <urdf_model/pose.h>
+#endif
 
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -41,10 +41,10 @@
 #include <OgreAny.h>
 #include <OgreMaterial.h>
 #include <OgreSharedPtr.h>
-#endif
 
 #include <urdf/model.h> // can be replaced later by urdf_model/types.h
 #include <urdf_model/pose.h>
+#endif
 
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"


### PR DESCRIPTION
I needed this patch to compile the indigo-devel branch (or the latest released version [1.11.18](https://github.com/ros-visualization/rviz/tree/1.11.18)) successfully in Ubuntu Xenial with Boost 1.58 and Qt 4.8.7 for a custom build of `ros-indigo-desktop-full` from source:

```cpp
Generating moc_robot.cpp
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
AUTOGEN: error: process for /home/jenkins/workspace/ros-indigo-xenial/rviz/obj-x86_64-linux-gnu/src/rviz/moc_robot.cpp failed:
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"

Generating moc_robot_joint.cpp
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
AUTOGEN: error: process for /home/jenkins/workspace/ros-indigo-xenial/rviz/obj-x86_64-linux-gnu/src/rviz/moc_robot_joint.cpp failed:
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"

Generating moc_robot_link.cpp
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"
AUTOGEN: error: process for /home/jenkins/workspace/ros-indigo-xenial/rviz/obj-x86_64-linux-gnu/src/rviz/moc_robot_link.cpp failed:
usr/include/boost/type_traits/detail/has_binary_operator.hp:50: Parse error at "BOOST_JOIN"

```
```sh
$ dpkg -l libqt4-dev libboost1.58-dev
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                   Version                Architecture Description
+++-======================-======================-============-=====================================
ii  libboost1.58-dev:amd64 1.58.0+dfsg-5ubuntu3.1 amd64        Boost C++ Libraries development files
ii  libqt4-dev             4:4.8.7+dfsg-5ubuntu2  amd64        Qt 4 development files
```