### PR TITLE
Warn on unnormalised quaternions instead of rejecting them

### DIFF
--- a/src/rviz/default_plugin/interactive_marker_display.cpp
+++ b/src/rviz/default_plugin/interactive_marker_display.cpp
@@ -232,9 +232,12 @@ void InteractiveMarkerDisplay::updateMarkers(
 
     if( !validateQuaternions( marker ))
     {
-      setStatusStd( StatusProperty::Error, marker.name,
-                    "Marker contains invalid quaternions (length not equal to 1)!" );
-      continue;
+      ROS_WARN_ONCE_NAMED( "quaternions", "Interactive marker '%s' contains unnormalized quaternions. "
+                           "This warning will only be output once but may be true for others; "
+                           "enable DEBUG messages for ros.rviz.quaternions to see more details.",
+                           marker.name.c_str() );
+      ROS_DEBUG_NAMED( "quaternions", "Interactive marker '%s' contains unnormalized quaternions.",
+                       marker.name.c_str() );
     }
     ROS_DEBUG("Processing interactive marker '%s'. %d", marker.name.c_str(), (int)marker.controls.size() );
 

--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -658,8 +658,12 @@ void MapDisplay::showMap()
 
   if( !validateQuaternions( current_map_.info.origin ))
   {
-    setStatus( StatusProperty::Error, "Map", "Message contained invalid quaternions (length not equal to 1)!" );
-    return;
+    ROS_WARN_ONCE_NAMED( "quaternions", "Map received on topic '%s' contains unnormalized quaternions. "
+                         "This warning will only be output once but may be true for others; "
+                         "enable DEBUG messages for ros.rviz.quaternions to see more details.",
+                         topic_property_->getTopicStd().c_str() );
+    ROS_DEBUG_NAMED( "quaternions", "Map received on topic '%s' contains unnormalized quaternions.", 
+                     topic_property_->getTopicStd().c_str() );
   }
 
   if( current_map_.info.width * current_map_.info.height == 0 )

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -303,9 +303,12 @@ void MarkerDisplay::processMessage( const visualization_msgs::Marker::ConstPtr& 
 
   if( !validateQuaternions( message->pose ))
   {
-    setMarkerStatus( MarkerID( message->ns, message->id ), StatusProperty::Error,
-                     "Contains invalid quaternions (length not equal to 1)!" );
-    return;
+    ROS_WARN_ONCE_NAMED( "quaternions", "Marker '%s/%d' contains unnormalized quaternions. "
+                         "This warning will only be output once but may be true for others; "
+                         "enable DEBUG messages for ros.rviz.quaternions to see more details.",
+                         message->ns.c_str(), message->id );
+    ROS_DEBUG_NAMED( "quaternions", "Marker '%s/%d' contains unnormalized quaternions.", 
+                     message->ns.c_str(), message->id );
   }
 
   switch ( message->action )

--- a/src/rviz/default_plugin/odometry_display.cpp
+++ b/src/rviz/default_plugin/odometry_display.cpp
@@ -266,8 +266,12 @@ void OdometryDisplay::processMessage( const nav_msgs::Odometry::ConstPtr& messag
 
   if( !validateQuaternions( message->pose.pose ))
   {
-    setStatus( StatusProperty::Error, "Topic", "Message contained unnormalized quaternion (squares of values don't add to 1)" );
-    return;
+    ROS_WARN_ONCE_NAMED( "quaternions", "Odometry '%s' contains unnormalized quaternions. "
+                         "This warning will only be output once but may be true for others; "
+                         "enable DEBUG messages for ros.rviz.quaternions to see more details.",
+                         qPrintable( getName() ) );
+    ROS_DEBUG_NAMED( "quaternions", "Odometry '%s' contains unnormalized quaternions.", 
+                     qPrintable( getName() ) );
   }
 
   if( last_used_message_ )

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -426,8 +426,12 @@ void PathDisplay::processMessage( const nav_msgs::Path::ConstPtr& msg )
 
   if( !validateQuaternions( msg->poses ))
   {
-    setStatus( StatusProperty::Error, "Topic", "Message contained invalid quaternions (length not equal to 1)" );
-    return;
+    ROS_WARN_ONCE_NAMED( "quaternions", "Path '%s' contains unnormalized quaternions. "
+                         "This warning will only be output once but may be true for others; "
+                         "enable DEBUG messages for ros.rviz.quaternions to see more details.",
+                         qPrintable( getName() ) );
+    ROS_DEBUG_NAMED( "quaternions", "Path '%s' contains unnormalized quaternions.", 
+                     qPrintable( getName() ) );
   }
 
   // Lookup transform into fixed frame

--- a/src/rviz/default_plugin/pose_array_display.cpp
+++ b/src/rviz/default_plugin/pose_array_display.cpp
@@ -144,8 +144,12 @@ void PoseArrayDisplay::processMessage( const geometry_msgs::PoseArray::ConstPtr&
 
   if( !validateQuaternions( msg->poses ))
   {
-    setStatus( StatusProperty::Error, "Topic", "Message contained invalid quaternions (length not equal to 1)" );
-    return;
+    ROS_WARN_ONCE_NAMED( "quaternions", "PoseArray '%s' contains unnormalized quaternions. "
+                         "This warning will only be output once but may be true for others; "
+                         "enable DEBUG messages for ros.rviz.quaternions to see more details.",
+                         qPrintable( getName() ) );
+    ROS_DEBUG_NAMED( "quaternions", "PoseArray '%s' contains unnormalized quaternions.", 
+                     qPrintable( getName() ) );
   }
 
   if( !setTransform( msg->header ) )

--- a/src/rviz/default_plugin/pose_display.cpp
+++ b/src/rviz/default_plugin/pose_display.cpp
@@ -264,8 +264,12 @@ void PoseDisplay::processMessage( const geometry_msgs::PoseStamped::ConstPtr& me
 
   if( !validateQuaternions( *message ))
   {
-    setStatus( StatusProperty::Error, "Topic", "Message contained invalid quaternions (length not equal to 1)" );
-    return;
+    ROS_WARN_ONCE_NAMED( "quaternions", "Pose '%s' contains unnormalized quaternions. "
+                          "This warning will only be output once but may be true for others; "
+                          "enable DEBUG messages for ros.rviz.quaternions to see more details.",
+                          qPrintable( getName() ) );
+    ROS_DEBUG_NAMED( "quaternions", "Pose '%s' contains unnormalized quaternions.",
+                     qPrintable( getName() ) );
   }
 
   Ogre::Vector3 position;

--- a/src/rviz/default_plugin/pose_with_covariance_display.cpp
+++ b/src/rviz/default_plugin/pose_with_covariance_display.cpp
@@ -308,8 +308,12 @@ void PoseWithCovarianceDisplay::processMessage( const geometry_msgs::PoseWithCov
 
   if( !validateQuaternions( message->pose.pose ))
   {
-    setStatus( StatusProperty::Error, "Topic", "Message contained invalid quaternions (length not equal to 1)" );
-    return;
+    ROS_WARN_ONCE_NAMED( "quaternions", "PoseWithCovariance '%s' contains unnormalized quaternions. "
+                         "This warning will only be output once but may be true for others; "
+                         "enable DEBUG messages for ros.rviz.quaternions to see more details.",
+                         qPrintable( getName() ) );
+    ROS_DEBUG_NAMED( "quaternions", "PoseWithCovariance '%s' contains unnormalized quaternions.", 
+                     qPrintable( getName() ) );
   }
 
   Ogre::Vector3 position;

--- a/src/rviz/validate_quaternions.h
+++ b/src/rviz/validate_quaternions.h
@@ -32,6 +32,7 @@
 
 #include <geometry_msgs/PoseStamped.h>
 #include <OgreQuaternion.h>
+#include <ros/ros.h>
 #include <tf/LinearMath/Quaternion.h>
 
 #include <boost/array.hpp>
@@ -46,7 +47,11 @@ inline bool validateQuaternions( float w, float x, float y, float z )
     // Allow null quaternions to pass because they are common in uninitialized ROS messages.
     return true;
   }
-  return std::abs( w * w + x * x + y * y + z * z - 1.0f ) < 10e-3f;
+  float norm2 = w * w + x * x + y * y + z * z; 
+  bool is_normalized = std::abs( norm2 - 1.0f ) < 10e-3f;
+  ROS_DEBUG_COND_NAMED( !is_normalized, "quaternions", "Quaternion [x: %.3f, y: %.3f, z: %.3f, w: %.3f] not normalized. "
+                        "Magnitude: %.3f", x, y, z, w, std::sqrt(norm2) );
+  return is_normalized;
 }
 
 inline bool validateQuaternions( double w, double x, double y, double z )
@@ -56,7 +61,11 @@ inline bool validateQuaternions( double w, double x, double y, double z )
     // Allow null quaternions to pass because they are common in uninitialized ROS messages.
     return true;
   }
-  return std::abs( w * w + x * x + y * y + z * z - 1.0 ) < 10e-3;
+  double norm2 = w * w + x * x + y * y + z * z; 
+  bool is_normalized = std::abs( norm2 - 1.0 ) < 10e-3;
+  ROS_DEBUG_COND_NAMED( !is_normalized, "quaternions", "Quaternion [x: %.3f, y: %.3f, z: %.3f, w: %.3f] not normalized. "
+                        "Magnitude: %.3f", x, y, z, w, std::sqrt(norm2) );
+  return is_normalized;
 }
 
 inline bool validateQuaternions( Ogre::Quaternion quaternion )

--- a/src/rviz/validate_quaternions.h
+++ b/src/rviz/validate_quaternions.h
@@ -41,11 +41,21 @@ namespace rviz
 
 inline bool validateQuaternions( float w, float x, float y, float z )
 {
+  if ( 0.0f == x && 0.0f == y && 0.0f == z && 0.0f == w )
+  {
+    // Allow null quaternions to pass because they are common in uninitialized ROS messages.
+    return true;
+  }
   return std::abs( w * w + x * x + y * y + z * z - 1.0f ) < 10e-3f;
 }
 
 inline bool validateQuaternions( double w, double x, double y, double z )
 {
+  if ( 0.0 == x && 0.0 == y && 0.0 == z && 0.0 == w )
+  {
+    // Allow null quaternions to pass because they are common in uninitialized ROS messages.
+    return true;
+  }
   return std::abs( w * w + x * x + y * y + z * z - 1.0 ) < 10e-3;
 }
 


### PR DESCRIPTION
Since https://github.com/ros-visualization/rviz/pull/1180 fixes the only confirmed issue with invalid quaternions, don't reject them anymore.

Null quaternions will be set to identity by `FrameManager::transform` where appropriate. We do not output a warning for these because they are common in uninitialised ROS messages and are more likely indicative of users just being lazy than an error in the publisher.

Non-null, unnormalised quaternions will generate a warning, as it may be from an error in the code of the publisher (see https://github.com/ros-visualization/rviz/pull/1179#issuecomment-354910545). It would be most convenient for this warning to be displayed as a status in the GUI so it can be coupled with the specific offender. However, #1167 has revealed that there are many such cases (particularly markers), and having so many warnings throughout the display may cause more serious warnings to go unnoticed.

Instead, a console warning is generated, with `ONCE` since there's such a high prevalence of unnormalised quaternions around these days (it would be more appropriate to log a warning once for each invalid quaternion but that'd be less straightforward). Users can access info about all offending messages by setting the `quaternions` sublogger to debug. If it's more appropriate to potentially flood with console warnings then we can remove the ONCE filter; this seemed like a "gentler" approach.