### PR TITLE
Show badge of devel job instead of PR job in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![rviz logo](https://raw.githubusercontent.com/ros-visualization/rviz/kinetic-devel/images/splash.png)
-[![Build Status](http://build.ros.org/buildStatus/icon?job=Kpr__rviz__ubuntu_xenial_amd64)](http://build.ros.org/job/Kpr__rviz__ubuntu_xenial_amd64)
+[![Build Status](http://build.ros.org/buildStatus/icon?job=Kdev__rviz__ubuntu_xenial_amd64)](http://build.ros.org/view/Kdev/job/Kdev__rviz__ubuntu_xenial_amd64/)
 
 rviz is a 3D visualizer for the Robot Operating System (ROS) framework.
 


### PR DESCRIPTION
So that the badge reflects the state of kinetic-devel branch instead of the latest PR build