### PR TITLE
check length of display-config parameter before extracting substring

### DIFF
--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -172,7 +172,7 @@ bool VisualizerApp::init( int argc, char** argv )
       if (vm.count("display-config"))
       {
         display_config = vm["display-config"].as<std::string>();
-        if( display_config.substr( display_config.size() - 4, 4 ) == ".vcg" )
+        if (display_config.size() >= 4 && display_config.substr( display_config.size() - 4, 4 ) == ".vcg")
         {
           std::cerr << "ERROR: the config file '" << display_config << "' is a .vcg file, which is the old rviz config format." << std::endl;
           std::cerr << "       New config files have a .rviz extension and use YAML formatting.  The format changed" << std::endl;


### PR DESCRIPTION
When running `rviz -d bla`, rviz would segfault as it tried to extract a substring of the display-config parameter without checking its size first.