### PR TITLE
Indigo backports from kinetic-devel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,3 +241,6 @@ install(FILES default.rviz
 install(FILES plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+install(FILES help/help.html
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/help
+)

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -267,6 +267,11 @@ namespace rviz
     // This is our callback to handle an incoming message.
     void EffortDisplay::processMessage( const sensor_msgs::JointState::ConstPtr& msg )
     {
+        // Robot model might not be loaded already
+        if (!robot_model_)
+        {
+            return;
+        }
         // We are keeping a circular buffer of visual pointers.  This gets
         // the next one, or creates and stores it if the buffer is not full
         boost::shared_ptr<EffortVisual> visual;

--- a/src/rviz/default_plugin/markers/triangle_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.cpp
@@ -56,9 +56,12 @@ TriangleListMarker::TriangleListMarker(MarkerDisplay* owner, DisplayContext* con
 
 TriangleListMarker::~TriangleListMarker()
 {
-  context_->getSceneManager()->destroyManualObject(manual_object_);
-  material_->unload();
-  Ogre::MaterialManager::getSingleton().remove(material_->getName());
+  if (manual_object_)
+  {
+    context_->getSceneManager()->destroyManualObject(manual_object_);
+    material_->unload();
+    Ogre::MaterialManager::getSingleton().remove(material_->getName());
+  }
 }
 
 void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const MarkerConstPtr& new_message)


### PR DESCRIPTION
Backports for:

- Only tear down triangle list objects if they've been created: https://github.com/ros-visualization/rviz/pull/1164
- Install help.html: https://github.com/ros-visualization/rviz/pull/1218
- Ensure robot model has been loaded before processing JointState msg: https://github.com/ros-visualization/rviz/pull/1229