### PR TITLE
Deprecate tf for tf2

### DIFF
--- a/src/rviz/default_plugin/axes_display.cpp
+++ b/src/rviz/default_plugin/axes_display.cpp
@@ -29,8 +29,19 @@
 
 #include <boost/bind.hpp>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-W#warnings"
+# endif
+#endif
+
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"

--- a/src/rviz/default_plugin/camera_display.cpp
+++ b/src/rviz/default_plugin/camera_display.cpp
@@ -29,6 +29,13 @@
 
 #include <boost/bind.hpp>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-W#warnings"
+# endif
+#endif
+
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreRectangle2D.h>
@@ -41,6 +48,9 @@
 #include <OgreTechnique.h>
 #include <OgreCamera.h>
 
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include <tf2_ros/message_filter.h>
 

--- a/src/rviz/default_plugin/camera_display.cpp
+++ b/src/rviz/default_plugin/camera_display.cpp
@@ -41,7 +41,8 @@
 #include <OgreTechnique.h>
 #include <OgreCamera.h>
 
-#include <tf/transform_listener.h>
+
+#include <tf2_ros/message_filter.h>
 
 #include "rviz/bit_allocator.h"
 #include "rviz/frame_manager.h"
@@ -82,7 +83,7 @@ CameraDisplay::CameraDisplay()
   : ImageDisplayBase()
   , texture_()
   , render_panel_( 0 )
-  , caminfo_tf_filter_( 0 )
+  , caminfo_tf_filter_( nullptr )
   , new_caminfo_( false )
   , force_render_( false )
   , caminfo_ok_(false)
@@ -127,8 +128,6 @@ CameraDisplay::~CameraDisplay()
     bg_scene_node_->getParentSceneNode()->removeAndDestroyChild( bg_scene_node_->getName() );
     fg_scene_node_->getParentSceneNode()->removeAndDestroyChild( fg_scene_node_->getName() );
 
-    delete caminfo_tf_filter_;
-
     context_->visibilityBits()->freeBits(vis_bit_);
   }
 }
