### PR TITLE
OGRE_PLUGIN_PATH definable at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,13 @@ if(NOT OGRE_OV_FOUND)
 endif(NOT OGRE_OV_FOUND)
 
 ## Find OGRE Plugin path (not necessarily platform-independent, I guess)
-execute_process(COMMAND
-  ${PKG_CONFIG_EXECUTABLE} --variable=plugindir OGRE
-  OUTPUT_VARIABLE OGRE_PLUGIN_PATH
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
+if(NOT DEFINED OGRE_PLUGIN_PATH)
+  execute_process(COMMAND
+    ${PKG_CONFIG_EXECUTABLE} --variable=plugindir OGRE
+    OUTPUT_VARIABLE OGRE_PLUGIN_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif(NOT DEFINED OGRE_PLUGIN_PATH)
 message(STATUS OGRE_PLUGIN_PATH=${OGRE_PLUGIN_PATH})
 
 # find absolute path of ogre libraries.


### PR DESCRIPTION
I was attempting the package rviz in a snap and had difficulty because of OGRE_PLUGIN_PATH.  The OGRE_PLUGIN_PATH would take a path pointing to a build directory from the package config.  This allows OGRE_PLUGIN_PATH to be specified as a cmake arg if the plugin path is known to be different on the system rviz is installed from the one it is built on.