### PR TITLE
Fix compiler warning and potential heap corruption due to mismatched new/delete

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -210,7 +210,7 @@ void Swatch::updateData()
                                                                  pixel_stream, width_, height_, Ogre::PF_L8, Ogre::TEX_TYPE_2D,
                                                                  0);
 
-  delete pixels;
+  delete[] pixels;
 }
 
 


### PR DESCRIPTION
This fixes a [-Wmismatched-new-delete](https://clang.llvm.org/docs/DiagnosticsReference.html#wmismatched-new-delete) compiler warning with Apple LLVM version 9.0.0 (clang-900.0.39.2) in macOS Sierra:

```cpp
[ 77%] Building CXX object src/rviz/default_plugin/CMakeFiles/rviz_default_plugin.dir/map_display.cpp.o
/Users/vagrant/ros_kinetic_desktop_ws/src/rviz/src/rviz/default_plugin/map_display.cpp:213:3: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
  delete pixels;
  ^
        []
/Users/vagrant/ros_kinetic_desktop_ws/src/rviz/src/rviz/default_plugin/map_display.cpp:183:27: note: allocated with 'new[]' here
  unsigned char* pixels = new unsigned char[pixels_size];
                          ^
```

According to the [C++ FAQ](https://isocpp.org/wiki/faq/freestore-mgmt#delete-array) and the critical [C++ FQA](https://yosefk.com/c++fqa/heap.html#fqa-16.12) this is undefined behavior and can potentially lead to heap corruption. Probably it would be a good idea to use [boost::shared_array](http://www.boost.org/doc/libs/1_66_0/libs/smart_ptr/doc/html/smart_ptr.html#shared_array) instead for exception safety.

Note that I did not look into the source code in detail or check whether and when the `Swatch::updateData()` function is called.