### PR TITLE
update include statements to use new pluginlib and class_loader headers

### DIFF
--- a/src/rviz/default_plugin/axes_display.cpp
+++ b/src/rviz/default_plugin/axes_display.cpp
@@ -122,5 +122,5 @@ void AxesDisplay::update( float dt, float ros_dt )
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::AxesDisplay, rviz::Display )

--- a/src/rviz/default_plugin/camera_display.cpp
+++ b/src/rviz/default_plugin/camera_display.cpp
@@ -531,5 +531,5 @@ void CameraDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::CameraDisplay, rviz::Display )

--- a/src/rviz/default_plugin/depth_cloud_display.cpp
+++ b/src/rviz/default_plugin/depth_cloud_display.cpp
@@ -613,7 +613,7 @@ void DepthCloudDisplay::fixedFrameChanged()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS( rviz::DepthCloudDisplay, rviz::Display)
 

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -356,7 +356,7 @@ namespace rviz
 
 // Tell pluginlib about this class.  It is important to do this in
 // global scope, outside our package's namespace.
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::EffortDisplay, rviz::Display )
 
 

--- a/src/rviz/default_plugin/fluid_pressure_display.cpp
+++ b/src/rviz/default_plugin/fluid_pressure_display.cpp
@@ -152,5 +152,5 @@ void FluidPressureDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::FluidPressureDisplay, rviz::Display )

--- a/src/rviz/default_plugin/grid_cells_display.cpp
+++ b/src/rviz/default_plugin/grid_cells_display.cpp
@@ -252,5 +252,5 @@ void GridCellsDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::GridCellsDisplay, rviz::Display )

--- a/src/rviz/default_plugin/grid_display.cpp
+++ b/src/rviz/default_plugin/grid_display.cpp
@@ -234,5 +234,5 @@ void GridDisplay::updatePlane()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::GridDisplay, rviz::Display )

--- a/src/rviz/default_plugin/illuminance_display.cpp
+++ b/src/rviz/default_plugin/illuminance_display.cpp
@@ -152,5 +152,5 @@ void IlluminanceDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::IlluminanceDisplay, rviz::Display )

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -247,5 +247,5 @@ void ImageDisplay::processMessage(const sensor_msgs::Image::ConstPtr& msg)
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::ImageDisplay, rviz::Display )

--- a/src/rviz/default_plugin/interactive_marker_display.cpp
+++ b/src/rviz/default_plugin/interactive_marker_display.cpp
@@ -417,5 +417,5 @@ void InteractiveMarkerDisplay::updateEnableTransparency()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::InteractiveMarkerDisplay, rviz::Display )

--- a/src/rviz/default_plugin/laser_scan_display.cpp
+++ b/src/rviz/default_plugin/laser_scan_display.cpp
@@ -120,5 +120,5 @@ void LaserScanDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::LaserScanDisplay, rviz::Display )

--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -833,5 +833,5 @@ void MapDisplay::update( float wall_dt, float ros_dt ) {
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::MapDisplay, rviz::Display )

--- a/src/rviz/default_plugin/marker_array_display.cpp
+++ b/src/rviz/default_plugin/marker_array_display.cpp
@@ -84,5 +84,5 @@ void MarkerArrayDisplay::handleMarkerArray( const visualization_msgs::MarkerArra
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::MarkerArrayDisplay, rviz::Display )

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -496,5 +496,5 @@ void MarkerNamespace::onEnableChanged()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::MarkerDisplay, rviz::Display )

--- a/src/rviz/default_plugin/odometry_display.cpp
+++ b/src/rviz/default_plugin/odometry_display.cpp
@@ -374,5 +374,5 @@ void OdometryDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::OdometryDisplay, rviz::Display )

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -542,5 +542,5 @@ void PathDisplay::processMessage( const nav_msgs::Path::ConstPtr& msg )
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PathDisplay, rviz::Display )

--- a/src/rviz/default_plugin/point_cloud2_display.cpp
+++ b/src/rviz/default_plugin/point_cloud2_display.cpp
@@ -178,5 +178,5 @@ void PointCloud2Display::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PointCloud2Display, rviz::Display )

--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -37,7 +37,7 @@
 
 #include <tf/transform_listener.h>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include "rviz/default_plugin/point_cloud_transformer.h"
 #include "rviz/default_plugin/point_cloud_transformers.h"

