### PR TITLE
Add properties for the covariance of the initial pose tool

### DIFF
--- a/src/rviz/default_plugin/tools/initial_pose_tool.cpp
+++ b/src/rviz/default_plugin/tools/initial_pose_tool.cpp
@@ -33,6 +33,7 @@
 
 #include "rviz/display_context.h"
 #include "rviz/properties/string_property.h"
+#include "rviz/properties/float_property.h"
 
 #include "rviz/default_plugin/tools/initial_pose_tool.h"
 
@@ -46,6 +47,12 @@ InitialPoseTool::InitialPoseTool()
   topic_property_ = new StringProperty( "Topic", "initialpose",
                                         "The topic on which to publish initial pose estimates.",
                                         getPropertyContainer(), SLOT( updateTopic() ), this );
+  cov_x_ = new FloatProperty("X covariance", 0.5 * 0.5, "X covariance for initial pose", getPropertyContainer());
+  cov_y_ = new FloatProperty("Y covariance", 0.5 * 0.5, "Y covariance for initial pose", getPropertyContainer());
+  cov_theta_ = new FloatProperty("Theta covariance", M_PI / 12.0 * M_PI / 12.0, "Theta covariance for initial pose", getPropertyContainer());
+  cov_x_->setMin(0);
+  cov_y_->setMin(0);
+  cov_theta_->setMin(0);
 }
 
 void InitialPoseTool::onInitialize()
@@ -73,9 +80,9 @@ void InitialPoseTool::onPoseSet(double x, double y, double theta)
   quat.setRPY(0.0, 0.0, theta);
   tf::quaternionTFToMsg(quat,
                         pose.pose.pose.orientation);
-  pose.pose.covariance[6*0+0] = 0.5 * 0.5;
-  pose.pose.covariance[6*1+1] = 0.5 * 0.5;
-  pose.pose.covariance[6*5+5] = M_PI/12.0 * M_PI/12.0;
+  pose.pose.covariance[6*0+0] = cov_x_->getFloat();
+  pose.pose.covariance[6*1+1] = cov_y_->getFloat();
+  pose.pose.covariance[6*5+5] = cov_theta_->getFloat();
   ROS_INFO("Setting pose: %.3f %.3f %.3f [frame=%s]", x, y, theta, fixed_frame.c_str());
   pub_.publish(pose);
 }

--- a/src/rviz/default_plugin/tools/initial_pose_tool.cpp
+++ b/src/rviz/default_plugin/tools/initial_pose_tool.cpp
@@ -47,12 +47,12 @@ InitialPoseTool::InitialPoseTool()
   topic_property_ = new StringProperty( "Topic", "initialpose",
                                         "The topic on which to publish initial pose estimates.",
                                         getPropertyContainer(), SLOT( updateTopic() ), this );
-  cov_x_ = new FloatProperty("X covariance", 0.5 * 0.5, "X covariance for initial pose", getPropertyContainer());
-  cov_y_ = new FloatProperty("Y covariance", 0.5 * 0.5, "Y covariance for initial pose", getPropertyContainer());
-  cov_theta_ = new FloatProperty("Theta covariance", M_PI / 12.0 * M_PI / 12.0, "Theta covariance for initial pose", getPropertyContainer());
-  cov_x_->setMin(0);
-  cov_y_->setMin(0);
-  cov_theta_->setMin(0);
+  std_dev_x_ = new FloatProperty("X std deviation", 0.5, "X standard deviation for initial pose [m]", getPropertyContainer());
+  std_dev_y_ = new FloatProperty("Y std deviation", 0.5, "Y standard deviation for initial pose [m]", getPropertyContainer());
+  std_dev_theta_ = new FloatProperty("Theta std deviation", M_PI / 12.0, "Theta standard deviation for initial pose [rad]", getPropertyContainer());
+  std_dev_x_->setMin(0);
+  std_dev_y_->setMin(0);
+  std_dev_theta_->setMin(0);
 }
 
 void InitialPoseTool::onInitialize()
@@ -80,9 +80,9 @@ void InitialPoseTool::onPoseSet(double x, double y, double theta)
   quat.setRPY(0.0, 0.0, theta);
   tf::quaternionTFToMsg(quat,
                         pose.pose.pose.orientation);
-  pose.pose.covariance[6*0+0] = cov_x_->getFloat();
-  pose.pose.covariance[6*1+1] = cov_y_->getFloat();
-  pose.pose.covariance[6*5+5] = cov_theta_->getFloat();
+  pose.pose.covariance[6*0+0] = std::pow(std_dev_x_->getFloat(), 2);
+  pose.pose.covariance[6*1+1] = std::pow(std_dev_y_->getFloat(), 2);
+  pose.pose.covariance[6*5+5] = std::pow(std_dev_theta_->getFloat(), 2);
   ROS_INFO("Setting pose: %.3f %.3f %.3f [frame=%s]", x, y, theta, fixed_frame.c_str());
   pub_.publish(pose);
 }

--- a/src/rviz/default_plugin/tools/initial_pose_tool.h
+++ b/src/rviz/default_plugin/tools/initial_pose_tool.h
@@ -43,6 +43,7 @@ namespace rviz
 class Arrow;
 class DisplayContext;
 class StringProperty;
+class FloatProperty;
 
 class InitialPoseTool: public PoseTool
 {
@@ -63,9 +64,9 @@ private:
   ros::Publisher pub_;
 
   StringProperty* topic_property_;
-  FloatProperty* cov_x_;
-  FloatProperty* cov_y_;
-  FloatProperty* cov_theta_;
+  FloatProperty* std_dev_x_;
+  FloatProperty* std_dev_y_;
+  FloatProperty* std_dev_theta_;
 };
 
 }

--- a/src/rviz/default_plugin/tools/initial_pose_tool.h
+++ b/src/rviz/default_plugin/tools/initial_pose_tool.h
@@ -63,6 +63,9 @@ private:
   ros::Publisher pub_;
 
   StringProperty* topic_property_;
+  FloatProperty* cov_x_;
+  FloatProperty* cov_y_;
+  FloatProperty* cov_theta_;
 };
 
 }


### PR DESCRIPTION
Currently the initial pose tool has a hardcoded covariance matrix. Sometimes it is useful to send an initial pose with a low covariance. This PR adds properties to the initial pose tool that allows specifying the main elements of the covariance matrix.