### PR TITLE
Add a checkbox to toggle Tool keyboard shortcuts.

### DIFF
--- a/src/rviz/tool.h
+++ b/src/rviz/tool.h
@@ -160,6 +160,8 @@ public:
   const QCursor& getCursor() { return cursor_; }
 
   void setStatus( const QString & message );
+
+  bool access_all_keys_;
   
 Q_SIGNALS:
     void close();
@@ -175,7 +177,6 @@ protected:
   DisplayContext* context_;
 
   char shortcut_key_;
-  bool access_all_keys_;
 
   QIcon icon_;
 

--- a/src/rviz/tool_manager.cpp
+++ b/src/rviz/tool_manager.cpp
@@ -127,6 +127,14 @@ bool ToolManager::toKey( QString const& str, uint& key )
   }
 }
 
+void ToolManager::toggleKeyboardShortcuts()
+{
+  for( int i = 0; i < tools_.size(); i++ )
+  {
+    tools_[ i ]->access_all_keys_ = !tools_[ i ]->access_all_keys_;
+  }  
+}
+
 void ToolManager::handleChar( QKeyEvent* event, RenderPanel* panel )
 {
   // if the incoming key is ESC fallback to the default tool

--- a/src/rviz/tool_manager.h
+++ b/src/rviz/tool_manager.h
@@ -113,6 +113,8 @@ public:
 
   QStringList getToolClasses();
 
+  void toggleKeyboardShortcuts();
+
   void handleChar( QKeyEvent* event, RenderPanel* panel );
 
   PluginlibFactory<Tool>* getFactory() { return factory_; }

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -518,6 +518,11 @@ void VisualizationFrame::initToolbars()
   toolbar_->addWidget( remove_tool_button );
   connect( remove_tool_menu_, SIGNAL( triggered( QAction* )), this, SLOT( onToolbarRemoveTool( QAction* )));
 
+  toggle_shortcuts_box_ = new QCheckBox(this);
+  toggle_shortcuts_box_->setToolTip( "Toggle keyboard shortcuts" );
+  toggle_shortcuts_box_->setCheckState( Qt::CheckState(2) );
+  toolbar_->addWidget( toggle_shortcuts_box_ );
+  connect( toggle_shortcuts_box_, SIGNAL( toggled( bool ) ), this, SLOT( onToggleShortcuts() ) );
 }
 
 void VisualizationFrame::hideDockImpl( Qt::DockWidgetArea area, bool hide )
@@ -1113,6 +1118,13 @@ void VisualizationFrame::onToolbarRemoveTool( QAction* remove_tool_menu_action )
       return;
     }
   }
+}
+
+void VisualizationFrame::onToggleShortcuts()
+{
+  ToolManager* tool_man = manager_->getToolManager();
+
+  tool_man->toggleKeyboardShortcuts();
 }
 
 void VisualizationFrame::removeTool( Tool* tool )

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -30,6 +30,7 @@
 #ifndef RVIZ_VISUALIZATION_FRAME_H
 #define RVIZ_VISUALIZATION_FRAME_H
 
+#include <QCheckBox>
 #include <QMainWindow>
 #include <QList>
 
@@ -186,6 +187,9 @@ protected Q_SLOTS:
 
   /** @brief Remove a the tool whose name is given by remove_tool_menu_action->text(). */
   void onToolbarRemoveTool( QAction* remove_tool_menu_action );
+
+  /** @brief Toggle whether keyboard shortcuts are enabled or ignored. */
+  void onToggleShortcuts();
 
   /** @brief Looks up the Tool for this action and calls
    * VisualizationManager::setCurrentTool(). */
@@ -345,6 +349,7 @@ protected:
 
   QAction* add_tool_action_;
   QMenu* remove_tool_menu_;
+  QCheckBox* toggle_shortcuts_box_;
 
   bool initialized_;
   WidgetGeometryChangeDetector* geom_change_detector_;


### PR DESCRIPTION
We had an "incident" where a hotkey for another executable was 'g'. Of course, that's the same hotkey for sending a move_base command in RViz so the robot took off unexpectedly.

I'd like to allow hotkeys to be disabled for that reason.

By default, they will still be enabled, so this should be a transparent change for most users.