### PR TITLE
Install help.html

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,3 +242,6 @@ install(FILES default.rviz
 install(FILES plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+install(FILES help/help.html
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/help
+)


### PR DESCRIPTION
Not sure why this wasn't being installed.

`Help` > `Show Help Panel` works now (without it gives "Help file '/opt/ros/kinetic/share/rviz/help/help.html' does not exist.")