### PR TITLE
change to use non-deprecated header (#1231)

### DIFF
--- a/src/rviz/default_plugin/point_cloud_common.h
+++ b/src/rviz/default_plugin/point_cloud_common.h
@@ -47,7 +47,7 @@
 
 # include <message_filters/time_sequencer.h>
 
-# include <pluginlib/class_loader.h>
+# include <pluginlib/class_loader.hpp>
 
 # include <sensor_msgs/PointCloud.h>
 # include <sensor_msgs/PointCloud2.h>


### PR DESCRIPTION
Backport of https://github.com/ros-visualization/rviz/pull/1231, followup of https://github.com/ros-visualization/rviz/pull/1217