### PR TITLE
Add tf2 Buffer accessor in FrameManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ find_package(catkin REQUIRED
   std_msgs
   std_srvs
   tf
+  tf2_ros
   urdf
   visualization_msgs
   urdfdom_headers

--- a/package.xml
+++ b/package.xml
@@ -43,6 +43,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>tinyxml</build_depend>
   <build_depend>urdf</build_depend>
   <build_depend>visualization_msgs</build_depend>
@@ -77,6 +78,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>tf2_ros</run_depend>
   <run_depend>tinyxml</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>visualization_msgs</run_depend>

--- a/src/rviz/frame_manager.cpp
+++ b/src/rviz/frame_manager.cpp
@@ -32,6 +32,8 @@
 #include "properties/property.h"
 
 #include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <ros/ros.h>
 
 #include <std_msgs/Float32.h>
@@ -43,6 +45,9 @@ FrameManager::FrameManager(boost::shared_ptr<tf::TransformListener> tf)
 {
   if (!tf) tf_.reset(new tf::TransformListener(ros::NodeHandle(), ros::Duration(10*60), true));
   else tf_ = tf;
+
+  tf2_buffer_ = std::make_shared<tf2_ros::Buffer>(ros::Duration(10*60));
+  tf2_listener_.reset(new tf2_ros::TransformListener(*tf2_buffer_));
 
   setSyncMode( SyncOff );
   setPause(false);

--- a/src/rviz/frame_manager.h
+++ b/src/rviz/frame_manager.h
@@ -52,6 +52,12 @@ namespace tf
 class TransformListener;
 }
 
+namespace tf2_ros
+{
+class Buffer;
+class TransformListener;
+}
+
 namespace rviz
 {
 class Display;
@@ -186,6 +192,9 @@ public:
   /** @brief Return a boost shared pointer to the tf::TransformListener used to receive transform data. */
   const boost::shared_ptr<tf::TransformListener>& getTFClientPtr() { return tf_; }
 
+  /** @brief Return a shared pointer to the tf2_ros::Buffer object used to receive tf2 transform data. */
+  const std::shared_ptr<tf2_ros::Buffer> getTFBufferPtr() { return tf2_buffer_; };
+
   /** @brief Create a description of a transform problem.
    * @param frame_id The name of the frame with issues.
    * @param stamp The time for which the problem was detected.
@@ -266,6 +275,8 @@ private:
   M_Cache cache_;
 
   boost::shared_ptr<tf::TransformListener> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf2_buffer_;
+  std::unique_ptr<tf2_ros::TransformListener> tf2_listener_;
   std::string fixed_frame_;
 
   bool pause_;


### PR DESCRIPTION
As this modifies headers (though only **adding** API), this may need to target `melodic-devel`.

This PR would mitigate the Issue related to using tf2 in the FrameManager https://github.com/ros-visualization/rviz/issues/1215 by creating a `tf2_ros` `TransformListener` and `Buffer` for use by those who wish to use the RViz API and rely solely on the `tf2` libraries. In particular, MoveIt! is in the middle of a migration to tf2 ( https://github.com/ros-planning/moveit/pull/830 ) and this PR would unblock that migration.