--- a/src/rviz/default_plugin/point_cloud_display.cpp
+++ b/src/rviz/default_plugin/point_cloud_display.cpp
@@ -93,5 +93,5 @@ void PointCloudDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PointCloudDisplay, rviz::Display )

--- a/src/rviz/default_plugin/point_cloud_transformers.cpp
+++ b/src/rviz/default_plugin/point_cloud_transformers.cpp
@@ -673,7 +673,7 @@ void AxisColorPCTransformer::updateAutoComputeBounds()
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::AxisColorPCTransformer, rviz::PointCloudTransformer )
 PLUGINLIB_EXPORT_CLASS( rviz::FlatColorPCTransformer, rviz::PointCloudTransformer )
 PLUGINLIB_EXPORT_CLASS( rviz::IntensityPCTransformer, rviz::PointCloudTransformer )

--- a/src/rviz/default_plugin/point_display.cpp
+++ b/src/rviz/default_plugin/point_display.cpp
@@ -133,7 +133,7 @@ namespace rviz
 
 // Tell pluginlib about this class.  It is important to do this in
 // global scope, outside our package's namespace.
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PointStampedDisplay, rviz::Display )
 
 

--- a/src/rviz/default_plugin/polygon_display.cpp
+++ b/src/rviz/default_plugin/polygon_display.cpp
@@ -128,5 +128,5 @@ void PolygonDisplay::processMessage(const geometry_msgs::PolygonStamped::ConstPt
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PolygonDisplay, rviz::Display )

--- a/src/rviz/default_plugin/pose_array_display.cpp
+++ b/src/rviz/default_plugin/pose_array_display.cpp
@@ -386,5 +386,5 @@ void PoseArrayDisplay::updateAxesGeometry()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PoseArrayDisplay, rviz::Display )

--- a/src/rviz/default_plugin/pose_display.cpp
+++ b/src/rviz/default_plugin/pose_display.cpp
@@ -301,5 +301,5 @@ void PoseDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PoseDisplay, rviz::Display )

--- a/src/rviz/default_plugin/pose_with_covariance_display.cpp
+++ b/src/rviz/default_plugin/pose_with_covariance_display.cpp
@@ -352,5 +352,5 @@ void PoseWithCovarianceDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PoseWithCovarianceDisplay, rviz::Display )

--- a/src/rviz/default_plugin/range_display.cpp
+++ b/src/rviz/default_plugin/range_display.cpp
@@ -163,5 +163,5 @@ void RangeDisplay::processMessage( const sensor_msgs::Range::ConstPtr& msg )
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::RangeDisplay, rviz::Display )

--- a/src/rviz/default_plugin/relative_humidity_display.cpp
+++ b/src/rviz/default_plugin/relative_humidity_display.cpp
@@ -149,5 +149,5 @@ void RelativeHumidityDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::RelativeHumidityDisplay, rviz::Display )

--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -248,5 +248,5 @@ void RobotModelDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::RobotModelDisplay, rviz::Display )

--- a/src/rviz/default_plugin/temperature_display.cpp
+++ b/src/rviz/default_plugin/temperature_display.cpp
@@ -151,5 +151,5 @@ void TemperatureDisplay::reset()
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::TemperatureDisplay, rviz::Display )

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -789,5 +789,5 @@ void FrameInfo::setEnabled( bool enabled )
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::TFDisplay, rviz::Display )

--- a/src/rviz/default_plugin/tools/focus_tool.cpp
+++ b/src/rviz/default_plugin/tools/focus_tool.cpp
@@ -109,5 +109,5 @@ int FocusTool::processMouseEvent( ViewportMouseEvent& event )
 
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::FocusTool, rviz::Tool )

--- a/src/rviz/default_plugin/tools/goal_tool.cpp
+++ b/src/rviz/default_plugin/tools/goal_tool.cpp
@@ -76,5 +76,5 @@ void GoalTool::onPoseSet(double x, double y, double theta)
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::GoalTool, rviz::Tool )

--- a/src/rviz/default_plugin/tools/initial_pose_tool.cpp
+++ b/src/rviz/default_plugin/tools/initial_pose_tool.cpp
@@ -82,5 +82,5 @@ void InitialPoseTool::onPoseSet(double x, double y, double theta)
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::InitialPoseTool, rviz::Tool )

--- a/src/rviz/default_plugin/tools/interaction_tool.cpp
+++ b/src/rviz/default_plugin/tools/interaction_tool.cpp
@@ -197,5 +197,5 @@ int InteractionTool::processKeyEvent( QKeyEvent* event, RenderPanel* panel )
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::InteractionTool, rviz::Tool )

