### PR TITLE
Fix crash when setting covariance using null quaternion

### DIFF
--- a/src/rviz/default_plugin/covariance_visual.cpp
+++ b/src/rviz/default_plugin/covariance_visual.cpp
@@ -300,6 +300,13 @@ void CovarianceVisual::setCovariance( const geometry_msgs::PoseWithCovariance& p
 
   // store orientation in Ogre structure
   Ogre::Quaternion ori(pose.pose.orientation.w, pose.pose.orientation.x, pose.pose.orientation.y, pose.pose.orientation.z);
+  // in the case that a null quaternion is in the message (e.g. if the field is uninitialized),
+  // set it to identity to prevent crashes
+  if (0.0 == ori.x && 0.0 == ori.y && 0.0 == ori.z && 0.0 == ori.w)
+  {
+    ori.w = 1.0;
+  }
+
   // Set the orientation of the fixed node. Since this node is attached to the root node, it's orientation will be the
   // inverse of pose's orientation.
   fixed_orientation_node_->setOrientation(ori.Inverse());


### PR DESCRIPTION
This is an alternative fix for https://github.com/ros-visualization/rviz/issues/1137. The current fix in place is from https://github.com/ros-visualization/rviz/pull/1139 which prevented the crash by rejecting the invalid quaternions.

The root cause of the crash was that, although the null quaternion is set to identity in [`FrameManager::transform()`](https://github.com/ros-visualization/rviz/blob/7970ba08cee3810cfa1609c3b0f5136970eb2f7c/src/rviz/frame_manager.cpp#L241) at [this line](https://github.com/ros-visualization/rviz/pull/1139/files#diff-bc9015d4b6ff8d1c30e5f237d306fcb3R297), it was still using the null quaternion [for the covariance display](https://github.com/ros-visualization/rviz/pull/1139/files#diff-bc9015d4b6ff8d1c30e5f237d306fcb3R335).

This will allow us to not reject null quaternions, which is important given the prevalence of invalid quaternions as uncovered by https://github.com/ros-visualization/rviz/pull/1167