### PR TITLE
Don't hide the toolbar when pressing esc

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -126,6 +126,8 @@ VisualizationFrame::VisualizationFrame( QWidget* parent )
   , loading_( false )
   , post_load_timer_( new QTimer( this ))
   , frame_count_(0)
+  , toolbar_visible_(true)
+  , is_fullscreen_(false)
 {
   panel_factory_ = new PanelFactory();
 
@@ -1247,6 +1249,7 @@ void VisualizationFrame::onDeletePanel()
 
 void VisualizationFrame::setFullScreen( bool full_screen )
 {
+  is_fullscreen_ = full_screen;
   Q_EMIT( fullScreenChange( full_screen ) );
 
   if (full_screen)
@@ -1265,7 +1268,8 @@ void VisualizationFrame::setFullScreen( bool full_screen )
 
 void VisualizationFrame::exitFullScreen()
 {
-  setFullScreen( false );
+  if (is_fullscreen_)
+    setFullScreen( false );
 }
 
 QDockWidget* VisualizationFrame::addPanelByName( const QString& name,

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -127,7 +127,6 @@ VisualizationFrame::VisualizationFrame( QWidget* parent )
   , post_load_timer_( new QTimer( this ))
   , frame_count_(0)
   , toolbar_visible_(true)
-  , is_fullscreen_(false)
 {
   panel_factory_ = new PanelFactory();
 
@@ -1249,27 +1248,25 @@ void VisualizationFrame::onDeletePanel()
 
 void VisualizationFrame::setFullScreen( bool full_screen )
 {
-  is_fullscreen_ = full_screen;
+  Qt::WindowStates state = windowState();
+  if (full_screen == state.testFlag(Qt::WindowFullScreen))
+    return;
   Q_EMIT( fullScreenChange( full_screen ) );
 
+  // when switching to fullscreen, remember visibility state of toolbar
   if (full_screen)
     toolbar_visible_ = toolbar_->isVisible();
   menuBar()->setVisible(!full_screen);
   toolbar_->setVisible(!full_screen && toolbar_visible_);
   statusBar()->setVisible(!full_screen);
   setHideButtonVisibility(!full_screen);
-
-  if (full_screen)
-    setWindowState(windowState() | Qt::WindowFullScreen);
-  else
-    setWindowState(windowState() & ~Qt::WindowFullScreen);
+  setWindowState(state.setFlag(Qt::WindowFullScreen, full_screen));
   show();
 }
 
 void VisualizationFrame::exitFullScreen()
 {
-  if (is_fullscreen_)
-    setFullScreen( false );
+  setFullScreen( false );
 }
 
 QDockWidget* VisualizationFrame::addPanelByName( const QString& name,

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1260,7 +1260,11 @@ void VisualizationFrame::setFullScreen( bool full_screen )
   toolbar_->setVisible(!full_screen && toolbar_visible_);
   statusBar()->setVisible(!full_screen);
   setHideButtonVisibility(!full_screen);
-  setWindowState(state.setFlag(Qt::WindowFullScreen, full_screen));
+
+  if (full_screen)
+    setWindowState(state | Qt::WindowFullScreen);
+  else
+    setWindowState(state & ~Qt::WindowFullScreen);
   show();
 }
 

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -362,6 +362,8 @@ protected:
 
   /// Indicates if the toolbar should be visible outside of fullscreen mode.
   bool toolbar_visible_;
+  /// Prevent exiting fullscreen if not in fullscreen
+  bool is_fullscreen_;
 };
 
 }

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -362,8 +362,6 @@ protected:
 
   /// Indicates if the toolbar should be visible outside of fullscreen mode.
   bool toolbar_visible_;
-  /// Prevent exiting fullscreen if not in fullscreen
-  bool is_fullscreen_;
 };
 
 }


### PR DESCRIPTION
The fullscreen code does not properly keep track of the toolbar visibility state. This leads to the following undesired behaviour:
- Pressing esc without ever having entered fullscreen may hides the toolbar because toolbar_visible_ is never set.
- Pressing esc after having entered fullscreen previously sets the toolbar visibility to what it was the last time fullscreen was entered.

By only calling setFullScreen(false) after we really were in fullscreen mode, we guarantee that toolbar_visible_ is valid and don't mess with the toolbar visibility otherwise.