### PR TITLE
Created a new Preferences window, and added PromptSaveOnExit option.

### DIFF
--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(${PROJECT_NAME}
   message_filter_display.h
   mesh_loader.cpp
   new_object_dialog.cpp
+  preferences_dialog.cpp
   add_display_dialog.cpp
   ogre_helpers/apply_visibility_bits.cpp
   ogre_helpers/arrow.cpp

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -47,7 +47,6 @@ add_library(${PROJECT_NAME}
   message_filter_display.h
   mesh_loader.cpp
   new_object_dialog.cpp
-  preferences_dialog.cpp
   add_display_dialog.cpp
   ogre_helpers/apply_visibility_bits.cpp
   ogre_helpers/arrow.cpp
@@ -72,6 +71,7 @@ add_library(${PROJECT_NAME}
   panel.cpp
   panel_dock_widget.cpp
   panel_factory.cpp
+  preferences_dialog.cpp
   properties/bool_property.cpp
   properties/color_editor.cpp
   properties/color_property.cpp

--- a/src/rviz/preferences.h
+++ b/src/rviz/preferences.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RVIZ_PREFERENCES_H
+#define RVIZ_PREFERENCES_H
+
+namespace rviz
+{
+
+struct Preferences
+{
+  bool prompt_save_on_exit = true;
+};
+
+} //namespace rviz
+
+#endif // RVIZ_PREFERENCES_H

--- a/src/rviz/preferences_dialog.cpp
+++ b/src/rviz/preferences_dialog.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <map>
+
+#include <boost/filesystem.hpp>
+
+#include <ros/package.h>
+#include <ros/ros.h>
+
+#include <QGroupBox>
+#include <QTreeWidget>
+#include <QLabel>
+#include <QLineEdit>
+#include <QCheckBox>
+#include <QTextBrowser>
+#include <QVBoxLayout>
+#include <QDialogButtonBox>
+#include <QPushButton>
+
+#include "preferences_dialog.h"
+#include "rviz/load_resource.h"
+
+namespace rviz
+{
+
+PreferencesDialog::PreferencesDialog( Factory* factory,
+                   bool* prompt_save_on_exit_output,
+                   QWidget* parent)
+: QDialog( parent )
+, factory_( factory )
+, prompt_save_on_exit_output_( prompt_save_on_exit_output )
+{
+  //***** Layout
+
+  // Display Type group
+  QGroupBox* preferences_box = new QGroupBox( "Preferences" );
+  
+  QVBoxLayout* preferences_layout = new QVBoxLayout;
+  preferences_layout->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+  prompt_save_on_exit_checkbox_ = new QCheckBox;
+  prompt_save_on_exit_checkbox_->setChecked(*prompt_save_on_exit_output_);
+  prompt_save_on_exit_checkbox_->setText(QString( "Prompt Save on Exit?"));
+  preferences_layout->addWidget( prompt_save_on_exit_checkbox_ );
+  preferences_box->setLayout( preferences_layout );
+
+  // Buttons
+  button_box_ = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
+                                      Qt::Horizontal );
+
+  QVBoxLayout* main_layout = new QVBoxLayout;
+  main_layout->addWidget( preferences_box );
+  main_layout->addWidget( button_box_ );
+  setLayout( main_layout );
+
+  //***** Connections
+  connect( button_box_, SIGNAL( accepted() ), this, SLOT( accept() ));
+  connect( button_box_, SIGNAL( rejected() ), this, SLOT( reject() ));
+}
+
+QSize PreferencesDialog::sizeHint () const
+{
+  return( QSize(500,100) );
+}
+
+void PreferencesDialog::setError( const QString& error_text )
+{
+  button_box_->button( QDialogButtonBox::Ok )->setToolTip( error_text );
+}
+
+bool PreferencesDialog::isValid()
+{
+  setError( "" );
+  return true;
+}
+
+void PreferencesDialog::accept()
+{
+  if( isValid() )
+  {
+    *prompt_save_on_exit_output_ = prompt_save_on_exit_checkbox_->isChecked();
+    QDialog::accept();
+  }
+}
+
+} // rviz
+

--- a/src/rviz/preferences_dialog.cpp
+++ b/src/rviz/preferences_dialog.cpp
@@ -27,36 +27,24 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <map>
-
-#include <boost/filesystem.hpp>
-
-#include <ros/package.h>
-#include <ros/ros.h>
-
 #include <QGroupBox>
-#include <QTreeWidget>
-#include <QLabel>
-#include <QLineEdit>
 #include <QCheckBox>
-#include <QTextBrowser>
 #include <QVBoxLayout>
 #include <QDialogButtonBox>
 #include <QPushButton>
 
 #include "preferences_dialog.h"
-#include "rviz/load_resource.h"
 #include "rviz/preferences.h"
 
 namespace rviz
 {
 
 PreferencesDialog::PreferencesDialog( Factory* factory,
-                   Preferences *preferences,
+                   Preferences* preferences_output,
                    QWidget* parent)
 : QDialog( parent )
 , factory_( factory )
-, preferences_( preferences)
+, preferences_( preferences_output )
 {
   //***** Layout
 

--- a/src/rviz/preferences_dialog.cpp
+++ b/src/rviz/preferences_dialog.cpp
@@ -46,16 +46,17 @@
 
 #include "preferences_dialog.h"
 #include "rviz/load_resource.h"
+#include "rviz/preferences.h"
 
 namespace rviz
 {
 
 PreferencesDialog::PreferencesDialog( Factory* factory,
-                   bool* prompt_save_on_exit_output,
+                   Preferences *preferences,
                    QWidget* parent)
 : QDialog( parent )
 , factory_( factory )
-, prompt_save_on_exit_output_( prompt_save_on_exit_output )
+, preferences_( preferences)
 {
   //***** Layout
 
@@ -65,7 +66,7 @@ PreferencesDialog::PreferencesDialog( Factory* factory,
   QVBoxLayout* preferences_layout = new QVBoxLayout;
   preferences_layout->setAlignment(Qt::AlignLeft | Qt::AlignTop);
   prompt_save_on_exit_checkbox_ = new QCheckBox;
-  prompt_save_on_exit_checkbox_->setChecked(*prompt_save_on_exit_output_);
+  prompt_save_on_exit_checkbox_->setChecked(preferences_->prompt_save_on_exit);
   prompt_save_on_exit_checkbox_->setText(QString( "Prompt Save on Exit?"));
   preferences_layout->addWidget( prompt_save_on_exit_checkbox_ );
   preferences_box->setLayout( preferences_layout );
@@ -104,7 +105,7 @@ void PreferencesDialog::accept()
 {
   if( isValid() )
   {
-    *prompt_save_on_exit_output_ = prompt_save_on_exit_checkbox_->isChecked();
+    preferences_->prompt_save_on_exit = prompt_save_on_exit_checkbox_->isChecked();
     QDialog::accept();
   }
 }

--- a/src/rviz/preferences_dialog.h
+++ b/src/rviz/preferences_dialog.h
@@ -34,12 +34,8 @@
 
 #include "rviz/factory.h"
 
-class QTreeWidget;
-class QTreeWidgetItem;
-class QTextBrowser;
-class QLineEdit;
+class QCheckBox;
 class QDialogButtonBox;
-class QLabel;
 
 namespace rviz
 {
@@ -50,23 +46,13 @@ class PreferencesDialog : public QDialog
 {
 Q_OBJECT
 public:
-  /** Dialog for choosing a new object to load with a pluginlib ClassLoader.
+  /** Dialog for setting preferences.
    *
-   * @param disallowed_display_names set of display names to prevent
-   *        the user from using.
-   *
-   * @param disallowed_class_lookup_names set of class lookup names to
-   *        prevent the user from selecting.  Names found in the class loader
-   *        which are in this list will appear disabled.
-   *
-   * @param lookup_name_output Pointer to a string where dialog will
-   *        put the class lookup name chosen.
-   *
-   * @param display_name_output Pointer to a string where dialog will
-   *        put the display name entered, or NULL (default) if display
-   *        name entry field should not be shown. */
+   * @param preferences_output Pointer to Preferences struct where
+   *        preferences chosen by the user will be put.
+   */
   PreferencesDialog( Factory* factory,
-                   Preferences* preferences,
+                   Preferences* preferences_output,
                    QWidget* parent = 0 );
 
   virtual QSize sizeHint () const;

--- a/src/rviz/preferences_dialog.h
+++ b/src/rviz/preferences_dialog.h
@@ -44,6 +44,8 @@ class QLabel;
 namespace rviz
 {
 
+class Preferences;
+
 class PreferencesDialog : public QDialog
 {
 Q_OBJECT
@@ -64,7 +66,7 @@ public:
    *        put the display name entered, or NULL (default) if display
    *        name entry field should not be shown. */
   PreferencesDialog( Factory* factory,
-                   bool* prompt_save_on_exit_output,
+                   Preferences* preferences,
                    QWidget* parent = 0 );
 
   virtual QSize sizeHint () const;
@@ -84,7 +86,7 @@ private:
   Factory* factory_;
 
   QCheckBox* prompt_save_on_exit_checkbox_;
-  bool* prompt_save_on_exit_output_;
+  Preferences* preferences_;
 
   /** Widget with OK and CANCEL buttons. */
   QDialogButtonBox* button_box_;

--- a/src/rviz/preferences_dialog.h
+++ b/src/rviz/preferences_dialog.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RVIZ_PREFERENCES_DIALOG_H
+#define RVIZ_PREFERENCES_DIALOG_H
+
+#include <QDialog>
+
+#include "rviz/factory.h"
+
+class QTreeWidget;
+class QTreeWidgetItem;
+class QTextBrowser;
+class QLineEdit;
+class QDialogButtonBox;
+class QLabel;
+
+namespace rviz
+{
+
+class PreferencesDialog : public QDialog
+{
+Q_OBJECT
+public:
+  /** Dialog for choosing a new object to load with a pluginlib ClassLoader.
+   *
+   * @param disallowed_display_names set of display names to prevent
+   *        the user from using.
+   *
+   * @param disallowed_class_lookup_names set of class lookup names to
+   *        prevent the user from selecting.  Names found in the class loader
+   *        which are in this list will appear disabled.
+   *
+   * @param lookup_name_output Pointer to a string where dialog will
+   *        put the class lookup name chosen.
+   *
+   * @param display_name_output Pointer to a string where dialog will
+   *        put the display name entered, or NULL (default) if display
+   *        name entry field should not be shown. */
+  PreferencesDialog( Factory* factory,
+                   bool* prompt_save_on_exit_output,
+                   QWidget* parent = 0 );
+
+  virtual QSize sizeHint () const;
+
+public Q_SLOTS:
+  virtual void accept();
+
+private:
+  /** Returns true if entered display name is non-empty and unique and
+   * if lookup name is non-empty. */
+  bool isValid();
+
+  /** Display an error message to the user, or clear the previous
+   * error message if error_text is empty. */
+  void setError( const QString& error_text );
+
+  Factory* factory_;
+
+  QCheckBox* prompt_save_on_exit_checkbox_;
+  bool* prompt_save_on_exit_output_;
+
+  /** Widget with OK and CANCEL buttons. */
+  QDialogButtonBox* button_box_;
+};
+
+} //namespace rviz
+
+#endif // RVIZ_NEW_OBJECT_DIALOG_H

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -945,7 +945,7 @@ bool VisualizationFrame::prepareToExit()
 
   savePersistentSettings();
 
-  if( isWindowModified() && preferences_->prompt_save_on_exit)
+  if( isWindowModified() && preferences_->prompt_save_on_exit )
   {
     QMessageBox box( this );
     box.setText( "There are unsaved changes." );

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -466,8 +466,6 @@ void VisualizationFrame::initMenus()
   }
   file_menu_->addSeparator();
   file_menu_->addAction( "&Preferences", this, SLOT( openPreferencesDialog() ), QKeySequence( "Ctrl+P" ));
-  file_menu_->addSeparator();
-  file_menu_->addAction( "&Quit", this, SLOT( close() ), QKeySequence( "Ctrl+Q" ));
 
   QAction * file_menu_quit_action = file_menu_->addAction( "&Quit", this, SLOT( close() ), QKeySequence( "Ctrl+Q" ));
   this->addAction(file_menu_quit_action);

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -471,7 +471,7 @@ void VisualizationFrame::initMenus()
   this->addAction(file_menu_quit_action);
 
   view_menu_ = menuBar()->addMenu( "&Panels" );
-  view_menu_->addAction( "Add &New Panel", this, SLOT( openNewPanelDialog() ), QKeySequence( "Ctrl+N" ));
+  view_menu_->addAction( "Add &New Panel", this, SLOT( openNewPanelDialog() ));
   delete_view_menu_ = view_menu_->addMenu( "&Delete Panel" );
   delete_view_menu_->setEnabled( false );
 

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -182,9 +182,9 @@ protected Q_SLOTS:
   void onRecentConfigSelected();
   void onHelpWiki();
   void onHelpAbout();
-  void openPreferencesDialog();
   void openNewPanelDialog();
   void openNewToolDialog();
+  void openPreferencesDialog();
   void showHelpPanel();
 
   /** @brief Remove a the tool whose name is given by remove_tool_menu_action->text(). */ 

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -30,6 +30,8 @@
 #ifndef RVIZ_VISUALIZATION_FRAME_H
 #define RVIZ_VISUALIZATION_FRAME_H
 
+#include <boost/shared_ptr.hpp>
+
 #include <QMainWindow>
 #include <QList>
 
@@ -54,6 +56,7 @@ namespace rviz
 {
 
 class PanelFactory;
+class Preferences;
 class RenderPanel;
 class VisualizationManager;
 class Tool;
@@ -307,7 +310,7 @@ protected:
   std::string last_image_dir_;
   std::string home_dir_;
 
-  bool prompt_save_on_exit_;
+  boost::shared_ptr<Preferences> preferences_;
 
   QMenu* file_menu_;
   QMenu* recent_configs_menu_;

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -179,6 +179,7 @@ protected Q_SLOTS:
   void onRecentConfigSelected();
   void onHelpWiki();
   void onHelpAbout();
+  void openPreferencesDialog();
   void openNewPanelDialog();
   void openNewToolDialog();
   void showHelpPanel();
@@ -278,6 +279,9 @@ protected:
   /** @brief Saves custom panels to the given config node. */
   void savePanels( Config config );
 
+  void loadPreferences( const Config& config );
+  void savePreferences( Config config );
+
   void loadWindowGeometry( const Config& config );
   void saveWindowGeometry( Config config );
 
@@ -302,6 +306,8 @@ protected:
   std::string last_config_dir_;
   std::string last_image_dir_;
   std::string home_dir_;
+
+  bool prompt_save_on_exit_;
 
   QMenu* file_menu_;
   QMenu* recent_configs_menu_;


### PR DESCRIPTION
Redo of #1106 on behalf of @MasterEric , who wrote:

> For tutorials installed to a read-only location, it may be disorienting for the user to be prompted to save. For this reason, I created a preferences dialog window, with a boolean option for whether to Prompt Save on Exit, defaulting to true. These preferences are saved to any config .rviz files that are created.