### PR TITLE
Fix compatibility with Ogre 1.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,6 @@ if (POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
-find_package(Boost REQUIRED
-  COMPONENTS
-  filesystem
-  program_options
-  signals
-  system
-  thread
-)
-
 find_package(urdfdom_headers REQUIRED)
 
 find_package(PkgConfig REQUIRED)
@@ -141,9 +132,14 @@ find_package(catkin REQUIRED
   urdfdom_headers
 )
 
+set(RVIZ_BOOST_COMPONENTS filesystem program_options system thread)
+
 if(${tf_VERSION} VERSION_LESS "1.11.3")
   add_definitions("-DRVIZ_USE_BOOST_SIGNAL_1")
+  list(APPEND RVIZ_BOOST_COMPONENTS signals)
 endif()
+
+find_package(Boost REQUIRED COMPONENTS ${RVIZ_BOOST_COMPONENTS})
 
 find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 

--- a/ogre_media/fonts/liberation_sans.fontdef
+++ b/ogre_media/fonts/liberation_sans.fontdef
@@ -1,4 +1,4 @@
-Liberation Sans
+font Liberation Sans
 {
   type truetype
   source liberation-sans/LiberationSans-Regular.ttf

--- a/ogre_media/materials/glsl120/glsl120.program
+++ b/ogre_media/materials/glsl120/glsl120.program
@@ -1,8 +1,8 @@
 
 //includes:
-fragment_program rviz/glsl120/include/circle_impl.frag glsl { source include/circle_impl.frag }
-fragment_program rviz/glsl120/include/pack_depth.frag glsl { source include/pack_depth.frag }
-vertex_program rviz/glsl120/include/pass_depth.vert glsl { source include/pass_depth.vert }
+fragment_program rviz/glsl120/include/circle_impl.frag glsl { source circle_impl.frag }
+fragment_program rviz/glsl120/include/pack_depth.frag glsl { source pack_depth.frag }
+vertex_program rviz/glsl120/include/pass_depth.vert glsl { source pass_depth.vert }
 
 //all shaders, sorted by name
 

--- a/ogre_media/materials/glsl120/nogp/nogp.program
+++ b/ogre_media/materials/glsl120/nogp/nogp.program
@@ -4,7 +4,7 @@
 // and each one is offset according to its texture coords.
 
 //includes:
-vertex_program rviz/glsl120/nogp/pass_depth.vert glsl { source ../include/pass_depth.vert }
+vertex_program rviz/glsl120/nogp/pass_depth.vert glsl { source pass_depth.vert }
 
 vertex_program rviz/glsl120/nogp/billboard_tile.vert glsl
 {

--- a/src/image_view/image_view.cpp
+++ b/src/image_view/image_view.cpp
@@ -33,6 +33,7 @@
 
 #include "rviz/ogre_helpers/qt_ogre_render_window.h"
 #include "rviz/ogre_helpers/initialization.h"
+#include "rviz/ogre_helpers/set_material.h"
 #include "rviz/image/ros_image_texture.h"
 
 #include "ros/ros.h"
@@ -114,7 +115,7 @@ void ImageView::showEvent( QShowEvent* event )
 
   Ogre::Rectangle2D* rect = new Ogre::Rectangle2D(true);
   rect->setCorners(-1.0f, 1.0f, 1.0f, -1.0f);
-  rect->setMaterial(material->getName());
+  setMaterial(*rect, material);
   rect->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY - 1);
   Ogre::AxisAlignedBox aabb;
   aabb.setInfinite();

--- a/src/python_bindings/sip/CMakeLists.txt
+++ b/src/python_bindings/sip/CMakeLists.txt
@@ -36,6 +36,7 @@ set(rviz_sip_DEPENDENT_FILES
   ${rviz_HDRS_DIR}/yaml_config_writer.h
 )
 
+find_package(rviz REQUIRED)
 find_package(python_qt_binding REQUIRED)
 include(${python_qt_binding_EXTRAS_DIR}/sip_helper.cmake)
 

--- a/src/rviz/default_plugin/camera_display.cpp
+++ b/src/rviz/default_plugin/camera_display.cpp
@@ -57,6 +57,7 @@
 #include "rviz/bit_allocator.h"
 #include "rviz/frame_manager.h"
 #include "rviz/ogre_helpers/axes.h"
+#include "rviz/ogre_helpers/set_material.h"
 #include "rviz/properties/enum_property.h"
 #include "rviz/properties/float_property.h"
 #include "rviz/properties/int_property.h"
@@ -186,7 +187,7 @@ void CameraDisplay::onInitialize()
 
     bg_screen_rect_->setRenderQueueGroup(Ogre::RENDER_QUEUE_BACKGROUND);
     bg_screen_rect_->setBoundingBox(aabInf);
-    bg_screen_rect_->setMaterial(bg_material_->getName());
+    setMaterial(*bg_screen_rect_, bg_material_);
 
     bg_scene_node_->attachObject(bg_screen_rect_);
     bg_scene_node_->setVisible(false);
@@ -197,7 +198,7 @@ void CameraDisplay::onInitialize()
 
     fg_material_ = bg_material_->clone( ss.str()+"fg" );
     fg_screen_rect_->setBoundingBox(aabInf);
-    fg_screen_rect_->setMaterial(fg_material_->getName());
+    setMaterial(*fg_screen_rect_, fg_material_);
 
     fg_material_->setSceneBlending( Ogre::SBT_TRANSPARENT_ALPHA );
     fg_screen_rect_->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY - 1);

--- a/src/rviz/default_plugin/covariance_visual.cpp
+++ b/src/rviz/default_plugin/covariance_visual.cpp
@@ -267,17 +267,17 @@ CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::Sce
 CovarianceVisual::~CovarianceVisual()
 {
   delete position_shape_;
-  scene_manager_->destroySceneNode( position_node_->getName() );
+  scene_manager_->destroySceneNode( position_node_ );
 
   for(int i = 0; i < kNumOriShapes; i++)
   {
     delete orientation_shape_[i];
-    scene_manager_->destroySceneNode( orientation_offset_node_[i]->getName() );
+    scene_manager_->destroySceneNode( orientation_offset_node_[i] );
   }
 
-  scene_manager_->destroySceneNode( position_scale_node_->getName() );
-  scene_manager_->destroySceneNode( fixed_orientation_node_->getName() );
-  scene_manager_->destroySceneNode( root_node_->getName() );
+  scene_manager_->destroySceneNode( position_scale_node_ );
+  scene_manager_->destroySceneNode( fixed_orientation_node_ );
+  scene_manager_->destroySceneNode( root_node_ );
 }
 
 void CovarianceVisual::setCovariance( const geometry_msgs::PoseWithCovariance& pose )

--- a/src/rviz/default_plugin/effort_visual.h
+++ b/src/rviz/default_plugin/effort_visual.h
@@ -3,11 +3,7 @@
 
 #include <sensor_msgs/JointState.h>
 
-namespace Ogre
-{
-    class Vector3;
-    class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace urdf
 {

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -58,6 +58,7 @@
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
+#include "rviz/ogre_helpers/set_material.h"
 #include "rviz/render_panel.h"
 #include "rviz/validate_floats.h"
 
@@ -123,7 +124,7 @@ void ImageDisplay::onInitialize()
     Ogre::AxisAlignedBox aabInf;
     aabInf.setInfinite();
     screen_rect_->setBoundingBox(aabInf);
-    screen_rect_->setMaterial(material_->getName());
+    setMaterial(*screen_rect_, material_);
     img_scene_node_->attachObject(screen_rect_);
   }
 

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -150,7 +150,8 @@ ImageDisplay::~ImageDisplay()
   {
     delete render_panel_;
     delete screen_rect_;
-    img_scene_node_->getParentSceneNode()->removeAndDestroyChild( img_scene_node_->getName() );
+    img_scene_node_->getParentSceneNode()->removeChild( img_scene_node_ );
+    img_scene_node_->getCreator()->destroySceneNode(img_scene_node_);
   }
 }
 

--- a/src/rviz/default_plugin/markers/marker_base.h
+++ b/src/rviz/default_plugin/markers/marker_base.h
@@ -39,13 +39,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-namespace Ogre
-{
-class SceneNode;
-class Vector3;
-class Quaternion;
-class Entity;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -456,7 +456,7 @@ void PathDisplay::processMessage( const nav_msgs::Path::ConstPtr& msg )
   {
   case LINES:
     manual_object->estimateVertexCount( num_points );
-    manual_object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP );
+    manual_object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME );
     for( uint32_t i=0; i < num_points; ++i)
     {
       const geometry_msgs::Point& pos = msg->poses[ i ].pose.position;

--- a/src/rviz/default_plugin/point_visual.h
+++ b/src/rviz/default_plugin/point_visual.h
@@ -3,11 +3,7 @@
 
 #include <geometry_msgs/PointStamped.h>
 
-namespace Ogre
-{
-    class Vector3;
-    class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/polygon_display.cpp
+++ b/src/rviz/default_plugin/polygon_display.cpp
@@ -114,7 +114,7 @@ void PolygonDisplay::processMessage(const geometry_msgs::PolygonStamped::ConstPt
   if( num_points > 0 )
   {
     manual_object_->estimateVertexCount( num_points );
-    manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP );
+    manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME );
     for( uint32_t i=0; i < num_points + 1; ++i )
     {
       const geometry_msgs::Point32& msg_point = msg->polygon.points[ i % num_points ];

--- a/src/rviz/default_plugin/pose_array_display.cpp
+++ b/src/rviz/default_plugin/pose_array_display.cpp
@@ -196,7 +196,7 @@ void PoseArrayDisplay::updateArrows2d()
   float length = arrow2d_length_property_->getFloat();
   size_t num_poses = poses_.size();
   manual_object_->estimateVertexCount( num_poses * 6 );
-  manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_LIST );
+  manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_LIST, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME );
   for( size_t i=0; i < num_poses; ++i )
   {
     const Ogre::Vector3 & pos = poses_[i].position;

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -200,7 +200,7 @@ TFDisplay::~TFDisplay()
   if ( initialized() )
   {
     root_node_->removeAndDestroyAllChildren();
-    scene_manager_->destroySceneNode( root_node_->getName() );
+    scene_manager_->destroySceneNode( root_node_ );
   }
 }
 
@@ -733,7 +733,7 @@ void TFDisplay::deleteFrame( FrameInfo* frame, bool delete_properties )
   context_->getSelectionManager()->removeObject( frame->axes_coll_ );
   delete frame->parent_arrow_;
   delete frame->name_text_;
-  scene_manager_->destroySceneNode( frame->name_node_->getName() );
+  scene_manager_->destroySceneNode( frame->name_node_ );
   if( delete_properties )
   {
     delete frame->enabled_property_;

--- a/src/rviz/default_plugin/wrench_visual.h
+++ b/src/rviz/default_plugin/wrench_visual.h
@@ -3,11 +3,7 @@
 
 #include <geometry_msgs/Wrench.h>
 
-namespace Ogre
-{
-    class Vector3;
-    class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/geometry.h
+++ b/src/rviz/geometry.h
@@ -30,12 +30,7 @@
 #ifndef GEOMETRY_H
 #define GEOMETRY_H
 
-namespace Ogre
-{
-class Plane;
-class Vector3;
-class Vector2;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -378,7 +378,8 @@ void buildMesh( const aiScene* scene, const aiNode* node,
     }
     vbuf->unlock();
 
-    submesh->setMaterialName(material_table[input_mesh->mMaterialIndex]->getName());
+    Ogre::MaterialPtr const & material = material_table[input_mesh->mMaterialIndex];
+    submesh->setMaterialName(material->getName(), material->getGroup());
   }
 
   for (uint32_t i=0; i < node->mNumChildren; ++i)

--- a/src/rviz/ogre_helpers/arrow.cpp
+++ b/src/rviz/ogre_helpers/arrow.cpp
@@ -65,7 +65,7 @@ Arrow::~Arrow()
   delete shaft_;
   delete head_;
 
-  scene_manager_->destroySceneNode( scene_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
 }
 
 void Arrow::set( float shaft_length, float shaft_diameter, float head_length, float head_diameter )

--- a/src/rviz/ogre_helpers/arrow.h
+++ b/src/rviz/ogre_helpers/arrow.h
@@ -32,15 +32,13 @@
 #ifndef OGRE_TOOLS_ARROW_H
 #define OGRE_TOOLS_ARROW_H
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class SceneNode;
-class Vector3;
-class Quaternion;
-class ColourValue;
 class Any;
 }
+
 
 namespace rviz
 {

--- a/src/rviz/ogre_helpers/axes.cpp
+++ b/src/rviz/ogre_helpers/axes.cpp
@@ -63,7 +63,7 @@ Axes::~Axes()
   delete y_axis_;
   delete z_axis_;
 
-  scene_manager_->destroySceneNode( scene_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
 }
 
 void Axes::set( float length, float radius )

--- a/src/rviz/ogre_helpers/axes.h
+++ b/src/rviz/ogre_helpers/axes.h
@@ -37,14 +37,11 @@
 
 #include <vector>
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class ColourValue;
 }
 
 namespace rviz

--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -95,7 +95,7 @@ Ogre::BillboardChain* BillboardLine::createChain()
   static int count = 0;
   ss << "BillboardLine chain" << count++;
   Ogre::BillboardChain* chain = scene_manager_->createBillboardChain(ss.str());
-  chain->setMaterialName( material_->getName() );
+  chain->setMaterialName( material_->getName(), material_->getGroup() );
   scene_node_->attachObject( chain );
 
   chains_.push_back(chain);

--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -84,7 +84,7 @@ BillboardLine::~BillboardLine()
     scene_manager_->destroyBillboardChain(*it);
   }
 
-  scene_manager_->destroySceneNode( scene_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
 
   Ogre::MaterialManager::getSingleton().remove(material_->getName());
 }

--- a/src/rviz/ogre_helpers/grid.cpp
+++ b/src/rviz/ogre_helpers/grid.cpp
@@ -80,7 +80,7 @@ Grid::~Grid()
 {
   delete billboard_line_;
 
-  scene_manager_->destroySceneNode( scene_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
   scene_manager_->destroyManualObject( manual_object_ );
 
   material_->unload();

--- a/src/rviz/ogre_helpers/line.cpp
+++ b/src/rviz/ogre_helpers/line.cpp
@@ -73,7 +73,10 @@ Line::~Line()
   }
   scene_manager_->destroySceneNode(scene_node_);
   scene_manager_->destroyManualObject( manual_object_ );
-  Ogre::MaterialManager::getSingleton().remove(manual_object_material_->getName());
+  if (Ogre::MaterialManager::getSingleton().resourceExists(manual_object_material_->getName()))
+  {
+    Ogre::MaterialManager::getSingleton().remove(manual_object_material_->getName());
+  }
 }
 
 void Line::setPoints( Ogre::Vector3 start, Ogre::Vector3 end )

--- a/src/rviz/ogre_helpers/line.h
+++ b/src/rviz/ogre_helpers/line.h
@@ -35,15 +35,11 @@
 #include <OgreSceneNode.h>
 #include <OgreMaterial.h>
 #include <OgreSharedPtr.h>
+#include <OgrePrerequisites.h>
 
 namespace Ogre
 {
-class SceneManager;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class ColourValue;
 }
 
 namespace rviz

--- a/src/rviz/ogre_helpers/mesh_shape.cpp
+++ b/src/rviz/ogre_helpers/mesh_shape.cpp
@@ -127,7 +127,7 @@ void MeshShape::endTriangles()
     entity_ = scene_manager_->createEntity(name);
     if (entity_)
     {
-      entity_->setMaterialName(material_name_);
+      entity_->setMaterial(material_);
       offset_node_->attachObject(entity_);
     }
     else

--- a/src/rviz/ogre_helpers/object.h
+++ b/src/rviz/ogre_helpers/object.h
@@ -30,12 +30,10 @@
 #ifndef OGRE_TOOLS_OBJECT_H
 #define OGRE_TOOLS_OBJECT_H
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
 }
 

--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -48,6 +48,7 @@
 
 #include "rviz/ogre_helpers/custom_parameter_indices.h"
 #include "rviz/selection/forwards.h"
+#include "rviz/ogre_helpers/set_material.h"
 
 #define VERTEX_BUFFER_CAPACITY (36 * 1024 * 10)
 
@@ -337,7 +338,7 @@ void PointCloud::setRenderMode(RenderMode mode)
   V_PointCloudRenderable::iterator end = renderables_.end();
   for (; it != end; ++it)
   {
-    (*it)->setMaterial(current_material_->getName());
+    setMaterial(**it, current_material_);
   }
 
   regenerateAll();
@@ -765,7 +766,7 @@ void PointCloud::setPickColor(const Ogre::ColourValue& color)
 PointCloudRenderablePtr PointCloud::createRenderable( int num_points )
 {
   PointCloudRenderablePtr rend(new PointCloudRenderable(this, num_points, !current_mode_supports_geometry_shader_));
-  rend->setMaterial(current_material_->getName());
+  setMaterial(*rend, current_material_);
   Ogre::Vector4 size(width_, height_, depth_, 0.0f);
   Ogre::Vector4 alpha(alpha_, 0.0f, 0.0f, 0.0f);
   Ogre::Vector4 highlight(0.0f, 0.0f, 0.0f, 0.0f);

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -282,6 +282,7 @@ void RenderSystem::setupResources()
   Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/scripts", "FileSystem", ROS_PACKAGE_NAME );
   Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl120", "FileSystem", ROS_PACKAGE_NAME );
   Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl120/nogp", "FileSystem", ROS_PACKAGE_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl120/include", "FileSystem", ROS_PACKAGE_NAME );
   // Add resources that depend on a specific glsl version.
   // Unfortunately, Ogre doesn't have a notion of glsl versions so we can't go
   // the 'official' way of defining multiple schemes per material and let Ogre decide which one to use.

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -59,6 +59,7 @@
 
 #include <OgreRenderWindow.h>
 #include <OgreSceneManager.h>
+#include <OgreMaterialManager.h>
 #if ((OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 9) || OGRE_VERSION_MAJOR >= 2 )
 #include <OgreOverlaySystem.h>
 #endif
@@ -273,6 +274,12 @@ void RenderSystem::setupRenderSystem()
 
 void RenderSystem::setupResources()
 {
+  Ogre::ResourceGroupManager::getSingleton().createResourceGroup( ROS_PACKAGE_NAME );
+  // Add a BaseWhiteNoLighting to the rviz resource group too,
+  // since OGRE 1.11 doesn't look in other resource groups anymore,
+  // and .mesh files can't specify the resource group for a material.
+  Ogre::MaterialManager::getSingleton().create( "BaseWhiteNoLighting", ROS_PACKAGE_NAME )->setLightingEnabled( false );
+
   std::string rviz_path = ros::package::getPath(ROS_PACKAGE_NAME);
   Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media", "FileSystem", ROS_PACKAGE_NAME );
   Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/textures", "FileSystem", ROS_PACKAGE_NAME );

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -173,6 +173,9 @@ void RenderSystem::loadOgrePlugins()
   ogre_root_->loadPlugin( plugin_prefix + "RenderSystem_GL" );
   ogre_root_->loadPlugin( plugin_prefix + "Plugin_OctreeSceneManager" );
   ogre_root_->loadPlugin( plugin_prefix + "Plugin_ParticleFX" );
+#if OGRE_VERSION_MAJOR > 1 || (OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11)
+  ogre_root_->loadPlugin( plugin_prefix + "Codec_STBI" );
+#endif
 }
 
 void RenderSystem::detectGlVersion()

--- a/src/rviz/ogre_helpers/set_material.h
+++ b/src/rviz/ogre_helpers/set_material.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018, Fizyr BV
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OGRE_TOOLS_SET_MATERIAL_H
+#define OGRE_TOOLS_SET_MATERIAL_H
+
+#include <OgreSimpleRenderable.h>
+#include <OgreMaterialManager.h>
+
+#include <string>
+
+namespace rviz {
+
+/*
+ * This header allows setting the material of a renderable by either name or MaterialPtr
+ * across different versions of OGRE.
+ *
+ * OGRE 1.10 added:   renderable.setMaterial(const Ogre::MaterialPtr &)
+ * OGRE 1.11 removed: renderable.setMaterial(const std::string       &)
+ */
+
+#if OGRE_VERSION_MAJOR < 1 || (OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 10)
+inline void setMaterial(Ogre::SimpleRenderable & renderable, const std::string & material_name)
+{
+  renderable.setMaterial(material_name);
+}
+
+inline void setMaterial(Ogre::SimpleRenderable & renderable, const Ogre::MaterialPtr & material)
+{
+  renderable.setMaterial(material->getName());
+}
+#else
+inline void setMaterial(Ogre::SimpleRenderable & renderable, const std::string & material_name)
+{
+  Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().getByName(material_name);
+  // OGRE 1.11 also deprecated their own SharedPtr class and switched to std::shared_ptr.
+  // Checking for nullptr with .get() works in both versions.
+  if (!material.get())
+  {
+    OGRE_EXCEPT(Ogre::Exception::ERR_ITEM_NOT_FOUND, "Could not find material " + material_name, "SimpleRenderable::setMaterial");
+  }
+  renderable.setMaterial(material);
+}
+
+inline void setMaterial(Ogre::SimpleRenderable & renderable, const Ogre::MaterialPtr & material)
+{
+  renderable.setMaterial(material);
+}
+#endif
+
+}
+
+#endif

--- a/src/rviz/ogre_helpers/shape.cpp
+++ b/src/rviz/ogre_helpers/shape.cpp
@@ -102,7 +102,7 @@ Shape::Shape( Type type, Ogre::SceneManager* scene_manager, Ogre::SceneNode* par
   material_->getTechnique(0)->setAmbient( 0.5, 0.5, 0.5 );
 
   if (entity_)
-    entity_->setMaterialName(material_name_);
+    entity_->setMaterial(material_);
 
 #if (OGRE_VERSION_MAJOR <= 1 && OGRE_VERSION_MINOR <= 4)
   if (entity_)

--- a/src/rviz/ogre_helpers/shape.cpp
+++ b/src/rviz/ogre_helpers/shape.cpp
@@ -119,7 +119,10 @@ Shape::~Shape()
     scene_manager_->destroyEntity( entity_ );
 
   material_->unload();
-  Ogre::MaterialManager::getSingleton().remove(material_->getName());
+  if (Ogre::MaterialManager::getSingleton().resourceExists(material_->getName()))
+  {
+    Ogre::MaterialManager::getSingleton().remove(material_->getName());
+  }
 }
 
 void Shape::setColor(const Ogre::ColourValue& c)

--- a/src/rviz/ogre_helpers/shape.cpp
+++ b/src/rviz/ogre_helpers/shape.cpp
@@ -112,8 +112,8 @@ Shape::Shape( Type type, Ogre::SceneManager* scene_manager, Ogre::SceneNode* par
 
 Shape::~Shape()
 {
-  scene_manager_->destroySceneNode( scene_node_->getName() );
-  scene_manager_->destroySceneNode( offset_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
+  scene_manager_->destroySceneNode( offset_node_ );
 
   if (entity_)
     scene_manager_->destroyEntity( entity_ );

--- a/src/rviz/ogre_helpers/stl_loader.cpp
+++ b/src/rviz/ogre_helpers/stl_loader.cpp
@@ -233,7 +233,7 @@ void calculateUV(const Ogre::Vector3& vec, float& u, float& v)
 Ogre::MeshPtr STLLoader::toMesh(const std::string& name)
 {
   Ogre::ManualObject* object = new Ogre::ManualObject( "the one and only" );
-  object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST );
+  object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME );
 
   unsigned int vertexCount = 0;
   V_Triangle::const_iterator it = triangles_.begin();
@@ -245,7 +245,7 @@ Ogre::MeshPtr STLLoader::toMesh(const std::string& name)
       // Subdivide large meshes into submeshes with at most 2004
       // vertices to prevent problems on some graphics cards.
       object->end();
-      object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST );
+      object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME );
       vertexCount = 0;
     }
 