--- a/src/rviz/default_plugin/tools/measure_tool.cpp
+++ b/src/rviz/default_plugin/tools/measure_tool.cpp
@@ -138,5 +138,5 @@ int MeasureTool::processMouseEvent( ViewportMouseEvent& event )
 } /* namespace rviz */
 
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::MeasureTool, rviz::Tool )

--- a/src/rviz/default_plugin/tools/move_tool.cpp
+++ b/src/rviz/default_plugin/tools/move_tool.cpp
@@ -68,5 +68,5 @@ int MoveTool::processKeyEvent( QKeyEvent* event, RenderPanel* panel )
 
 } // namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::MoveTool, rviz::Tool )

--- a/src/rviz/default_plugin/tools/point_tool.cpp
+++ b/src/rviz/default_plugin/tools/point_tool.cpp
@@ -132,5 +132,5 @@ int PointTool::processMouseEvent( ViewportMouseEvent& event )
 
 }
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::PointTool, rviz::Tool )

--- a/src/rviz/default_plugin/tools/selection_tool.cpp
+++ b/src/rviz/default_plugin/tools/selection_tool.cpp
@@ -187,5 +187,5 @@ int SelectionTool::processKeyEvent( QKeyEvent* event, RenderPanel* panel )
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::SelectionTool, rviz::Tool )

--- a/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.cpp
@@ -218,5 +218,5 @@ void FixedOrientationOrthoViewController::move( float dx, float dy )
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::FixedOrientationOrthoViewController, rviz::ViewController )

--- a/src/rviz/default_plugin/view_controllers/fps_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/fps_view_controller.cpp
@@ -243,5 +243,5 @@ void FPSViewController::move( float x, float y, float z )
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::FPSViewController, rviz::ViewController )

--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
@@ -330,5 +330,5 @@ void OrbitViewController::move( float x, float y, float z )
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::OrbitViewController, rviz::ViewController )

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
@@ -235,5 +235,5 @@ void ThirdPersonFollowerViewController::lookAt( const Ogre::Vector3& point )
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::ThirdPersonFollowerViewController, rviz::ViewController )

--- a/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.cpp
@@ -221,5 +221,5 @@ void XYOrbitViewController::lookAt( const Ogre::Vector3& point )
 
 } // end namespace rviz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::XYOrbitViewController, rviz::ViewController )

--- a/src/rviz/default_plugin/wrench_display.cpp
+++ b/src/rviz/default_plugin/wrench_display.cpp
@@ -172,5 +172,5 @@ void WrenchStampedDisplay::processMessage( const geometry_msgs::WrenchStamped::C
 
 // Tell pluginlib about this class.  It is important to do this in
 // global scope, outside our package's namespace.
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz::WrenchStampedDisplay, rviz::Display )

--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -31,7 +31,7 @@
 #include <boost/foreach.hpp>
 #include <boost/shared_ptr.hpp>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include <image_transport/subscriber_plugin.h>
 

--- a/src/rviz/pluginlib_factory.h
+++ b/src/rviz/pluginlib_factory.h
@@ -37,7 +37,7 @@
 #include <vector>
 
 #ifndef Q_MOC_RUN
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #endif
 
 #include "rviz/class_id_recording_factory.h"

--- a/src/test/new_display_dialog_test.cpp
+++ b/src/test/new_display_dialog_test.cpp
@@ -31,7 +31,7 @@
 
 #include <QApplication>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 #include "rviz/display.h"
 #include "rviz/pluginlib_factory.h"


### PR DESCRIPTION
Disclaimer: This in an automated PR, if it is not relevant on this branch, apologies for the inconveniance, feel free close it.

----

`pluginlib` and `class_loader` headers have been refactored and renamed. The previous headers `.h` have been deprecated in favor of their `.hpp` equivalent. The new headers are available on all active ROS distributions and the deprecated ones will be removed in a future version of ROS (likely ROS-N).

This PR migrates the include statements to use the non-deprecated ones and should compile for any active ROS distribution starting with Indigo
The migration was done by running the scripts [pluginlib_headers_migration.py](https://github.com/ros/pluginlib/blob/6ada92c4665a392339c683682de1d1503658c209/scripts/pluginlib_headers_migration.py) and [class_loader_headers_update.py](https://github.com/ros/class_loader/blob/1515546103de4d987daa8f5519ca43fe6cffbca6/scripts/class_loader_headers_update.py) on this repository.