@@ -137,8 +136,12 @@ void CameraDisplay::onInitialize()
 {
   ImageDisplayBase::onInitialize();
 
-  caminfo_tf_filter_ = new tf::MessageFilter<sensor_msgs::CameraInfo>( *context_->getTFClient(), fixed_frame_.toStdString(),
-                                                                       queue_size_property_->getInt(), update_nh_ );
+  caminfo_tf_filter_.reset(new tf2_ros::MessageFilter<sensor_msgs::CameraInfo>(
+    *context_->getTF2BufferPtr(),
+    fixed_frame_.toStdString(),
+    queue_size_property_->getInt(),
+    update_nh_
+  ));
 
   bg_scene_node_ = scene_node_->createChildSceneNode();
   fg_scene_node_ = scene_node_->createChildSceneNode();

--- a/src/rviz/default_plugin/camera_display.h
+++ b/src/rviz/default_plugin/camera_display.h
@@ -30,6 +30,8 @@
 #ifndef RVIZ_CAMERA_DISPLAY_H
 #define RVIZ_CAMERA_DISPLAY_H
 
+#include <memory>
+
 #include <QObject>
 
 #ifndef Q_MOC_RUN
@@ -40,7 +42,7 @@
 # include <sensor_msgs/CameraInfo.h>
 
 # include <message_filters/subscriber.h>
-# include <tf/message_filter.h>
+# include <tf2_ros/message_filter.h>
 
 # include "rviz/image/image_display_base.h"
 # include "rviz/image/ros_image_texture.h"
@@ -126,7 +128,7 @@ private:
   Ogre::MaterialPtr fg_material_;
 
   message_filters::Subscriber<sensor_msgs::CameraInfo> caminfo_sub_;
-  tf::MessageFilter<sensor_msgs::CameraInfo>* caminfo_tf_filter_;
+  std::unique_ptr<tf2_ros::MessageFilter<sensor_msgs::CameraInfo>> caminfo_tf_filter_;
 
   FloatProperty* alpha_property_;
   EnumProperty* image_position_property_;

--- a/src/rviz/default_plugin/depth_cloud_display.cpp
+++ b/src/rviz/default_plugin/depth_cloud_display.cpp
@@ -39,7 +39,7 @@
 #include "rviz/properties/int_property.h"
 #include "rviz/frame_manager.h"
 
-#include <tf/transform_listener.h>
+#include <tf2_ros/buffer.h>
 
 #include <boost/bind.hpp>
 #include <boost/algorithm/string/erase.hpp>
@@ -310,8 +310,13 @@ void DepthCloudDisplay::subscribe()
       // subscribe to depth map topic
       depthmap_sub_->subscribe(*depthmap_it_, depthmap_topic, queue_size_,  image_transport::TransportHints(depthmap_transport));
 
-      depthmap_tf_filter_.reset(
-          new tf::MessageFilter<sensor_msgs::Image>(*depthmap_sub_, *context_->getTFClient(), fixed_frame_.toStdString(), queue_size_, threaded_nh_));
+      depthmap_tf_filter_.reset(new tf2_ros::MessageFilter<sensor_msgs::Image>(
+        *depthmap_sub_,
+        *context_->getTF2BufferPtr(),
+        fixed_frame_.toStdString(),
+        queue_size_,
+        threaded_nh_
+      ));
 
       // subscribe to CameraInfo  topic
       std::string info_topic = image_transport::getCameraInfoTopic(depthmap_topic);

--- a/src/rviz/default_plugin/depth_cloud_display.h
+++ b/src/rviz/default_plugin/depth_cloud_display.h
@@ -40,7 +40,7 @@
 # include <message_filters/subscriber.h>
 # include <message_filters/synchronizer.h>
 # include <message_filters/sync_policies/approximate_time.h>
-# include <tf/message_filter.h>
+# include <tf2_ros/message_filter.h>
 
 # include "rviz/properties/enum_property.h"
 # include "rviz/properties/float_property.h"
@@ -181,7 +181,7 @@ protected:
   // ROS image subscription & synchronization
   boost::scoped_ptr<image_transport::ImageTransport> depthmap_it_;
   boost::shared_ptr<image_transport::SubscriberFilter > depthmap_sub_;
-  boost::shared_ptr<tf::MessageFilter<sensor_msgs::Image> > depthmap_tf_filter_;
+  boost::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::Image> > depthmap_tf_filter_;
   boost::scoped_ptr<image_transport::ImageTransport> rgb_it_;
   boost::shared_ptr<image_transport::SubscriberFilter > rgb_sub_;
   boost::shared_ptr<message_filters::Subscriber<sensor_msgs::CameraInfo> > cam_info_sub_;

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -1,8 +1,6 @@
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 
-#include <tf/transform_listener.h>
-
 #include <rviz/visualization_manager.h>
 #include <rviz/properties/color_property.h>
 #include <rviz/properties/float_property.h>

--- a/src/rviz/default_plugin/effort_display.h
+++ b/src/rviz/default_plugin/effort_display.h
@@ -544,12 +544,33 @@ public:
 
   virtual void onInitialize()
     {
-      tf_filter_ = new tf::MessageFilterJointState( *context_->getTFClient(),
+    	// TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+		  auto tf_client = context_->getTFClient();
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+      tf_filter_ = new tf::MessageFilterJointState( *tf_client,
                                                     fixed_frame_.toStdString(), 10, update_nh_ );
 
       tf_filter_->connectInput( sub_ );
       tf_filter_->registerCallback( boost::bind( &MessageFilterJointStateDisplay::incomingMessage, this, _1 ));
+     	// TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
       context_->getFrameManager()->registerFilterForTransformStatusCheck( tf_filter_, this );
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
     }
 
   virtual ~MessageFilterJointStateDisplay()

--- a/src/rviz/default_plugin/grid_cells_display.cpp
+++ b/src/rviz/default_plugin/grid_cells_display.cpp
@@ -29,11 +29,24 @@
 
 #include <boost/bind.hpp>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+# endif
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 #include <OgreManualObject.h>
 #include <OgreBillboardSet.h>
 
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "rviz/frame_manager.h"
 #include "rviz/ogre_helpers/arrow.h"

--- a/src/rviz/default_plugin/grid_cells_display.cpp
+++ b/src/rviz/default_plugin/grid_cells_display.cpp
@@ -34,7 +34,6 @@
 #include <OgreManualObject.h>
 #include <OgreBillboardSet.h>
 
-#include <tf/transform_listener.h>
 
 #include "rviz/frame_manager.h"
 #include "rviz/ogre_helpers/arrow.h"
@@ -73,8 +72,23 @@ GridCellsDisplay::GridCellsDisplay()
 
 void GridCellsDisplay::onInitialize()
 {
-  tf_filter_ = new tf::MessageFilter<nav_msgs::GridCells>( *context_->getTFClient(), fixed_frame_.toStdString(),
-                                                           10, update_nh_ );
+  // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+  auto tf_client = context_->getTFClient();
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
+  tf_filter_ = new tf::MessageFilter<nav_msgs::GridCells>(
+    *tf_client,
+    fixed_frame_.toStdString(),
+    10,
+    update_nh_);
   static int count = 0;
   std::stringstream ss;
   ss << "PolyLine" << count++;
@@ -88,7 +102,17 @@ void GridCellsDisplay::onInitialize()
 
   tf_filter_->connectInput( sub_ );
   tf_filter_->registerCallback( boost::bind( &GridCellsDisplay::incomingMessage, this, _1 ));
+// TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
   context_->getFrameManager()->registerFilterForTransformStatusCheck( tf_filter_, this );
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 GridCellsDisplay::~GridCellsDisplay()

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -42,7 +42,6 @@
 #include <OgreTechnique.h>
 #include <OgreCamera.h>
 
-#include <tf/transform_listener.h>
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -29,6 +29,16 @@
 
 #include <boost/bind.hpp>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+# endif
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreRectangle2D.h>
@@ -42,6 +52,9 @@
 #include <OgreTechnique.h>
 #include <OgreCamera.h>
 
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
@@ -188,6 +201,8 @@ void ImageDisplay::clear()
 
 void ImageDisplay::update( float wall_dt, float ros_dt )
 {
+  Q_UNUSED(wall_dt)
+  Q_UNUSED(ros_dt)
   try
   {
     texture_.update();

--- a/src/rviz/default_plugin/interactive_marker_display.cpp
+++ b/src/rviz/default_plugin/interactive_marker_display.cpp
@@ -106,7 +106,17 @@ InteractiveMarkerDisplay::InteractiveMarkerDisplay()
 
 void InteractiveMarkerDisplay::onInitialize()
 {
+  // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
   tf::Transformer* tf = context_->getFrameManager()->getTFClient();
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   im_client_.reset( new interactive_markers::InteractiveMarkerClient( *tf, fixed_frame_.toStdString() ) );
 
   im_client_->setInitCb( boost::bind( &InteractiveMarkerDisplay::initCb, this, _1 ) );

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
@@ -315,8 +315,18 @@ void InteractiveMarker::updateReferencePose()
     else
     {
       std::string error;
+      // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
       int retval = context_->getFrameManager()->getTFClient()->getLatestCommonTime(
           reference_frame_, fixed_frame, reference_time_, &error );
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
       if ( retval != tf::NO_ERROR )
       {
         std::ostringstream s;

--- a/src/rviz/default_plugin/laser_scan_display.cpp
+++ b/src/rviz/default_plugin/laser_scan_display.cpp
@@ -94,7 +94,18 @@ void LaserScanDisplay::processMessage( const sensor_msgs::LaserScanConstPtr& sca
 
   try
   {
-    projector_->transformLaserScanToPointCloud( fixed_frame_.toStdString(), *scan, *cloud, *context_->getTFClient(),
+    // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+    auto tf_client = context_->getTFClient();
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+    projector_->transformLaserScanToPointCloud( fixed_frame_.toStdString(), *scan, *cloud, *tf_client,
                                                 laser_geometry::channel_option::Intensity );
   }
   catch (tf::TransformException& e)

--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -39,8 +39,6 @@
 
 #include <ros/ros.h>
 
-#include <tf/transform_listener.h>
-
 #include "rviz/frame_manager.h"
 #include "rviz/ogre_helpers/custom_parameter_indices.h"
 #include "rviz/ogre_helpers/grid.h"

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -73,7 +73,18 @@ MarkerDisplay::MarkerDisplay()
 
 void MarkerDisplay::onInitialize()
 {
-  tf_filter_ = new tf::MessageFilter<visualization_msgs::Marker>( *context_->getTFClient(),
+  // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+  auto tf_client = context_->getTFClient();
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+  tf_filter_ = new tf::MessageFilter<visualization_msgs::Marker>( *tf_client,
                                                                   fixed_frame_.toStdString(),
                                                                   queue_size_property_->getInt(),
                                                                   update_nh_ );
@@ -272,7 +283,21 @@ void MarkerDisplay::failedMarker(const ros::MessageEvent<visualization_msgs::Mar
     return this->processMessage(marker);
   }
   std::string authority = marker_evt.getPublisherName();
-  std::string error = context_->getFrameManager()->discoverFailureReason(marker->header.frame_id, marker->header.stamp, authority, reason);
+// TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+  std::string error = context_->getFrameManager()->discoverFailureReason(
+    marker->header.frame_id,
+    marker->header.stamp,
+    authority,
+    reason);
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   setMarkerStatus(MarkerID(marker->ns, marker->id), StatusProperty::Error, error);
 }
 

--- a/src/rviz/default_plugin/markers/arrow_marker.cpp
+++ b/src/rviz/default_plugin/markers/arrow_marker.cpp
@@ -33,8 +33,6 @@
 #include <OgreSceneManager.h>
 #include <OgreEntity.h>
 
-#include <tf/transform_listener.h>
-
 #include "rviz/default_plugin/marker_display.h"
 #include "rviz/default_plugin/markers/marker_selection_handler.h"
 #include "rviz/display_context.h"

--- a/src/rviz/default_plugin/markers/marker_base.cpp
+++ b/src/rviz/default_plugin/markers/marker_base.cpp
@@ -40,9 +40,6 @@
 #include <OgreSubEntity.h>
 #include <OgreSharedPtr.h>
 
-#include <tf/tf.h>
-#include <tf/transform_listener.h>
-
 namespace rviz
 {
 

--- a/src/rviz/default_plugin/odometry_display.h
+++ b/src/rviz/default_plugin/odometry_display.h
@@ -38,7 +38,6 @@
 
 #ifndef Q_MOC_RUN
 #include <message_filters/subscriber.h>
-#include <tf/message_filter.h>
 #endif
 
 #include "rviz/message_filter_display.h"

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -35,8 +35,6 @@
 #include <OgreBillboardSet.h>
 #include <OgreMatrix4.h>
 
-#include <tf/transform_listener.h>
-
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
 #include "rviz/properties/enum_property.h"

--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -35,8 +35,6 @@
 
 #include <ros/time.h>
 
-#include <tf/transform_listener.h>
-
 #include <pluginlib/class_loader.hpp>
 
 #include "rviz/default_plugin/point_cloud_transformer.h"

--- a/src/rviz/default_plugin/point_cloud_display.cpp
+++ b/src/rviz/default_plugin/point_cloud_display.cpp
@@ -32,8 +32,6 @@
 
 #include <ros/time.h>
 
-#include <tf/transform_listener.h>
-
 #include "rviz/default_plugin/point_cloud_common.h"
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"

--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -33,8 +33,6 @@
 #include <tinyxml.h>
 #include <urdf/model.h>
 
-#include <tf/transform_listener.h>
-
 #include "rviz/display_context.h"
 #include "rviz/robot/robot.h"
 #include "rviz/robot/tf_link_updater.h"

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -368,7 +368,17 @@ void TFDisplay::updateFrames()
 {
   typedef std::vector<std::string> V_string;
   V_string frames;
+  // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
   context_->getTFClient()->getFrameStrings( frames );
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   std::sort(frames.begin(), frames.end());
 
   S_FrameInfo current_frames;
@@ -494,7 +504,17 @@ Ogre::ColourValue lerpColor(const Ogre::ColourValue& start, const Ogre::ColourVa
 
 void TFDisplay::updateFrame( FrameInfo* frame )
 {
+  // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
   tf::TransformListener* tf = context_->getTFClient();
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   // Check last received time so we can grey out/fade out frames that have stopped being published
   ros::Time latest_time;
@@ -617,7 +637,18 @@ void TFDisplay::updateFrame( FrameInfo* frame )
 
     tf::StampedTransform transform;
     try {
-      context_->getFrameManager()->getTFClientPtr()->lookupTransform(frame->parent_,frame->name_,ros::Time(0),transform);
+      // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+      auto tf_client = context_->getFrameManager()->getTFClientPtr();
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+      tf_client->lookupTransform(frame->parent_,frame->name_,ros::Time(0),transform);
     }
     catch(tf::TransformException& e)
     {

--- a/src/rviz/display_context.h
+++ b/src/rviz/display_context.h
@@ -29,7 +29,8 @@
 #ifndef DISPLAY_CONTEXT_H
 #define DISPLAY_CONTEXT_H
 
-#include <stdint.h> // for uint64_t
+#include <cstdint> // for uint64_t
+#include <memory>
 
 #include <QObject>
 #include <QString>
@@ -49,6 +50,11 @@ class CallbackQueueInterface;
 namespace tf
 {
 class TransformListener;
+}
+
+namespace tf2_ros
+{
+class Buffer;
 }
 
 namespace rviz
@@ -90,7 +96,11 @@ public:
   virtual FrameManager* getFrameManager() const = 0;
 
   /** @brief Convenience function: returns getFrameManager()->getTFClient(). */
+  [[deprecated("use getTF2BufferPtr() instead")]]
   virtual tf::TransformListener* getTFClient() const = 0;
+
+  /** @brief Convenience function: returns getFrameManager()->getTF2BufferPtr(). */
+  virtual std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() const = 0;
 
   /** @brief Return the fixed frame name. */
   virtual QString getFixedFrame() const = 0;

--- a/src/rviz/frame_manager.cpp
+++ b/src/rviz/frame_manager.cpp
@@ -101,17 +101,17 @@ void FrameManager::update()
 
 void FrameManager::setFixedFrame(const std::string& frame)
 {
-  bool emit = false;
+  bool should_emit = false;
   {
     boost::mutex::scoped_lock lock(cache_mutex_);
     if( fixed_frame_ != frame )
     {
       fixed_frame_ = frame;
       cache_.clear();
-      emit = true;
+      should_emit = true;
     }
   }
-  if( emit )
+  if( should_emit )
   {
     // This emission must be kept outside of the mutex lock to avoid deadlocks.
     Q_EMIT fixedFrameChanged();

--- a/src/rviz/frame_manager.cpp
+++ b/src/rviz/frame_manager.cpp
@@ -39,6 +39,20 @@
 namespace rviz
 {
 
+// TODO(wjwwood): remove this when deprecated interface is removed
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+FrameManager::FrameManager()
+: FrameManager(boost::shared_ptr<tf::TransformListener>())
+{}
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
 FrameManager::FrameManager(boost::shared_ptr<tf::TransformListener> tf)
 {
   if (!tf) tf_.reset(new tf::TransformListener(ros::NodeHandle(), ros::Duration(10*60), true));
@@ -323,9 +337,39 @@ std::string getTransformStatusName(const std::string& caller_id)
   return ss.str();
 }
 
-std::string FrameManager::discoverFailureReason(const std::string& frame_id, const ros::Time& stamp, const std::string& caller_id, tf::FilterFailureReason reason)
+std::string
+FrameManager::discoverFailureReason(
+  const std::string& frame_id,
+  const ros::Time& stamp,
+  const std::string& caller_id,
+  tf::FilterFailureReason reason)
 {
   if (reason == tf::filter_failure_reasons::OutTheBack)
+  {
+    std::stringstream ss;
+    ss << "Message removed because it is too old (frame=[" << frame_id << "], stamp=[" << stamp << "])";
+    return ss.str();
+  }
+  else
+  {
+    std::string error;
+    if (transformHasProblems(frame_id, stamp, error))
+    {
+      return error;
+    }
+  }
+
+  return "Unknown reason for transform failure";
+}
+
+std::string
+FrameManager::discoverFailureReason(
+  const std::string& frame_id,
+  const ros::Time& stamp,
+  const std::string& caller_id,
+  tf2_ros::FilterFailureReason reason)
+{
+  if (reason == tf2_ros::filter_failure_reasons::OutTheBack)
   {
     std::stringstream ss;
     ss << "Message removed because it is too old (frame=[" << frame_id << "], stamp=[" << stamp << "])";
@@ -349,11 +393,12 @@ void FrameManager::messageArrived( const std::string& frame_id, const ros::Time&
   display->setStatusStd( StatusProperty::Ok, getTransformStatusName( caller_id ), "Transform OK" );
 }
 
-void FrameManager::messageFailed( const std::string& frame_id, const ros::Time& stamp,
-                                  const std::string& caller_id, tf::FilterFailureReason reason, Display* display )
+void FrameManager::messageFailedImpl(
+  const std::string& caller_id,
+  const std::string& status_text,
+  Display* display)
 {
   std::string status_name = getTransformStatusName( caller_id );
-  std::string status_text = discoverFailureReason( frame_id, stamp, caller_id, reason );
 
   display->setStatusStd(StatusProperty::Error, status_name, status_text );
 }

--- a/src/rviz/frame_manager.h
+++ b/src/rviz/frame_manager.h
@@ -36,8 +36,20 @@
 
 #include <ros/time.h>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+# endif
+#endif
+
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include <boost/thread/mutex.hpp>
 

--- a/src/rviz/frame_manager.h
+++ b/src/rviz/frame_manager.h
@@ -45,11 +45,17 @@
 
 #ifndef Q_MOC_RUN
 #include <tf/message_filter.h>
+#include <tf2_ros/message_filter.h>
 #endif
 
 namespace tf
 {
 class TransformListener;
+}
+
+namespace tf2_ros
+{
+class Buffer;
 }
 
 namespace rviz
@@ -71,10 +77,24 @@ public:
     SyncApprox
   };
 
+  /// Default constructor, which will create a tf::TransformListener automatically.
+  FrameManager();
+
   /** @brief Constructor
    * @param tf a pointer to tf::TransformListener (should not be used anywhere else because of thread safety)
    */
-  FrameManager(boost::shared_ptr<tf::TransformListener> tf = boost::shared_ptr<tf::TransformListener>());
+  [[deprecated(
+    "This constructor signature will be removed in the next version. "
+    "If you still need to pass a boost::shared_ptr<tf::TransformListener>, "
+    "disable the warning explicitly. "
+    "When this constructor is removed, a new constructor with a single, "
+    "optional argument will take a std::pair<> containing a "
+    "std::shared_ptr<tf2_ros::Buffer> and a "
+    "std::shared_ptr<tf2_ros::TransformListener>. "
+    "However, that cannot occur until the use of tf::TransformListener is "
+    "removed internally."
+  )]]
+  explicit FrameManager(boost::shared_ptr<tf::TransformListener> tf);
 
   /** @brief Destructor.
    *
@@ -171,20 +191,44 @@ public:
    * based on success or failure of the filter, including appropriate
    * error messages. */
   template<class M>
+  [[deprecated("use a tf2_ros::MessageFilter instead")]]
   void registerFilterForTransformStatusCheck(tf::MessageFilter<M>* filter, Display* display)
   {
     filter->registerCallback(boost::bind(&FrameManager::messageCallback<M>, this, _1, display));
-    filter->registerFailureCallback(boost::bind(&FrameManager::failureCallback<M>, this, _1, _2, display));
+    filter->registerFailureCallback(boost::bind(
+      &FrameManager::failureCallback<M, tf::FilterFailureReason>, this, _1, _2, display
+    ));
+  }
+
+  /** Connect success and failure callbacks to a tf2_ros::MessageFilter.
+   * @param filter The tf2_ros::MessageFilter to connect to.
+   * @param display The Display using the filter.
+   *
+   * FrameManager has internal functions for handling success and
+   * failure of tf2_ros::MessageFilters which call Display::setStatus()
+   * based on success or failure of the filter, including appropriate
+   * error messages. */
+  template<class M>
+  void registerFilterForTransformStatusCheck(tf2_ros::MessageFilter<M>* filter, Display* display)
+  {
+    filter->registerCallback(boost::bind(&FrameManager::messageCallback<M>, this, _1, display));
+    filter->registerFailureCallback(boost::bind(
+      &FrameManager::failureCallback<M, tf2_ros::FilterFailureReason>, this, _1, _2, display
+    ));
   }
 
   /** @brief Return the current fixed frame name. */
   const std::string& getFixedFrame() { return fixed_frame_; }
 
   /** @brief Return the tf::TransformListener used to receive transform data. */
+  [[deprecated("use getTF2BufferPtr() instead")]]
   tf::TransformListener* getTFClient() { return tf_.get(); }
 
   /** @brief Return a boost shared pointer to the tf::TransformListener used to receive transform data. */
+  [[deprecated("use getTF2BufferPtr() instead")]]
   const boost::shared_ptr<tf::TransformListener>& getTFClientPtr() { return tf_; }
+
+  const std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() { return tf_->getTF2BufferPtr(); }
 
   /** @brief Create a description of a transform problem.
    * @param frame_id The name of the frame with issues.
@@ -195,10 +239,26 @@ public:
    *
    * Once a problem has been detected with a given frame or transform,
    * call this to get an error message describing the problem. */
+  [[deprecated("used tf2 version instead")]]
   std::string discoverFailureReason(const std::string& frame_id,
                                     const ros::Time& stamp,
                                     const std::string& caller_id,
                                     tf::FilterFailureReason reason);
+
+  /** Create a description of a transform problem.
+   * @param frame_id The name of the frame with issues.
+   * @param stamp The time for which the problem was detected.
+   * @param caller_id Dummy parameter, not used.
+   * @param reason The reason given by the tf2_ros::MessageFilter in its failure callback.
+   * @return An error message describing the problem.
+   *
+   * Once a problem has been detected with a given frame or transform,
+   * call this to get an error message describing the problem. */
+  std::string discoverFailureReason(
+    const std::string& frame_id,
+    const ros::Time& stamp,
+    const std::string& caller_id,
+    tf2_ros::FilterFailureReason reason);
 
 Q_SIGNALS:
   /** @brief Emitted whenever the fixed frame changes. */
@@ -217,8 +277,11 @@ private:
     messageArrived(msg->header.frame_id, msg->header.stamp, authority, display);
   }
 
-  template<class M>
-  void failureCallback(const ros::MessageEvent<M const>& msg_evt, tf::FilterFailureReason reason, Display* display)
+  template<class M, class TfFilterFailureReasonType>
+  void failureCallback(
+    const ros::MessageEvent<M const>& msg_evt,
+    TfFilterFailureReasonType reason,
+    Display* display)
   {
     boost::shared_ptr<M const> const &msg = msg_evt.getConstMessage();
     std::string authority = msg_evt.getPublisherName();
@@ -227,7 +290,34 @@ private:
   }
 
   void messageArrived(const std::string& frame_id, const ros::Time& stamp, const std::string& caller_id, Display* display);
-  void messageFailed(const std::string& frame_id, const ros::Time& stamp, const std::string& caller_id, tf::FilterFailureReason reason, Display* display);
+
+  void messageFailedImpl(
+    const std::string& caller_id,
+    const std::string& status_text,
+    Display* display);
+
+  template<class TfFilterFailureReasonType>
+  void messageFailed(
+    const std::string& frame_id,
+    const ros::Time& stamp,
+    const std::string& caller_id,
+    TfFilterFailureReasonType reason,
+    Display* display)
+  {
+    // TODO(wjwwood): remove this when only Tf2 is supported
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+    std::string status_text = discoverFailureReason( frame_id, stamp, caller_id, reason );
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
+    messageFailedImpl(caller_id, status_text, display);
+  }
 
   struct CacheKey
   {

--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -176,7 +176,13 @@ void ImageDisplayBase::subscribe()
       }
       else
       {
-        tf_filter_.reset( new tf::MessageFilter<sensor_msgs::Image>(*sub_, (tf::Transformer&)*(context_->getTFClient()), targetFrame_, (uint32_t)queue_size_property_->getInt(), update_nh_));
+        tf_filter_.reset(new tf2_ros::MessageFilter<sensor_msgs::Image>(
+          *sub_,
+          *context_->getTF2BufferPtr(),
+          targetFrame_,
+          queue_size_property_->getInt(),
+          update_nh_
+        ));
         tf_filter_->registerCallback(boost::bind(&ImageDisplayBase::incomingMessage, this, _1));
       }
     }

--- a/src/rviz/image/image_display_base.h
+++ b/src/rviz/image/image_display_base.h
@@ -33,7 +33,7 @@
 
 #ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
 # include <message_filters/subscriber.h>
-# include <tf/message_filter.h>
+# include <tf2_ros/message_filter.h>
 # include <sensor_msgs/Image.h>
 
 # include <image_transport/image_transport.h>
@@ -53,7 +53,7 @@ namespace rviz
 /** @brief Display subclass for subscribing and displaying to image messages.
  *
  * This class brings together some common things used for subscribing and displaying image messages in Display
- * types.  It has a tf::MessageFilter and image_tranport::SubscriberFilter to filter incoming image messages, and
+ * types.  It has a tf2_ros::MessageFilter and image_tranport::SubscriberFilter to filter incoming image messages, and
  * it handles subscribing and unsubscribing when the display is
  * enabled or disabled.  */
 
@@ -111,7 +111,7 @@ protected:
 
   boost::scoped_ptr<image_transport::ImageTransport> it_;
   boost::shared_ptr<image_transport::SubscriberFilter> sub_;
-  boost::shared_ptr<tf::MessageFilter<sensor_msgs::Image> > tf_filter_;
+  boost::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::Image> > tf_filter_;
 
   std::string targetFrame_;
 

--- a/src/rviz/message_filter_display.h
+++ b/src/rviz/message_filter_display.h
@@ -34,7 +34,7 @@
 #include <OgreSceneNode.h>
 
 #include <message_filters/subscriber.h>
-#include <tf/message_filter.h>
+#include <tf2_ros/message_filter.h>
 #endif
 
 #include "rviz/display_context.h"
@@ -72,10 +72,10 @@ protected:
   BoolProperty* unreliable_property_;
 };
 
-/** @brief Display subclass using a tf::MessageFilter, templated on the ROS message type.
+/** @brief Display subclass using a tf2_ros::MessageFilter, templated on the ROS message type.
  *
  * This class brings together some common things used in many Display
- * types.  It has a tf::MessageFilter to filter incoming messages, and
+ * types.  It has a tf2_ros::MessageFilter to filter incoming messages, and
  * it handles subscribing and unsubscribing when the display is
  * enabled or disabled.  It also has an Ogre::SceneNode which  */
 template<class MessageType>
@@ -98,8 +98,11 @@ public:
 
   virtual void onInitialize()
     {
-      tf_filter_ = new tf::MessageFilter<MessageType>( *context_->getTFClient(),
-                                                       fixed_frame_.toStdString(), 10, update_nh_ );
+      tf_filter_ = new tf2_ros::MessageFilter<MessageType>(
+        *context_->getTF2BufferPtr(),
+        fixed_frame_.toStdString(),
+        10,
+        update_nh_);
 
       tf_filter_->connectInput( sub_ );
       tf_filter_->registerCallback( boost::bind( &MessageFilterDisplay<MessageType>::incomingMessage, this, _1 ));
@@ -201,7 +204,7 @@ protected:
   virtual void processMessage( const typename MessageType::ConstPtr& msg ) = 0;
 
   message_filters::Subscriber<MessageType> sub_;
-  tf::MessageFilter<MessageType>* tf_filter_;
+  tf2_ros::MessageFilter<MessageType>* tf_filter_;
   uint32_t messages_received_;
 };
 

--- a/src/rviz/ogre_helpers/point_cloud.h
+++ b/src/rviz/ogre_helpers/point_cloud.h
@@ -30,6 +30,16 @@
 #ifndef OGRE_TOOLS_OGRE_POINT_CLOUD_H
 #define OGRE_TOOLS_OGRE_POINT_CLOUD_H
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+# endif
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 #include <OgreSimpleRenderable.h>
 #include <OgreMovableObject.h>
 #include <OgreString.h>
@@ -40,6 +50,10 @@
 #include <OgreRoot.h>
 #include <OgreHardwareBufferManager.h>
 #include <OgreSharedPtr.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include <stdint.h>
 
@@ -68,7 +82,17 @@ public:
   PointCloudRenderable(PointCloud* parent, int num_points, bool use_tex_coords);
   ~PointCloudRenderable();
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+
   Ogre::RenderOperation* getRenderOperation() { return &mRenderOp; }
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
   Ogre::HardwareVertexBufferSharedPtr getBuffer();
 
   virtual Ogre::Real getBoundingRadius(void) const;

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -50,10 +50,21 @@
 #include <ros/package.h> // This dependency should be moved out of here, it is just used for a search path.
 #include <ros/console.h>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-W#warnings"
+# endif
+#endif
+
 #include <OgreRenderWindow.h>
 #include <OgreSceneManager.h>
 #if ((OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 9) || OGRE_VERSION_MAJOR >= 2 )
 #include <OgreOverlaySystem.h>
+#endif
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
 #endif
 
 #include "rviz/env_config.h"

--- a/src/rviz/ogre_helpers/render_system.h
+++ b/src/rviz/ogre_helpers/render_system.h
@@ -29,8 +29,19 @@
 #ifndef RENDER_SYSTEM_H
 #define RENDER_SYSTEM_H
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-W#warnings"
+# endif
+#endif
+
 #include <OgreRoot.h>
 #include <stdint.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 namespace Ogre
 {

--- a/src/rviz/properties/tf_frame_property.cpp
+++ b/src/rviz/properties/tf_frame_property.cpp
@@ -86,7 +86,17 @@ void TfFrameProperty::setFrameManager( FrameManager* frame_manager )
 void TfFrameProperty::fillFrameList()
 {
   std::vector<std::string> std_frames;
+  // TODO(wjwwood): remove this and use tf2 interface instead
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
   frame_manager_->getTFClient()->getFrameStrings( std_frames );
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   std::sort( std_frames.begin(), std_frames.end() );
 
   clearOptions();

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -146,7 +146,16 @@ VisualizationManager::VisualizationManager(
   // visibility_bit_allocator_ is listed after default_visibility_bit_ (and thus initialized later be default):
   default_visibility_bit_ = visibility_bit_allocator_.allocBit();
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
   frame_manager_ = new FrameManager(tf);
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   render_panel->setAutoRender(false);
 

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -117,7 +117,21 @@ public:
   boost::mutex render_mutex_;
 };
 
-VisualizationManager::VisualizationManager( RenderPanel* render_panel, WindowManagerInterface* wm, boost::shared_ptr<tf::TransformListener> tf )
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+VisualizationManager::VisualizationManager(RenderPanel* render_panel, WindowManagerInterface * wm)
+: VisualizationManager(render_panel, wm, boost::shared_ptr<tf::TransformListener>())
+{}
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
+VisualizationManager::VisualizationManager(
+  RenderPanel* render_panel,
+  WindowManagerInterface* wm,
+  boost::shared_ptr<tf::TransformListener> tf)
 : ogre_root_( Ogre::Root::getSingletonPtr() )
 , update_timer_(0)
 , shutting_down_(false)
@@ -422,6 +436,11 @@ void VisualizationManager::updateFrames()
 tf::TransformListener* VisualizationManager::getTFClient() const
 {
   return frame_manager_->getTFClient();
+}
+
+std::shared_ptr<tf2_ros::Buffer> VisualizationManager::getTF2BufferPtr() const
+{
+  return frame_manager_->getTF2BufferPtr();
 }
 
 void VisualizationManager::resetTime()

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -407,7 +407,14 @@ void VisualizationManager::updateFrames()
 {
   typedef std::vector<std::string> V_string;
   V_string frames;
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   frame_manager_->getTFClient()->getFrameStrings( frames );
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   // Check the fixed frame to see if it's ok
   std::string error;
@@ -435,7 +442,14 @@ void VisualizationManager::updateFrames()
 
 tf::TransformListener* VisualizationManager::getTFClient() const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return frame_manager_->getTFClient();
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 std::shared_ptr<tf2_ros::Buffer> VisualizationManager::getTF2BufferPtr() const
@@ -446,7 +460,14 @@ std::shared_ptr<tf2_ros::Buffer> VisualizationManager::getTF2BufferPtr() const
 void VisualizationManager::resetTime()
 {
   root_display_group_->reset();
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   frame_manager_->getTFClient()->clear();
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   ros_time_begin_ = ros::Time();
   wall_clock_begin_ = ros::WallTime();

--- a/src/rviz/visualization_manager.h
+++ b/src/rviz/visualization_manager.h
@@ -109,7 +109,25 @@ public:
    *        VisualizationFrame, the top-level container widget of rviz).
    * @param tf a pointer to tf::TransformListener which will be internally used by FrameManager.
    */
-  VisualizationManager( RenderPanel* render_panel, WindowManagerInterface* wm = 0, boost::shared_ptr<tf::TransformListener> tf = boost::shared_ptr<tf::TransformListener>() );
+  explicit VisualizationManager(
+    RenderPanel* render_panel,
+    WindowManagerInterface* wm = 0);
+
+  [[deprecated(
+    "This constructor signature will be removed in the next version. "
+    "If you still need to pass a boost::shared_ptr<tf::TransformListener>, "
+    "disable the warning explicitly. "
+    "When this constructor is removed, a new optional argument will added to "
+    "the other constructor and it will take a std::pair<> containing a "
+    "std::shared_ptr<tf2_ros::Buffer> and a "
+    "std::shared_ptr<tf2_ros::TransformListener>. "
+    "However, that cannot occur until the use of tf::TransformListener is "
+    "removed internally."
+  )]]
+  VisualizationManager(
+    RenderPanel* render_panel,
+    WindowManagerInterface* wm,
+    boost::shared_ptr<tf::TransformListener> tf);
 
   /**
    * \brief Destructor
@@ -187,7 +205,13 @@ public:
   /**
    * @brief Convenience function: returns getFrameManager()->getTFClient().
    */
+  [[deprecated("use getTF2BufferPtr() instead")]]
   tf::TransformListener* getTFClient() const;
+
+  /**
+   * @brief Convenience function: returns getFrameManager()->getTF2BufferPtr().
+   */
+  std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() const;
 
   /**
    * @brief Returns the Ogre::SceneManager used for the main RenderPanel.


### PR DESCRIPTION
This pr deprecates all of the interfaces in rviz which I believe need to be so that in a future version we can drop the dependency on tf completely.

The two main places where interfaces are disabled are:

- `VisualizationManager`: b1bb6a2
- `FrameManager`: 7ee47f3

I migrated the `MessageFilterDisplay` which is a base class that many display plugins inherit from and therefore most of them will require no changes at all. I also migrated a couple other displays to show how it can be done, but I just suppressed the rest of the displays that produced deprecation warnings because I wanted to give an example of how to do that and because the work to convert them can be deferred until we actually remove the dependency on `tf` completely.

Examples of migrating to `tf2`:

- `MessageFilterDisplay`: 0f227e5
- Image related displays (image and camera): ffdfad0
- `DepthCloudDisplay`: 2dc400d

Examples of suppressing the deprecation warnings:

- `GridCellsDisplay`: 89b51e7
- `TFDisplay`: c7f6a4a

There are a few unrelated style/warnings related changes at the end, which I could separate if desired, but they're small and mostly only affect macOS.