### PR TITLE
add option to disable keyboard focus being set on mouse move

### DIFF
--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -49,6 +49,7 @@ RenderPanel::RenderPanel( QWidget* parent )
   : QtOgreRenderWindow( parent )
   , mouse_x_( 0 )
   , mouse_y_( 0 )
+  , focus_on_mouse_move_( true )
   , context_( 0 )
   , scene_manager_( 0 )
   , view_controller_( 0 )
@@ -56,6 +57,7 @@ RenderPanel::RenderPanel( QWidget* parent )
   , default_camera_(0)
   , context_menu_visible_(false)
 {
+  setFocusPolicy(Qt::WheelFocus);
   setFocus( Qt::OtherFocusReason );
 }
 
@@ -141,7 +143,8 @@ void RenderPanel::onRenderWindowMouseEvents( QMouseEvent* event )
 
   if (context_)
   {
-    setFocus( Qt::MouseFocusReason );
+    if (focus_on_mouse_move_)
+      setFocus( Qt::MouseFocusReason );
 
     ViewportMouseEvent vme(this, getViewport(), event, last_x, last_y);
     context_->handleMouseEvent(vme);
@@ -159,8 +162,6 @@ void RenderPanel::wheelEvent( QWheelEvent* event )
 
   if (context_)
   {
-    setFocus( Qt::MouseFocusReason );
-
     ViewportMouseEvent vme(this, getViewport(), event, last_x, last_y);
     context_->handleMouseEvent(vme);
     event->accept();
@@ -232,6 +233,16 @@ void RenderPanel::sceneManagerDestroyed( Ogre::SceneManager* destroyed_scene_man
     default_camera_ = NULL;
     setCamera( NULL );
   }
+}
+
+bool RenderPanel::getFocusOnMouseMove() const
+{
+  return focus_on_mouse_move_;
+}
+
+void RenderPanel::setFocusOnMouseMove(bool enabled)
+{
+  focus_on_mouse_move_ = enabled;
 }
 
 } // namespace rviz

--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -143,8 +143,9 @@ void RenderPanel::onRenderWindowMouseEvents( QMouseEvent* event )
 
   if (context_)
   {
-    if (focus_on_mouse_move_)
+    if (focus_on_mouse_move_) {
       setFocus( Qt::MouseFocusReason );
+    }
 
     ViewportMouseEvent vme(this, getViewport(), event, last_x, last_y);
     context_->handleMouseEvent(vme);

--- a/src/rviz/render_panel.h
+++ b/src/rviz/render_panel.h
@@ -100,6 +100,12 @@ public:
 
   virtual void sceneManagerDestroyed( Ogre::SceneManager* source );
 
+  /** Return true if moving the mouse within this widget should set keyboard focus */
+  bool getFocusOnMouseMove() const;
+
+  /** Set to true if moving the mouse within this widget should set keyboard focus, default true */
+  void setFocusOnMouseMove( bool enabled );
+
 protected:
   // Override from QWidget
   void contextMenuEvent( QContextMenuEvent* event );
@@ -124,6 +130,7 @@ protected:
   // Mouse handling
   int mouse_x_;                                           ///< X position of the last mouse event
   int mouse_y_;                                           ///< Y position of the last mouse event
+  bool focus_on_mouse_move_;                              ///< a moving the mouse catches keyboard focus
 
   DisplayContext* context_;
   Ogre::SceneManager* scene_manager_;


### PR DESCRIPTION
currently all mouse events get forwarded to onRenderWindowMouseEvents,
there keyboard focus is requested (setFocus) unconditionally. This commit
adds a new property "focus_on_mouse_move_" that enables setting keyboard
focus on mouse move events. Setting focus on click or wheel is handled by
QObject::setFocusPolicy

Subclasses/Users of rvis::RenderPanel can disable either setting focus on
mouse move by using the boolean property and disable keyboard focus on click,
on wheel or totally via setFocusPolicy