### PR TITLE
hiding small wrenches should be optional

### DIFF
--- a/src/rviz/default_plugin/wrench_display.cpp
+++ b/src/rviz/default_plugin/wrench_display.cpp
@@ -23,38 +23,43 @@ WrenchStampedDisplay::WrenchStampedDisplay()
     force_color_property_ =
             new rviz::ColorProperty( "Force Color", QColor( 204, 51, 51 ),
                                      "Color to draw the force arrows.",
-                                     this, SLOT( updateColorAndAlpha() ));
+                                     this, SLOT( updateProperties() ));
 
     torque_color_property_ =
             new rviz::ColorProperty( "Torque Color", QColor( 204, 204, 51),
                                      "Color to draw the torque arrows.",
-                                     this, SLOT( updateColorAndAlpha() ));
+                                     this, SLOT( updateProperties() ));
 
     alpha_property_ =
             new rviz::FloatProperty( "Alpha", 1.0,
                                      "0 is fully transparent, 1.0 is fully opaque.",
-                                     this, SLOT( updateColorAndAlpha() ));
+                                     this, SLOT( updateProperties() ));
 
     force_scale_property_ =
             new rviz::FloatProperty( "Force Arrow Scale", 2.0,
                                      "force arrow scale",
-                                     this, SLOT( updateColorAndAlpha() ));
+                                     this, SLOT( updateProperties() ));
 
     torque_scale_property_ =
             new rviz::FloatProperty( "Torque Arrow Scale", 2.0,
                                      "torque arrow scale",
-                                     this, SLOT( updateColorAndAlpha() ));
+                                     this, SLOT( updateProperties() ));
 
     width_property_ =
             new rviz::FloatProperty( "Arrow Width", 0.5,
                                      "arrow width",
-                                     this, SLOT( updateColorAndAlpha() ));
+                                     this, SLOT( updateProperties() ));
 
 
     history_length_property_ =
             new rviz::IntProperty( "History Length", 1,
                                    "Number of prior measurements to display.",
                                    this, SLOT( updateHistoryLength() ));
+
+    hide_small_values_property_ =
+            new rviz::BoolProperty( "Hide Small Values", true,
+                                    "Hide small values",
+                                    this, SLOT( updateProperties() ));
 
     history_length_property_->setMin( 1 );
     history_length_property_->setMax( 100000 );
@@ -77,12 +82,13 @@ void WrenchStampedDisplay::reset()
     visuals_.clear();
 }
 
-void WrenchStampedDisplay::updateColorAndAlpha()
+void WrenchStampedDisplay::updateProperties()
 {
     float alpha = alpha_property_->getFloat();
     float force_scale = force_scale_property_->getFloat();
     float torque_scale = torque_scale_property_->getFloat();
     float width = width_property_->getFloat();
+    bool hide_small_values = hide_small_values_property_->getBool();
     Ogre::ColourValue force_color = force_color_property_->getOgreColor();
     Ogre::ColourValue torque_color = torque_color_property_->getOgreColor();
 
@@ -93,6 +99,7 @@ void WrenchStampedDisplay::updateColorAndAlpha()
         visuals_[i]->setForceScale( force_scale );
         visuals_[i]->setTorqueScale( torque_scale );
         visuals_[i]->setWidth( width );
+        visuals_[i]->setHideSmallValues( hide_small_values );
     }
 }
 
@@ -101,6 +108,7 @@ void WrenchStampedDisplay::updateHistoryLength()
 {
     visuals_.rset_capacity(history_length_property_->getInt());
 }
+
 
 bool validateFloats( const geometry_msgs::WrenchStamped& msg )
 {

--- a/src/rviz/default_plugin/wrench_display.h
+++ b/src/rviz/default_plugin/wrench_display.h
@@ -41,7 +41,7 @@ protected:
     virtual void reset();
 
 private Q_SLOTS:
-    // Helper function to apply color and alpha to all visuals.
+    // Helper function to properties for all visuals.
     void updateProperties();
     void updateHistoryLength();
 

--- a/src/rviz/default_plugin/wrench_display.h
+++ b/src/rviz/default_plugin/wrench_display.h
@@ -42,7 +42,7 @@ protected:
 
 private Q_SLOTS:
     // Helper function to apply color and alpha to all visuals.
-    void updateColorAndAlpha();
+    void updateProperties();
     void updateHistoryLength();
 
 private:
@@ -58,6 +58,7 @@ private:
     rviz::ColorProperty *force_color_property_, *torque_color_property_;
     rviz::FloatProperty *alpha_property_, *force_scale_property_, *torque_scale_property_, *width_property_;
     rviz::IntProperty *history_length_property_;
+    rviz::BoolProperty *hide_small_values_property_;
 };
 } // end namespace rviz_plugin_tutorials
 

--- a/src/rviz/default_plugin/wrench_visual.cpp
+++ b/src/rviz/default_plugin/wrench_visual.cpp
@@ -59,9 +59,11 @@ void WrenchVisual::setWrench( const Ogre::Vector3 &force, const Ogre::Vector3 &t
 {
     double force_length = force.length() * force_scale_;
     double torque_length = torque.length() * torque_scale_;
-    // hide markers if they get too short
-    bool show_force = (force_length > width_);
-    bool show_torque = (torque_length > width_);
+    // hide markers if they get too short and hide_small_values_ is activated
+    // "too short" is defined as "force_length > width_"
+    bool show_force = (force_length > width_)   || !hide_small_values_;
+    bool show_torque = (torque_length > width_) || !hide_small_values_;
+
     if (show_force) {
         arrow_force_->setScale(Ogre::Vector3(force_length, width_, width_));
         arrow_force_->setDirection(force);
@@ -130,6 +132,12 @@ void  WrenchVisual::setWidth( float w )
 {
     width_ = w;
 }
+
+void  WrenchVisual::setHideSmallValues( bool h )
+{
+    hide_small_values_ = h;
+}
+
 
 void WrenchVisual::setVisible(bool visible)
 {

--- a/src/rviz/default_plugin/wrench_visual.h
+++ b/src/rviz/default_plugin/wrench_visual.h
@@ -53,6 +53,7 @@ public:
     void setForceScale( float s );
     void setTorqueScale( float s );
     void setWidth( float w );
+    void setHideSmallValues(bool h);
     void setVisible( bool visible );
 
 private:
@@ -62,6 +63,7 @@ private:
     rviz::BillboardLine* circle_torque_;
     rviz::Arrow* circle_arrow_torque_;
     float force_scale_, torque_scale_, width_;
+    bool hide_small_values_;
 
     // A SceneNode whose pose is set to match the coordinate frame of
     // the WrenchStamped message header.

--- a/src/rviz/default_plugin/wrench_visual.h
+++ b/src/rviz/default_plugin/wrench_visual.h
@@ -53,7 +53,7 @@ public:
     void setForceScale( float s );
     void setTorqueScale( float s );
     void setWidth( float w );
-    void setHideSmallValues(bool h);
+    void setHideSmallValues( bool h );
     void setVisible( bool visible );
 
 private:


### PR DESCRIPTION
The default behavior for wrench messages was to hide the visualization if the length of the vector was smaller than the width. This pull request adds a boolean property to enable/disable this feature as discussed in  #1081.

I also renamed the function `updateColorAndAlpha()` to `updateProperties()`. The name made no sense anymore (even before) because scale and width are also updated here. The new name clarifies that several properties are updated.

@v4hn 