### PR TITLE
Fixes "Parse error at BOOST_JOIN error" under Xenial.

### DIFF
--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -39,7 +39,9 @@
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 
+#ifndef Q_MOC_RUN
 #include <urdf/model.h> // can be replaced later by urdf_model/types.h
+#endif
 
 namespace Ogre
 {

--- a/src/rviz/robot/robot_joint.h
+++ b/src/rviz/robot/robot_joint.h
@@ -42,8 +42,10 @@
 #include <OgreMaterial.h>
 #endif
 
+#ifndef Q_MOC_RUN
 #include <urdf/model.h>
 #include <urdf_model/pose.h>
+#endif
 
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -43,8 +43,10 @@
 #include <OgreSharedPtr.h>
 #endif
 
+#ifndef Q_MOC_RUN
 #include <urdf/model.h> // can be replaced later by urdf_model/types.h
 #include <urdf_model/pose.h>
+#endif
 
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"


### PR DESCRIPTION
When compiling under Ubuntu Xenial I countered "Parse error at 'BOOST_JOIN'" error. This fix should not break building on Trusty, but also allows rviz to build under Xenial.

Related:
https://github.com/ros-planning/moveit_ros/issues/653
https://github.com/ros-planning/moveit_ros/pull/666