### PR TITLE
Add automatic ABI checker from ros-industrial/industrial_ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ env:
   matrix:
     - ROS_DISTRO="kinetic" ABICHECK_URL='github:ros-visualization/rviz#kinetic-devel' ABICHECK_MERGE=auto
 
-matrix:
-  allow_failures:
-    - env: ROS_DISTRO="kinetic" ABICHECK_URL='github:ros-visualization/rviz#kinetic-devel' ABICHECK_MERGE=auto
-
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+dist: trusty
+language: generic
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+env:
+  global:
+    - CCACHE_DIR=$HOME/.ccache
+
+  matrix:
+    - ROS_DISTRO="kinetic" ABICHECK_URL='github:ros-visualization/rviz#kinetic-devel' ABICHECK_MERGE=auto
+
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="kinetic" ABICHECK_URL='github:ros-visualization/rviz#kinetic-devel' ABICHECK_MERGE=auto
+
+install:
+  - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
+
+script: 
+  - .ci_config/travis.sh


### PR DESCRIPTION
If I've understood [the documentation](https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst) correctly this should check against the merge parent