--- a/src/rviz/robot/link_updater.h
+++ b/src/rviz/robot/link_updater.h
@@ -33,11 +33,7 @@
 #include <string>
 #include "rviz/properties/status_property.h"
 
-namespace Ogre
-{
-class Vector3;
-class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -120,9 +120,9 @@ Robot::~Robot()
 {
   clear();
 
-  scene_manager_->destroySceneNode( root_visual_node_->getName() );
-  scene_manager_->destroySceneNode( root_collision_node_->getName() );
-  scene_manager_->destroySceneNode( root_other_node_->getName() );
+  scene_manager_->destroySceneNode( root_visual_node_ );
+  scene_manager_->destroySceneNode( root_collision_node_ );
+  scene_manager_->destroySceneNode( root_other_node_ );
   delete link_factory_;
 }
 

--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -41,16 +41,11 @@
 
 #include <urdf/model.h> // can be replaced later by urdf_model/types.h
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class Entity;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class RibbonTrail;
-class SceneNode;
 }
 
 namespace rviz

--- a/src/rviz/robot/robot_joint.h
+++ b/src/rviz/robot/robot_joint.h
@@ -48,16 +48,11 @@
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class Entity;
-class SubEntity;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class RibbonTrail;
 }
 
 namespace rviz

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -650,7 +650,7 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
 
       if (material_name == "BaseWhite" || material_name == "BaseWhiteNoLighting")
       {
-        sub->setMaterialName(default_material_name_);
+        sub->setMaterial(default_material_);
       }
       else
       {
@@ -886,11 +886,11 @@ void RobotLink::setToErrorMaterial()
 {
   for( size_t i = 0; i < visual_meshes_.size(); i++ )
   {
-    visual_meshes_[ i ]->setMaterialName("BaseWhiteNoLighting");
+    visual_meshes_[ i ]->setMaterialName("BaseWhiteNoLighting", Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
   }
   for( size_t i = 0; i < collision_meshes_.size(); i++ )
   {
-    collision_meshes_[ i ]->setMaterialName("BaseWhiteNoLighting");
+    collision_meshes_[ i ]->setMaterialName("BaseWhiteNoLighting", Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
   }
 }
 

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -49,16 +49,11 @@
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class Entity;
-class SubEntity;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class RibbonTrail;
 }
 
 namespace rviz

--- a/src/rviz/selection/selection_handler.cpp
+++ b/src/rviz/selection/selection_handler.cpp
@@ -42,6 +42,7 @@
 #include <OgreSubEntity.h>
 
 #include "rviz/selection/selection_manager.h"
+#include "rviz/ogre_helpers/set_material.h"
 
 namespace rviz
 {
@@ -198,7 +199,7 @@ void SelectionHandler::createBox(const std::pair<CollObjectHandle, uint64_t>& ha
     box = it->second.second;
   }
 
-  box->setMaterial(material_name);
+  setMaterial(*box, material_name);
 
   box->setupBoundingBox(aabb);
   node->detachAllObjects();

--- a/src/rviz/selection/selection_manager.cpp
+++ b/src/rviz/selection/selection_manager.cpp
@@ -59,6 +59,7 @@
 #include "rviz/ogre_helpers/arrow.h"
 #include "rviz/ogre_helpers/axes.h"
 #include "rviz/ogre_helpers/custom_parameter_indices.h"
+#include "rviz/ogre_helpers/set_material.h"
 #include "rviz/ogre_helpers/qt_ogre_render_window.h"
 #include "rviz/ogre_helpers/shape.h"
 #include "rviz/properties/property.h"
@@ -142,7 +143,7 @@ void SelectionManager::initialize()
   Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().create(ss.str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
   material->setLightingEnabled(false);
   //material->getTechnique(0)->getPass(0)->setPolygonMode(Ogre::PM_WIREFRAME);
-  highlight_rectangle_->setMaterial(material->getName());
+  setMaterial(*highlight_rectangle_, material);
   Ogre::AxisAlignedBox aabInf;
   aabInf.setInfinite();
   highlight_rectangle_->setBoundingBox(aabInf);

--- a/src/rviz/selection/selection_manager.cpp
+++ b/src/rviz/selection/selection_manager.cpp
@@ -101,7 +101,9 @@ SelectionManager::~SelectionManager()
 
   setSelection(M_Picked());
 
-  highlight_node_->getParentSceneNode()->removeAndDestroyChild(highlight_node_->getName());
+  highlight_node_->getParentSceneNode()->removeChild(highlight_node_);
+  highlight_node_->getCreator()->destroySceneNode(highlight_node_);
+
   delete highlight_rectangle_;
 
   for (uint32_t i = 0; i < s_num_render_textures_; ++i)

--- a/src/rviz/view_controller.h
+++ b/src/rviz/view_controller.h
@@ -34,17 +34,11 @@
 
 #include <QCursor>
 
+#include <OgrePrerequisites.h>
+
 #include "rviz/properties/property.h"
 
 class QKeyEvent;
-
-namespace Ogre
-{
-class Camera;
-class SceneNode;
-class Vector3;
-class Quaternion;
-}
 
 namespace rviz
 {


### PR DESCRIPTION
This PR makes rviz compatible with ogre 1.11 while maintaining compatibility with 1.7.

This PR:
* adds a cross-version compatibility function for setting materials on a `SimpleRenderable`.
* prevents removing materials that are unknown to the resource manager (I may have missed some).
* loads the now split-off `Codec_STBI` plugin for ogre >= 1.11, required for PNG decoding.
* avoids the use of relative paths in shader programs because they break in Ogre 1.11.
* prevents removing anonymous scene nodes by name.
* makes sure to preserve resource group names when referring to materials by name.
* adds a `BaseWhiteNoLighting` material to the "rviz" resource group, because it seems impossible to specify a resource group for materials in a `.mesh` file.

The main changes in Ogre that make this PR necessary are the removal of `SimpleRenderable::setMaterial(const std::string & name)` and the now default resource manager strict mode. This strict mode implies that resources are not looked up in alternative resource groups anymore.

I think I managed to keep things compatible with atleast Ogre 1.7. I checked the headers of 1.7 and 1.11 when making use of different APIs.