### PR TITLE
Disable dock widget text eliding

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -48,6 +48,7 @@
 #include <QLabel>
 #include <QToolButton>
 #include <QHBoxLayout>
+#include <QTabBar>
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -409,7 +410,7 @@ void VisualizationFrame::loadPersistentSettings()
       last_config_dir_ = last_config_dir.toStdString();
       last_image_dir_ = last_image_dir.toStdString();
     }
-    
+
     Config recent_configs_list = config.mapGetChild( "Recent Configs" );
     recent_configs_.clear();
     int num_recent = recent_configs_list.listLength();
@@ -599,7 +600,9 @@ void VisualizationFrame::openNewPanelDialog()
   manager_->stopUpdate();
   if( dialog->exec() == QDialog::Accepted )
   {
-    addPanelByName( display_name, class_id );
+    QDockWidget *dock = addPanelByName( display_name, class_id );
+    if ( dock )
+      connect( dock, SIGNAL( dockLocationChanged( Qt::DockWidgetArea )), this, SLOT( onDockPanelChange() ) );
   }
   manager_->startUpdate();
 }
@@ -676,7 +679,7 @@ void VisualizationFrame::loadDisplayConfig( const QString& qpath )
   std::string actual_load_path = path;
   if( !fs::exists( path ) || fs::is_directory( path ) || fs::is_empty( path ))
   {
-    actual_load_path = (fs::path(package_path_) / "default.rviz").BOOST_FILE_STRING();      
+    actual_load_path = (fs::path(package_path_) / "default.rviz").BOOST_FILE_STRING();
     if( !fs::exists( actual_load_path ))
     {
       ROS_ERROR( "Default display config '%s' not found.  RViz will be very empty at first.", actual_load_path.c_str() );
@@ -808,7 +811,7 @@ void VisualizationFrame::loadWindowGeometry( const Config& config )
       config.mapGetInt( "Height", &height ))
   {
     resize( width, height );
-  }    
+  }
 
   QString main_window_config;
   if( config.mapGetString( "QMainWindow State", &main_window_config ))
@@ -886,6 +889,7 @@ void VisualizationFrame::loadPanels( const Config& config )
       // qobject_cast.
       if( dock )
       {
+        connect(dock, SIGNAL( dockLocationChanged( Qt::DockWidgetArea )), this, SLOT( onDockPanelChange() ) );
         Panel* panel = qobject_cast<Panel*>( dock->widget() );
         if( panel )
         {
@@ -894,6 +898,8 @@ void VisualizationFrame::loadPanels( const Config& config )
       }
     }
   }
+
+  Q_EMIT onDockPanelChange();
 }
 
 void VisualizationFrame::savePanels( Config config )
@@ -951,7 +957,7 @@ bool VisualizationFrame::prepareToExit()
         default:
           return false;
         }
-        
+
       }
     case QMessageBox::Discard:
       return true;
@@ -1193,6 +1199,13 @@ void VisualizationFrame::onHelpAbout()
   .arg(OGRE_VERSION_NAME);
 
   QMessageBox::about(QApplication::activeWindow(), "About", about_text);
+}
+
+void VisualizationFrame::onDockPanelChange()
+{
+  QList<QTabBar *> tab_bars = findChildren<QTabBar *>(QString(), Qt::FindDirectChildrenOnly);
+  for ( QList<QTabBar *>::iterator it = tab_bars.begin(); it != tab_bars.end(); it++ )
+    (*it)->setElideMode( Qt::ElideNone );
 }
 
 QWidget* VisualizationFrame::getParentWindow()

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -602,7 +602,9 @@ void VisualizationFrame::openNewPanelDialog()
   {
     QDockWidget *dock = addPanelByName( display_name, class_id );
     if ( dock )
+    {
       connect( dock, SIGNAL( dockLocationChanged( Qt::DockWidgetArea )), this, SLOT( onDockPanelChange() ) );
+    }
   }
   manager_->startUpdate();
 }
@@ -899,7 +901,7 @@ void VisualizationFrame::loadPanels( const Config& config )
     }
   }
 
-  Q_EMIT onDockPanelChange();
+  onDockPanelChange();
 }
 
 void VisualizationFrame::savePanels( Config config )
@@ -1205,7 +1207,9 @@ void VisualizationFrame::onDockPanelChange()
 {
   QList<QTabBar *> tab_bars = findChildren<QTabBar *>(QString(), Qt::FindDirectChildrenOnly);
   for ( QList<QTabBar *>::iterator it = tab_bars.begin(); it != tab_bars.end(); it++ )
+  {
     (*it)->setElideMode( Qt::ElideNone );
+  }
 }
 
 QWidget* VisualizationFrame::getParentWindow()

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -137,7 +137,7 @@ public:
   QString getErrorMessage() const { return error_message_; }
 
   /** @brief Load the properties of all subsystems from the given Config.
-   * 
+   *
    * This is called by loadDisplayConfig().
    *
    * @param config Must have type Config::Map.
@@ -182,8 +182,9 @@ protected Q_SLOTS:
   void openNewPanelDialog();
   void openNewToolDialog();
   void showHelpPanel();
+  void onDockPanelChange();
 
-  /** @brief Remove a the tool whose name is given by remove_tool_menu_action->text(). */ 
+  /** @brief Remove a the tool whose name is given by remove_tool_menu_action->text(). */
   void onToolbarRemoveTool( QAction* remove_tool_menu_action );
 
   /** @brief Looks up the Tool for this action and calls


### PR DESCRIPTION
Fixes #1148 

Diff without trailing whitespace changes:
https://github.com/ros-visualization/rviz/compare/kinetic-devel...VictorLamoine:QTabWidget_elide?w=1

The new slot `onDockPanelChange` checks for every QTabBar there is in the main window and makes sure text is not elided inside it.

This slot is triggered
- When a config file is loaded
- When a panel is created
- When a panel is moved

# Before
![default_behaviour](https://user-images.githubusercontent.com/5566160/32040911-9860d0ba-ba32-11e7-9f33-edaf2a517380.png)

# After
![no_elide](https://user-images.githubusercontent.com/5566160/32040918-9f6a51b0-ba32-11e7-87e2-cf3bea03b50c.png)