### PR TITLE
systematic check of incoming markers

### DIFF
--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -368,10 +368,10 @@ void MarkerDisplay::processAdd( const visualization_msgs::Marker::ConstPtr& mess
   if ( create )
   {
     marker.reset(createMarker(message->type, this, context_, scene_node_));
-    if (!marker) {
-      ROS_ERROR( "Unknown marker type: %d", message->type );
+    if (marker)
+    {
+      markers_.insert(std::make_pair(MarkerID(message->ns, message->id), marker));
     }
-    markers_.insert(std::make_pair(MarkerID(message->ns, message->id), marker));
   }
 
   if (marker)

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -246,12 +246,9 @@ void MarkerDisplay::deleteMarkerStatus(MarkerID id)
 
 void MarkerDisplay::incomingMarkerArray(const visualization_msgs::MarkerArray::ConstPtr& array)
 {
-  std::vector<visualization_msgs::Marker>::const_iterator it = array->markers.begin();
-  std::vector<visualization_msgs::Marker>::const_iterator end = array->markers.end();
   checkMarkerArrayMsg(*array, this);
-  for (; it != end; ++it)
+  for (const visualization_msgs::Marker& marker : array->markers)
   {
-    const visualization_msgs::Marker& marker = *it;
     tf_filter_->add(visualization_msgs::Marker::Ptr(new visualization_msgs::Marker(marker)));
   }
 }

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -43,7 +43,6 @@
 #include "rviz/properties/ros_topic_property.h"
 #include "rviz/selection/selection_manager.h"
 #include "rviz/validate_floats.h"
-#include "rviz/validate_quaternions.h"
 
 #include "rviz/default_plugin/marker_display.h"
 
@@ -249,6 +248,7 @@ void MarkerDisplay::incomingMarkerArray(const visualization_msgs::MarkerArray::C
 {
   std::vector<visualization_msgs::Marker>::const_iterator it = array->markers.begin();
   std::vector<visualization_msgs::Marker>::const_iterator end = array->markers.end();
+  checkMarkerArrayMsg(*array, this);
   for (; it != end; ++it)
   {
     const visualization_msgs::Marker& marker = *it;
@@ -258,6 +258,7 @@ void MarkerDisplay::incomingMarkerArray(const visualization_msgs::MarkerArray::C
 
 void MarkerDisplay::incomingMarker( const visualization_msgs::Marker::ConstPtr& marker )
 {
+  checkMarkerMsg(*marker, this);
   boost::mutex::scoped_lock lock(queue_mutex_);
 
   message_queue_.push_back(marker);
@@ -293,16 +294,6 @@ void MarkerDisplay::processMessage( const visualization_msgs::Marker::ConstPtr& 
     setMarkerStatus( MarkerID( message->ns, message->id ), StatusProperty::Error,
                      "Contains invalid floating point values (nans or infs)" );
     return;
-  }
-
-  if( !validateQuaternions( message->pose ))
-  {
-    ROS_WARN_ONCE_NAMED( "quaternions", "Marker '%s/%d' contains unnormalized quaternions. "
-                         "This warning will only be output once but may be true for others; "
-                         "enable DEBUG messages for ros.rviz.quaternions to see more details.",
-                         message->ns.c_str(), message->id );
-    ROS_DEBUG_NAMED( "quaternions", "Marker '%s/%d' contains unnormalized quaternions.", 
-                     message->ns.c_str(), message->id );
   }
 
   switch ( message->action )
@@ -344,8 +335,6 @@ void MarkerDisplay::processAdd( const visualization_msgs::Marker::ConstPtr& mess
   {
     return;
   }
-
-  deleteMarkerStatus( MarkerID( message->ns, message->id ));
 
   bool create = true;
   MarkerBasePtr marker;

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -232,12 +232,12 @@ void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream
     && marker.pose.orientation.z == 0.0
     && marker.pose.orientation.w == 0.0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "uninitialized quaternion assuming identity";
   }
   else if(!validateQuaternions(marker.pose))
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "unnormalized quaternion in marker message";
   }
 }
@@ -252,11 +252,11 @@ void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss)
   {
     if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST)
     {
-      addNewlineIfRequired(ss);
+      addCommaAndNewlineIfRequired(ss);
       ss << "scale contains 0.0 in x, y or z, TRIANGLE_LIST coordinates are scaled";
       return;
     }
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "scale contains 0.0 in x, y or z";
   }
 }
@@ -265,12 +265,12 @@ void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::s
 {
   if(marker.scale.x == 0.0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "width LINE_LIST or LINE_STRIP is 0.0 (scale.x)";
   }
   else if(marker.scale.y != 0.0 || marker.scale.z != 0.0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "scale.y and scale.z of LINE_LIST or LINE_STRIP are ignored";
   }
 }
@@ -279,12 +279,12 @@ void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(marker.scale.x == 0.0 || marker.scale.y == 0.0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "width and/or height of POINTS is 0.0 (scale.x, scale.y)";
   }
   else if(marker.scale.z != 0.0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "scale.z of POINTS is ignored";
   }
 }
@@ -293,12 +293,12 @@ void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if(marker.scale.z == 0.0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "text height of TEXT_VIEW_FACING is 0.0 (scale.z)";
   }
   else if(marker.scale.x != 0.0 || marker.scale.y != 0.0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "scale.x and scale.y of TEXT_VIEW_FACING are ignored";
   }
 }
@@ -307,7 +307,7 @@ void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss)
 {
   if(marker.color.a == 0.0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "marker is fully transparent (color.a is 0.0)";
   }
 }
@@ -316,7 +316,7 @@ void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(marker.points.size() != 0 && marker.points.size() != 2)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "Number of points for an ARROW marker should be either 0 or 2";
   }
 }
@@ -325,22 +325,22 @@ void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringst
 {
   if(marker.points.empty())
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "points should not be empty for specified marker type" ;
   }
   else if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST && (marker.points.size() % 3) != 0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "number of points should be a multiple of 3 for TRIANGLE_LIST Marker";
   }
   else if(marker.type == visualization_msgs::Marker::LINE_LIST && (marker.points.size() % 2) != 0)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "number of points should be a multiple of 2 for LINE_LIST Marker";
   }
   else if(marker.type == visualization_msgs::Marker::LINE_STRIP && marker.points.size() <= 1)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "at least two points are required for a LINE_STRIP Marker";
   }
 }
@@ -349,7 +349,7 @@ void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(!marker.points.empty())
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "points array is ignored by specified marker type";
   }
 }
@@ -363,7 +363,7 @@ void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss
   }
   if(marker.colors.size() != marker.points.size())
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "number of colors is not equal to number of points or 0";
   }
 }
@@ -372,7 +372,7 @@ void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(!marker.colors.empty())
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "colors array is ignored by specified marker type";
   }
 }
@@ -381,12 +381,12 @@ void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std
 {
   if(marker.text.empty())
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "text is empty for TEXT_VIEW_FACING type marker";
   }
   else if(marker.text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "text of TEXT_VIEW_FACING Marker only consists of whitespaces";
   }
 }
@@ -395,7 +395,7 @@ void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if(!marker.text.empty())
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "text is ignored for specified marker type";
   }
 }
@@ -404,7 +404,7 @@ void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss)
 {
   if(marker.mesh_resource.empty())
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "path to mesh resource is empty for MESH_RESOURCE marker";
   }
 }
@@ -413,21 +413,21 @@ void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if (!marker.mesh_resource.empty())
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "mesh_resource is ignored for specified marker type";
   }
   if (marker.mesh_use_embedded_materials)
   {
-    addNewlineIfRequired(ss);
+    addCommaAndNewlineIfRequired(ss);
     ss << "using embedded materials is not supported for markers other than MESH_RESOURCE";
   }
 }
 
-void addNewlineIfRequired(std::stringstream& ss)
+void addCommaAndNewlineIfRequired(std::stringstream& ss)
 {
   if (ss.tellp() != 0) // check if string is not empty
   {
-    ss << "\n";
+    ss << ",\n";
   }
 }
 

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -32,10 +32,18 @@
 #include "rviz/default_plugin/markers/arrow_marker.h"
 #include "rviz/default_plugin/markers/line_list_marker.h"
 #include "rviz/default_plugin/markers/line_strip_marker.h"
+#include "rviz/default_plugin/marker_display.h"
 #include "rviz/default_plugin/markers/points_marker.h"
 #include "rviz/default_plugin/markers/text_view_facing_marker.h"
 #include "rviz/default_plugin/markers/mesh_resource_marker.h"
 #include "rviz/default_plugin/markers/triangle_list_marker.h"
+#include "rviz/display_context.h"
+#include "rviz/properties/property.h"
+#include "rviz/properties/property_tree_model.h"
+#include "rviz/properties/status_list.h"
+#include "rviz/validate_quaternions.h"
+
+
 
 namespace rviz
 {
@@ -74,6 +82,291 @@ MarkerBase* createMarker(int marker_type, MarkerDisplay* owner, DisplayContext* 
   default:
      return nullptr;
   }
+}
+
+bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* owner)
+{
+  std::stringstream ss;
+
+  if(marker.action != visualization_msgs::Marker::ADD)
+    return true;
+
+  switch (marker.type) {
+  case visualization_msgs::Marker::ARROW:
+    ss << checkQuaternion(marker);
+    ss << checkScale(marker);
+    ss << checkColor(marker);
+    ss << checkPointsArrow(marker);
+    ss << checkColorsEmpty(marker);
+    ss << checkTextEmpty(marker);
+    ss << checkMeshEmpty(marker);
+    break;
+
+  case visualization_msgs::Marker::CUBE:
+  case visualization_msgs::Marker::CYLINDER:
+  case visualization_msgs::Marker::SPHERE:
+    ss << checkQuaternion(marker);
+    ss << checkScale(marker);
+    ss << checkColor(marker);
+    ss << checkPointsEmpty(marker);
+    ss << checkColorsEmpty(marker);
+    ss << checkTextEmpty(marker);
+    ss << checkMeshEmpty(marker);
+    break;
+
+
+  case visualization_msgs::Marker::LINE_STRIP:
+  case visualization_msgs::Marker::LINE_LIST:
+    ss << checkQuaternion(marker);
+    ss << checkScaleLineStripAndList(marker);
+    ss << checkPointsNotEmpty(marker);
+    ss << checkColors(marker);
+    ss << checkTextEmpty(marker);
+    ss << checkMeshEmpty(marker);
+    break;
+
+  case visualization_msgs::Marker::SPHERE_LIST:
+  case visualization_msgs::Marker::CUBE_LIST:
+  case visualization_msgs::Marker::TRIANGLE_LIST:
+    ss << checkQuaternion(marker);
+    ss << checkScale(marker);
+    ss << checkPointsNotEmpty(marker);
+    ss << checkColors(marker);
+    ss << checkTextEmpty(marker);
+    ss << checkMeshEmpty(marker);
+    break;
+
+  case visualization_msgs::Marker::POINTS:
+    ss << checkScalePoints(marker);
+    ss << checkPointsNotEmpty(marker);
+    ss << checkColors(marker);
+    ss << checkTextEmpty(marker);
+    ss << checkMeshEmpty(marker);
+    break;
+
+  case visualization_msgs::Marker::TEXT_VIEW_FACING:
+    ss << checkColor(marker);
+    ss << checkScaleText(marker);
+    ss << checkTextNotEmptyOrWhitespace(marker);
+    ss << checkPointsEmpty(marker);
+    ss << checkColorsEmpty(marker);
+    ss << checkMeshEmpty(marker);
+    break;
+
+  case visualization_msgs::Marker::MESH_RESOURCE:
+    ss << checkQuaternion(marker);
+    ss << checkColor(marker);
+    ss << checkScale(marker);
+    ss << checkPointsEmpty(marker);
+    ss << checkColorsEmpty(marker);
+    ss << checkTextEmpty(marker);
+
+    break;
+
+  default:
+    ss << "Unknown marker type: " << marker.type ;
+  }
+
+  std::string warning = ss.str();
+  if(!warning.empty())
+  {
+    if(warning.substr(warning.length()-2) == ", ")
+      warning = warning.erase(warning.length()-2, 2);
+
+    owner->setMarkerStatus(MarkerID(marker.ns, marker.id), StatusProperty::Warn, warning);
+    ROS_WARN("Marker '%s/%d': %s", marker.ns.c_str(), marker.id, warning.c_str());
+    return false;
+  }
+
+  owner->deleteMarkerStatus(MarkerID(marker.ns, marker.id));
+  return true;
+}
+
+bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDisplay* owner)
+{
+  std::set<MarkerID> marker_set;
+
+  for(int i = 0; i<array.markers.size(); i++)
+  {
+    if(i != 0 && array.markers[i].action == visualization_msgs::Marker::DELETEALL)
+    {
+      std::stringstream warning;
+      warning << "found a DELETEALL at index " << i << ", previous markers in the MarkerArray will never show";
+      ROS_WARN("MarkerArray: %s", warning.str().c_str());
+      owner->setStatusStd(StatusProperty::Warn, "marker_array", warning.str());
+      return false;
+    }
+    auto search = marker_set.find(MarkerID(array.markers[i].ns,array.markers[i].id));
+    if (search != marker_set.end())
+    {
+      std::stringstream ss;
+      ss << "found '" <<  array.markers[i].ns.c_str() << "/" << array.markers[i].id << "' multiple times";
+      ROS_WARN("MarkerArray: %s", ss.str().c_str());
+      owner->setStatusStd(StatusProperty::Warn, "marker_array", ss.str());
+      return false;
+    }
+    else
+    {
+      marker_set.insert(MarkerID(array.markers[i].ns,array.markers[i].id));
+    }
+  }
+  owner->setStatusStd(StatusProperty::Ok, "marker_array", "OK");
+  return true;
+}
+
+
+std::string checkQuaternion(const visualization_msgs::Marker& marker)
+{
+  if (marker.pose.orientation.x == 0.0
+    && marker.pose.orientation.y == 0.0
+    && marker.pose.orientation.z == 0.0
+    && marker.pose.orientation.w == 0.0)
+  {
+    return "uninitialized quaternion assuming identity, ";
+  }
+  if(!validateQuaternions(marker.pose))
+    return "unnormalized quaternion in marker message, ";
+
+  return "";
+}
+
+std::string checkScale(const visualization_msgs::Marker& marker)
+{
+  // for ARROW markers, scale.z is the optional head length
+  if(marker.type == visualization_msgs::Marker::ARROW && marker.scale.x != 0.0 && marker.scale.y != 0.0)
+    return "";
+
+  if(marker.scale.x == 0.0  || marker.scale.y == 0.0  || marker.scale.z == 0.0)
+  {
+    if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST)
+      return "scale contains 0.0 in x, y or z, TRIANGLE_LIST coordinates are scaled, ";
+    return "scale contains 0.0 in x, y or z, ";
+  }
+  return "";
+}
+
+std::string checkScaleLineStripAndList(const visualization_msgs::Marker& marker)
+{
+  if(marker.scale.x == 0.0)
+  {
+    return "width LINE_LIST or LINE_STRIP is 0.0 (scale.x), ";
+  }
+  else if(marker.scale.y != 0.0 || marker.scale.z != 0.0)
+  {
+    return "scale.y and scale.z of LINE_LIST or LINE_STRIP are ignored, ";
+  }
+  return "";
+}
+
+std::string checkScalePoints(const visualization_msgs::Marker& marker)
+{
+  if(marker.scale.x == 0.0 || marker.scale.y == 0.0)
+  {
+    return "width and/or height of POINTS is 0.0 (scale.x, scale.y), ";
+  }
+  else if(marker.scale.z != 0.0)
+  {
+    return "scale.z of POINTS is ignored, ";
+  }
+  return "";
+}
+
+std::string checkScaleText(const visualization_msgs::Marker& marker)
+{
+  if(marker.scale.z == 0.0)
+  {
+    return "text height of TEXT_VIEW_FACING is 0.0 (scale.z), ";
+  }
+  else if(marker.scale.x != 0.0 || marker.scale.y != 0.0)
+  {
+    return "scale.x and scale.y of TEXT_VIEW_FACING are ignored, ";
+  }
+  return "";
+}
+
+std::string checkColor(const visualization_msgs::Marker& marker)
+{
+  if(marker.color.a == 0.0)
+    return "marker is fully transparent (color.a is 0.0), ";
+  return "";
+}
+
+std::string checkPointsArrow(const visualization_msgs::Marker& marker)
+{
+  if(marker.points.size() != 0 && marker.points.size() != 2)
+    return "Number of points for an ARROW marker should be either 0 or 2";
+  return "";
+}
+
+std::string checkPointsNotEmpty(const visualization_msgs::Marker& marker)
+{
+  std::stringstream ss;
+  ss << marker.points.size();
+  if(marker.points.empty())
+    return "points should not be empty for specified marker type, " ;
+  else if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST && (marker.points.size() % 3) != 0)
+    return "number of points (" + ss.str() + ") should be a multiple of 3 for TRIANGLE_LIST Marker, ";
+  else if(marker.type == visualization_msgs::Marker::LINE_LIST && (marker.points.size() % 2) != 0)
+    return "number of points (" + ss.str() + ") should be a multiple of 2 for LINE_LIST Marker, ";
+  else if(marker.type == visualization_msgs::Marker::LINE_STRIP && marker.points.size() <= 1)
+    return "at least two points are required for a LINE_STRIP Marker, ";
+  return "";
+}
+
+std::string checkPointsEmpty(const visualization_msgs::Marker& marker)
+{
+  if(!marker.points.empty())
+    return "points array is ignored by specified marker type, ";
+  return "";
+}
+
+std::string checkColors(const visualization_msgs::Marker& marker)
+{
+  if(marker.colors.size() == 0)
+    return checkColor(marker);
+  if(marker.colors.size() != marker.points.size())
+    return "number of colors is not equal to number of points or 0, ";
+  return "";
+}
+
+std::string checkColorsEmpty(const visualization_msgs::Marker& marker)
+{
+  if(!marker.colors.empty())
+    return "colors array is ignored by specified marker type, ";
+  return "";
+}
+
+std::string checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker)
+{
+  if(marker.text.empty())
+    return "text is empty for TEXT_VIEW_FACING type marker, ";
+  else if(marker.text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
+    return "text of TEXT_VIEW_FACING Marker only consists of whitespaces, ";
+  return "";
+}
+
+std::string checkTextEmpty(const visualization_msgs::Marker& marker)
+{
+  if(!marker.text.empty())
+    return "text is ignored for specified marker type, ";
+  return "";
+}
+
+std::string checkMesh(const visualization_msgs::Marker& marker)
+{
+  if(marker.mesh_resource.empty())
+    return "path to mesh resource is empty for MESH_RESOURCE marker, ";
+  return "";
+}
+
+std::string checkMeshEmpty(const visualization_msgs::Marker& marker)
+{
+  std::stringstream ss;
+  if (!marker.mesh_resource.empty())
+    ss << "mesh_resource is ignored for specified marker type, ";
+  if (marker.mesh_use_embedded_materials)
+    ss << "using embedded materials is not supported for markers other than MESH_RESOURCE, ";
+  return ss.str();
 }
 
 } // namespace rviz

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -185,7 +185,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
 
   bool add_marker_in_array = false;
 
-  for(int i = 0; i<array.markers.size(); i++)
+  for(int i = 0; i < array.markers.size(); i++)
   {
     if(array.markers[i].action == visualization_msgs::Marker::ADD)
     {

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -184,7 +184,8 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
 
 bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDisplay* owner)
 {
-  std::set<MarkerID> marker_set;
+  std::vector<MarkerID> marker_ids;
+
 
   for(int i = 0; i<array.markers.size(); i++)
   {
@@ -196,8 +197,9 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
       owner->setStatusStd(StatusProperty::Warn, "marker_array", warning.str());
       return false;
     }
-    auto search = marker_set.find(MarkerID(array.markers[i].ns,array.markers[i].id));
-    if (search != marker_set.end())
+    MarkerID current_id(array.markers[i].ns, array.markers[i].id);
+    std::vector<MarkerID>::iterator search = std::lower_bound(marker_ids.begin(), marker_ids.end(), current_id);
+    if (search != marker_ids.end())
     {
       std::stringstream ss;
       ss << "found '" <<  array.markers[i].ns.c_str() << "/" << array.markers[i].id << "' multiple times";
@@ -207,7 +209,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
     }
     else
     {
-      marker_set.insert(MarkerID(array.markers[i].ns,array.markers[i].id));
+      marker_ids.insert(search, current_id);
     }
   }
   owner->setStatusStd(StatusProperty::Ok, "marker_array", "OK");

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -258,13 +258,6 @@ void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss,
 
   if(marker.scale.x == 0.0  || marker.scale.y == 0.0  || marker.scale.z == 0.0)
   {
-    if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST)
-    {
-      addCommaAndNewlineIfRequired(ss);
-      ss << "scale contains 0.0 in x, y or z, TRIANGLE_LIST coordinates are scaled";
-      increaseWarningLevel(StatusProperty::Error, level);
-      return;
-    }
     addCommaAndNewlineIfRequired(ss);
     ss << "scale contains 0.0 in x, y or z";
     increaseWarningLevel(StatusProperty::Error, level);

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -173,14 +173,16 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
   {
     std::string warning = ss.str();
 
-    owner->setMarkerStatus(MarkerID(marker.ns, marker.id), level, warning);
+    if (owner)
+      owner->setMarkerStatus(MarkerID(marker.ns, marker.id), level, warning);
     ROS_LOG((level == StatusProperty::Warn ? ::ros::console::levels::Warn : ::ros::console::levels::Error),
             ROSCONSOLE_DEFAULT_NAME, "Marker '%s/%d': %s", marker.ns.c_str(), marker.id, warning.c_str());
 
     return false;
   }
 
-  owner->deleteMarkerStatus(MarkerID(marker.ns, marker.id));
+  if (owner)
+    owner->deleteMarkerStatus(MarkerID(marker.ns, marker.id));
   return true;
 }
 
@@ -200,7 +202,8 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
     {
       const std::string warning = "found a DELETEALL after having markers added. These markers will never show";
       ROS_ERROR("MarkerArray: %s", warning.c_str());
-      owner->setStatusStd(StatusProperty::Error, "marker_array", warning);
+      if (owner)
+        owner->setStatusStd(StatusProperty::Error, "marker_array", warning);
       reset_status = false;
     }
 
@@ -212,7 +215,8 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
       ss << "found '" <<  marker.ns.c_str() << "/" << marker.id << "' multiple times";
       const std::string ss_str = ss.str();
       ROS_WARN("MarkerArray: %s", ss_str.c_str());
-      owner->setStatusStd(StatusProperty::Warn, "marker_array", ss_str);
+      if (owner)
+        owner->setStatusStd(StatusProperty::Warn, "marker_array", ss_str);
       reset_status = false;
     }
     else
@@ -221,7 +225,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
     }
   }
 
-  if(reset_status)
+  if (reset_status && owner)
     owner->setStatusStd(StatusProperty::Ok, "marker_array", "OK");
 
   return reset_status;

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -86,10 +86,11 @@ MarkerBase* createMarker(int marker_type, MarkerDisplay* owner, DisplayContext* 
 
 bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* owner)
 {
-  std::stringstream ss;
 
   if(marker.action != visualization_msgs::Marker::ADD)
     return true;
+
+  std::stringstream ss;
 
   switch (marker.type) {
   case visualization_msgs::Marker::ARROW:

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -186,10 +186,16 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
 {
   std::vector<MarkerID> marker_ids;
 
+  bool add_marker_in_array = false;
 
   for(int i = 0; i<array.markers.size(); i++)
   {
-    if(i != 0 && array.markers[i].action == visualization_msgs::Marker::DELETEALL)
+    if(array.markers[i].action == visualization_msgs::Marker::ADD)
+    {
+      add_marker_in_array = true;
+    }
+
+    if(add_marker_in_array && i != 0 && array.markers[i].action == visualization_msgs::Marker::DELETEALL)
     {
       std::stringstream warning;
       warning << "found a DELETEALL at index " << i << ", previous markers in the MarkerArray will never show";

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -165,7 +165,7 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
     break;
 
   default:
-    ss << "Unknown marker type: " << marker.type ;
+    ss << "Unknown marker type: " << marker.type << '.' ;
     level = StatusProperty::Error;
   }
 
@@ -204,7 +204,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
     {
       if (markers_added)
       {
-          addCommaAndNewlineIfRequired(ss);
+          addSeparatorIfRequired(ss);
           ss << "Found a DELETEALL after having markers added. These markers will never show";
           increaseWarningLevel(StatusProperty::Warn, level);
       }
@@ -216,7 +216,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
     std::vector<MarkerID>::iterator search = std::lower_bound(marker_ids.begin(), marker_ids.end(), current_id);
     if (search != marker_ids.end())
     {
-      addCommaAndNewlineIfRequired(ss);
+      addSeparatorIfRequired(ss);
       ss << "Found '" <<  marker.ns.c_str() << "/" << marker.id << "' multiple times";
       increaseWarningLevel(StatusProperty::Warn, level);
     }
@@ -249,15 +249,15 @@ void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream
   if (marker.pose.orientation.x == 0.0 && marker.pose.orientation.y == 0.0 && marker.pose.orientation.z == 0.0 &&
       marker.pose.orientation.w == 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "uninitialized quaternion assuming identity";
+    addSeparatorIfRequired(ss);
+    ss << "Uninitialized quaternion assuming identity.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
   else if(!validateQuaternions(marker.pose))
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "unnormalized quaternion in marker message";
-    increaseWarningLevel(StatusProperty::Warn, level);
+    addSeparatorIfRequired(ss);
+    ss << "Unnormalized quaternion in marker message.";
+    increaseWarningLevel(StatusProperty::Error, level);
   }
 }
 
@@ -269,8 +269,8 @@ void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss,
 
   if(marker.scale.x == 0.0  || marker.scale.y == 0.0  || marker.scale.z == 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "scale contains 0.0 in x, y or z";
+    addSeparatorIfRequired(ss);
+    ss << "Scale contains 0.0 in x, y or z.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
 }
@@ -279,14 +279,14 @@ void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::s
 {
   if(marker.scale.x == 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "width LINE_LIST or LINE_STRIP is 0.0 (scale.x)";
+    addSeparatorIfRequired(ss);
+    ss << "Width LINE_LIST or LINE_STRIP is 0.0 (scale.x).";
     increaseWarningLevel(StatusProperty::Error, level);
   }
   else if(marker.scale.y != 0.0 || marker.scale.z != 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "scale.y and scale.z of LINE_LIST or LINE_STRIP are ignored";
+    addSeparatorIfRequired(ss);
+    ss << "scale.y and scale.z of LINE_LIST or LINE_STRIP are ignored.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
 }
@@ -295,14 +295,14 @@ void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(marker.scale.x == 0.0 || marker.scale.y == 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "width and/or height of POINTS is 0.0 (scale.x, scale.y)";
+    addSeparatorIfRequired(ss);
+    ss << "Width and/or height of POINTS is 0.0 (scale.x, scale.y).";
     increaseWarningLevel(StatusProperty::Error, level);
   }
   else if(marker.scale.z != 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "scale.z of POINTS is ignored";
+    addSeparatorIfRequired(ss);
+    ss << "scale.z of POINTS is ignored.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
 }
@@ -311,14 +311,14 @@ void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if(marker.scale.z == 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "text height of TEXT_VIEW_FACING is 0.0 (scale.z)";
+    addSeparatorIfRequired(ss);
+    ss << "Text height of TEXT_VIEW_FACING is 0.0 (scale.z).";
     increaseWarningLevel(StatusProperty::Error, level);
   }
   else if(marker.scale.x != 0.0 || marker.scale.y != 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "scale.x and scale.y of TEXT_VIEW_FACING are ignored";
+    addSeparatorIfRequired(ss);
+    ss << "scale.x and scale.y of TEXT_VIEW_FACING are ignored.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
 }
@@ -327,8 +327,8 @@ void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss,
 {
   if(marker.color.a == 0.0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "marker is fully transparent (color.a is 0.0)";
+    addSeparatorIfRequired(ss);
+    ss << "Marker is fully transparent (color.a is 0.0).";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
 }
@@ -337,8 +337,8 @@ void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(marker.points.size() != 0 && marker.points.size() != 2)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "Number of points for an ARROW marker should be either 0 or 2";
+    addSeparatorIfRequired(ss);
+    ss << "Number of points for an ARROW marker should be either 0 or 2.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
 }
@@ -347,26 +347,26 @@ void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringst
 {
   if(marker.points.empty())
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "points should not be empty for specified marker type" ;
+    addSeparatorIfRequired(ss);
+    ss << "Points should not be empty for specified marker type.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
   else if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST && (marker.points.size() % 3) != 0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "number of points should be a multiple of 3 for TRIANGLE_LIST Marker";
+    addSeparatorIfRequired(ss);
+    ss << "Number of points should be a multiple of 3 for TRIANGLE_LIST Marker.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
   else if(marker.type == visualization_msgs::Marker::LINE_LIST && (marker.points.size() % 2) != 0)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "number of points should be a multiple of 2 for LINE_LIST Marker";
+    addSeparatorIfRequired(ss);
+    ss << "Number of points should be a multiple of 2 for LINE_LIST Marker.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
   else if(marker.type == visualization_msgs::Marker::LINE_STRIP && marker.points.size() <= 1)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "at least two points are required for a LINE_STRIP Marker";
+    addSeparatorIfRequired(ss);
+    ss << "At least two points are required for a LINE_STRIP Marker.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
 }
@@ -375,8 +375,8 @@ void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(!marker.points.empty())
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "points array is ignored by specified marker type";
+    addSeparatorIfRequired(ss);
+    ss << "Points array is ignored by specified marker type.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
 }
@@ -390,8 +390,8 @@ void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss
   }
   if(marker.colors.size() != marker.points.size())
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "number of colors is not equal to number of points or 0";
+    addSeparatorIfRequired(ss);
+    ss << "Number of colors is not equal to number of points or 0.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
 }
@@ -400,8 +400,8 @@ void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(!marker.colors.empty())
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "colors array is ignored by specified marker type";
+    addSeparatorIfRequired(ss);
+    ss << "Colors array is ignored by specified marker type.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
 }
@@ -410,14 +410,14 @@ void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std
 {
   if(marker.text.empty())
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "text is empty for TEXT_VIEW_FACING type marker";
+    addSeparatorIfRequired(ss);
+    ss << "Text is empty for TEXT_VIEW_FACING type marker.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
   else if(marker.text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "text of TEXT_VIEW_FACING Marker only consists of whitespaces";
+    addSeparatorIfRequired(ss);
+    ss << "Text of TEXT_VIEW_FACING Marker only consists of whitespaces.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
 }
@@ -426,8 +426,8 @@ void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if(!marker.text.empty())
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "text is ignored for specified marker type";
+    addSeparatorIfRequired(ss);
+    ss << "Text is ignored for specified marker type.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
 }
@@ -436,8 +436,8 @@ void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss, 
 {
   if(marker.mesh_resource.empty())
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "path to mesh resource is empty for MESH_RESOURCE marker";
+    addSeparatorIfRequired(ss);
+    ss << "Path to mesh resource is empty for MESH_RESOURCE marker.";
     increaseWarningLevel(StatusProperty::Error, level);
   }
 }
@@ -446,23 +446,23 @@ void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if (!marker.mesh_resource.empty())
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "mesh_resource is ignored for specified marker type";
+    addSeparatorIfRequired(ss);
+    ss << "Mesh_resource is ignored for specified marker type.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
   if (marker.mesh_use_embedded_materials)
   {
-    addCommaAndNewlineIfRequired(ss);
-    ss << "using embedded materials is not supported for markers other than MESH_RESOURCE";
+    addSeparatorIfRequired(ss);
+    ss << "Using embedded materials is not supported for markers other than MESH_RESOURCE.";
     increaseWarningLevel(StatusProperty::Warn, level);
   }
 }
 
-void addCommaAndNewlineIfRequired(std::stringstream& ss)
+void addSeparatorIfRequired(std::stringstream& ss)
 {
   if (ss.tellp() != 0) // check if string is not empty
   {
-    ss << ",\n";
+    ss << " \n";
   }
 }
 

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -196,8 +196,9 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
     {
       std::stringstream warning;
       warning << "found a DELETEALL at index " << i << ", previous markers in the MarkerArray will never show";
-      ROS_WARN("MarkerArray: %s", warning.str().c_str());
-      owner->setStatusStd(StatusProperty::Warn, "marker_array", warning.str());
+      std::string warning_str = warning.str();
+      ROS_WARN("MarkerArray: %s", warning_str.c_str());
+      owner->setStatusStd(StatusProperty::Warn, "marker_array", warning_str);
       return false;
     }
     MarkerID current_id(array.markers[i].ns, array.markers[i].id);
@@ -206,8 +207,9 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
     {
       std::stringstream ss;
       ss << "found '" <<  array.markers[i].ns.c_str() << "/" << array.markers[i].id << "' multiple times";
-      ROS_WARN("MarkerArray: %s", ss.str().c_str());
-      owner->setStatusStd(StatusProperty::Warn, "marker_array", ss.str());
+      std::string ss_str = ss.str();
+      ROS_WARN("MarkerArray: %s", ss_str.c_str());
+      owner->setStatusStd(StatusProperty::Warn, "marker_array", ss_str);
       return false;
     }
     else

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -356,8 +356,8 @@ void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss
   if(marker.colors.size() == 0)
   {
     checkColor(marker, ss);
+    return;
   }
-
   if(marker.colors.size() != marker.points.size())
   {
     addCommaIfRequired(ss);

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -229,12 +229,12 @@ void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream
     && marker.pose.orientation.z == 0.0
     && marker.pose.orientation.w == 0.0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "uninitialized quaternion assuming identity";
   }
   else if(!validateQuaternions(marker.pose))
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "unnormalized quaternion in marker message";
   }
 }
@@ -249,11 +249,11 @@ void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss)
   {
     if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST)
     {
-      addCommaIfRequired(ss);
+      addNewlineIfRequired(ss);
       ss << "scale contains 0.0 in x, y or z, TRIANGLE_LIST coordinates are scaled";
       return;
     }
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "scale contains 0.0 in x, y or z";
   }
 }
@@ -262,12 +262,12 @@ void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::s
 {
   if(marker.scale.x == 0.0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "width LINE_LIST or LINE_STRIP is 0.0 (scale.x)";
   }
   else if(marker.scale.y != 0.0 || marker.scale.z != 0.0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "scale.y and scale.z of LINE_LIST or LINE_STRIP are ignored";
   }
 }
@@ -276,12 +276,12 @@ void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(marker.scale.x == 0.0 || marker.scale.y == 0.0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "width and/or height of POINTS is 0.0 (scale.x, scale.y)";
   }
   else if(marker.scale.z != 0.0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "scale.z of POINTS is ignored";
   }
 }
@@ -290,12 +290,12 @@ void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if(marker.scale.z == 0.0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "text height of TEXT_VIEW_FACING is 0.0 (scale.z)";
   }
   else if(marker.scale.x != 0.0 || marker.scale.y != 0.0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "scale.x and scale.y of TEXT_VIEW_FACING are ignored";
   }
 }
@@ -304,7 +304,7 @@ void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss)
 {
   if(marker.color.a == 0.0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "marker is fully transparent (color.a is 0.0)";
   }
 }
@@ -313,7 +313,7 @@ void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(marker.points.size() != 0 && marker.points.size() != 2)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "Number of points for an ARROW marker should be either 0 or 2";
   }
 }
@@ -322,22 +322,22 @@ void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringst
 {
   if(marker.points.empty())
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "points should not be empty for specified marker type" ;
   }
   else if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST && (marker.points.size() % 3) != 0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "number of points should be a multiple of 3 for TRIANGLE_LIST Marker";
   }
   else if(marker.type == visualization_msgs::Marker::LINE_LIST && (marker.points.size() % 2) != 0)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "number of points should be a multiple of 2 for LINE_LIST Marker";
   }
   else if(marker.type == visualization_msgs::Marker::LINE_STRIP && marker.points.size() <= 1)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "at least two points are required for a LINE_STRIP Marker";
   }
 }
@@ -346,7 +346,7 @@ void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(!marker.points.empty())
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "points array is ignored by specified marker type";
   }
 }
@@ -360,7 +360,7 @@ void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss
   }
   if(marker.colors.size() != marker.points.size())
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "number of colors is not equal to number of points or 0";
   }
 }
@@ -369,7 +369,7 @@ void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstrea
 {
   if(!marker.colors.empty())
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "colors array is ignored by specified marker type";
   }
 }
@@ -378,12 +378,12 @@ void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std
 {
   if(marker.text.empty())
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "text is empty for TEXT_VIEW_FACING type marker";
   }
   else if(marker.text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "text of TEXT_VIEW_FACING Marker only consists of whitespaces";
   }
 }
@@ -392,7 +392,7 @@ void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if(!marker.text.empty())
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "text is ignored for specified marker type";
   }
 }
@@ -401,7 +401,7 @@ void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss)
 {
   if(marker.mesh_resource.empty())
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "path to mesh resource is empty for MESH_RESOURCE marker";
   }
 }
@@ -410,21 +410,21 @@ void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 {
   if (!marker.mesh_resource.empty())
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "mesh_resource is ignored for specified marker type";
   }
   if (marker.mesh_use_embedded_materials)
   {
-    addCommaIfRequired(ss);
+    addNewlineIfRequired(ss);
     ss << "using embedded materials is not supported for markers other than MESH_RESOURCE";
   }
 }
 
-void addCommaIfRequired(std::stringstream& ss)
+void addNewlineIfRequired(std::stringstream& ss)
 {
   if (ss.tellp() != 0) // check if string is not empty
   {
-    ss << ", ";
+    ss << "\n";
   }
 }
 

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -91,7 +91,6 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
     return true;
 
   std::stringstream ss;
-  addCommaIfRequired(ss);
   switch (marker.type) {
   case visualization_msgs::Marker::ARROW:
     checkQuaternion(marker, ss);

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -184,7 +184,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
   std::vector<MarkerID> marker_ids;
 
   bool add_marker_in_array = false;
-
+  bool reset_status = true;
   for(int i = 0; i < array.markers.size(); i++)
   {
     if(array.markers[i].action == visualization_msgs::Marker::ADD)
@@ -199,7 +199,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
       std::string warning_str = warning.str();
       ROS_WARN("MarkerArray: %s", warning_str.c_str());
       owner->setStatusStd(StatusProperty::Warn, "marker_array", warning_str);
-      return false;
+      reset_status = false;
     }
     MarkerID current_id(array.markers[i].ns, array.markers[i].id);
     std::vector<MarkerID>::iterator search = std::lower_bound(marker_ids.begin(), marker_ids.end(), current_id);
@@ -210,15 +210,18 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
       std::string ss_str = ss.str();
       ROS_WARN("MarkerArray: %s", ss_str.c_str());
       owner->setStatusStd(StatusProperty::Warn, "marker_array", ss_str);
-      return false;
+      reset_status = false;
     }
     else
     {
       marker_ids.insert(search, current_id);
     }
   }
-  owner->setStatusStd(StatusProperty::Ok, "marker_array", "OK");
-  return true;
+  if(reset_status)
+  {
+    owner->setStatusStd(StatusProperty::Ok, "marker_array", "OK");
+  }
+  return reset_status;
 }
 
 

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -161,7 +161,6 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
     ss << checkPointsEmpty(marker);
     ss << checkColorsEmpty(marker);
     ss << checkTextEmpty(marker);
-
     break;
 
   default:

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -215,7 +215,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
 }
 
 
-std::string checkQuaternion(const visualization_msgs::Marker& marker)
+const char* checkQuaternion(const visualization_msgs::Marker& marker)
 {
   if (marker.pose.orientation.x == 0.0
     && marker.pose.orientation.y == 0.0
@@ -230,7 +230,7 @@ std::string checkQuaternion(const visualization_msgs::Marker& marker)
   return "";
 }
 
-std::string checkScale(const visualization_msgs::Marker& marker)
+const char* checkScale(const visualization_msgs::Marker& marker)
 {
   // for ARROW markers, scale.z is the optional head length
   if(marker.type == visualization_msgs::Marker::ARROW && marker.scale.x != 0.0 && marker.scale.y != 0.0)
@@ -245,7 +245,7 @@ std::string checkScale(const visualization_msgs::Marker& marker)
   return "";
 }
 
-std::string checkScaleLineStripAndList(const visualization_msgs::Marker& marker)
+const char* checkScaleLineStripAndList(const visualization_msgs::Marker& marker)
 {
   if(marker.scale.x == 0.0)
   {
@@ -258,7 +258,7 @@ std::string checkScaleLineStripAndList(const visualization_msgs::Marker& marker)
   return "";
 }
 
-std::string checkScalePoints(const visualization_msgs::Marker& marker)
+const char* checkScalePoints(const visualization_msgs::Marker& marker)
 {
   if(marker.scale.x == 0.0 || marker.scale.y == 0.0)
   {
@@ -271,7 +271,7 @@ std::string checkScalePoints(const visualization_msgs::Marker& marker)
   return "";
 }
 
-std::string checkScaleText(const visualization_msgs::Marker& marker)
+const char* checkScaleText(const visualization_msgs::Marker& marker)
 {
   if(marker.scale.z == 0.0)
   {
@@ -284,43 +284,41 @@ std::string checkScaleText(const visualization_msgs::Marker& marker)
   return "";
 }
 
-std::string checkColor(const visualization_msgs::Marker& marker)
+const char* checkColor(const visualization_msgs::Marker& marker)
 {
   if(marker.color.a == 0.0)
     return "marker is fully transparent (color.a is 0.0), ";
   return "";
 }
 
-std::string checkPointsArrow(const visualization_msgs::Marker& marker)
+const char* checkPointsArrow(const visualization_msgs::Marker& marker)
 {
   if(marker.points.size() != 0 && marker.points.size() != 2)
     return "Number of points for an ARROW marker should be either 0 or 2";
   return "";
 }
 
-std::string checkPointsNotEmpty(const visualization_msgs::Marker& marker)
+const char* checkPointsNotEmpty(const visualization_msgs::Marker& marker)
 {
-  std::stringstream ss;
-  ss << marker.points.size();
   if(marker.points.empty())
     return "points should not be empty for specified marker type, " ;
   else if(marker.type == visualization_msgs::Marker::TRIANGLE_LIST && (marker.points.size() % 3) != 0)
-    return "number of points (" + ss.str() + ") should be a multiple of 3 for TRIANGLE_LIST Marker, ";
+    return "number of points should be a multiple of 3 for TRIANGLE_LIST Marker, ";
   else if(marker.type == visualization_msgs::Marker::LINE_LIST && (marker.points.size() % 2) != 0)
-    return "number of points (" + ss.str() + ") should be a multiple of 2 for LINE_LIST Marker, ";
+    return "number of points should be a multiple of 2 for LINE_LIST Marker, ";
   else if(marker.type == visualization_msgs::Marker::LINE_STRIP && marker.points.size() <= 1)
     return "at least two points are required for a LINE_STRIP Marker, ";
   return "";
 }
 
-std::string checkPointsEmpty(const visualization_msgs::Marker& marker)
+const char* checkPointsEmpty(const visualization_msgs::Marker& marker)
 {
   if(!marker.points.empty())
     return "points array is ignored by specified marker type, ";
   return "";
 }
 
-std::string checkColors(const visualization_msgs::Marker& marker)
+const char* checkColors(const visualization_msgs::Marker& marker)
 {
   if(marker.colors.size() == 0)
     return checkColor(marker);
@@ -329,14 +327,14 @@ std::string checkColors(const visualization_msgs::Marker& marker)
   return "";
 }
 
-std::string checkColorsEmpty(const visualization_msgs::Marker& marker)
+const char* checkColorsEmpty(const visualization_msgs::Marker& marker)
 {
   if(!marker.colors.empty())
     return "colors array is ignored by specified marker type, ";
   return "";
 }
 
-std::string checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker)
+const char* checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker)
 {
   if(marker.text.empty())
     return "text is empty for TEXT_VIEW_FACING type marker, ";
@@ -345,28 +343,28 @@ std::string checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& mark
   return "";
 }
 
-std::string checkTextEmpty(const visualization_msgs::Marker& marker)
+const char* checkTextEmpty(const visualization_msgs::Marker& marker)
 {
   if(!marker.text.empty())
     return "text is ignored for specified marker type, ";
   return "";
 }
 
-std::string checkMesh(const visualization_msgs::Marker& marker)
+const char* checkMesh(const visualization_msgs::Marker& marker)
 {
   if(marker.mesh_resource.empty())
     return "path to mesh resource is empty for MESH_RESOURCE marker, ";
   return "";
 }
 
-std::string checkMeshEmpty(const visualization_msgs::Marker& marker)
+const char* checkMeshEmpty(const visualization_msgs::Marker& marker)
 {
   std::stringstream ss;
   if (!marker.mesh_resource.empty())
     ss << "mesh_resource is ignored for specified marker type, ";
   if (marker.mesh_use_embedded_materials)
     ss << "using embedded materials is not supported for markers other than MESH_RESOURCE, ";
-  return ss.str();
+  return ss.str().c_str();
 }
 
 } // namespace rviz

--- a/src/rviz/default_plugin/marker_utils.h
+++ b/src/rviz/default_plugin/marker_utils.h
@@ -30,6 +30,10 @@
 #ifndef RVIZ_MARKER_UTILS_H
 #define RVIZ_MARKER_UTILS_H
 
+
+#include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
+
 namespace Ogre
 {
 class SceneNode;
@@ -44,6 +48,33 @@ class MarkerBase;
 
 /** Create a marker of given type as declared in visualization_messages::Marker */
 MarkerBase* createMarker(int marker_type, MarkerDisplay *owner, DisplayContext *context, Ogre::SceneNode *parent_node);
+
+bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* owner);
+bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDisplay* owner);
+
+std::string checkQuaternion(const visualization_msgs::Marker& marker);
+
+std::string checkScale(const visualization_msgs::Marker& marker);
+std::string checkScaleLineStripAndList(const visualization_msgs::Marker& marker);
+std::string checkScalePoints(const visualization_msgs::Marker& marker);
+std::string checkScaleText(const visualization_msgs::Marker& marker);
+
+std::string checkColor(const visualization_msgs::Marker& marker);
+
+
+std::string checkPointsArrow(const visualization_msgs::Marker& marker);
+std::string checkPointsNotEmpty(const visualization_msgs::Marker& marker);
+std::string checkPointsEmpty(const visualization_msgs::Marker& marker);
+
+std::string checkColors(const visualization_msgs::Marker& marker);
+std::string checkColorsEmpty(const visualization_msgs::Marker& marker);
+
+std::string checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker);
+std::string checkTextEmpty(const visualization_msgs::Marker& marker);
+
+std::string checkMesh(const visualization_msgs::Marker& marker);
+std::string checkMeshEmpty(const visualization_msgs::Marker& marker);
+
 
 }
 

--- a/src/rviz/default_plugin/marker_utils.h
+++ b/src/rviz/default_plugin/marker_utils.h
@@ -52,30 +52,30 @@ MarkerBase* createMarker(int marker_type, MarkerDisplay *owner, DisplayContext *
 bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* owner);
 bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDisplay* owner);
 
-const char* checkQuaternion(const visualization_msgs::Marker& marker);
+void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream& ss);
 
-const char* checkScale(const visualization_msgs::Marker& marker);
-const char* checkScaleLineStripAndList(const visualization_msgs::Marker& marker);
-const char* checkScalePoints(const visualization_msgs::Marker& marker);
-const char* checkScaleText(const visualization_msgs::Marker& marker);
+void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream& ss);
 
-const char* checkColor(const visualization_msgs::Marker& marker);
-
-
-const char* checkPointsArrow(const visualization_msgs::Marker& marker);
-const char* checkPointsNotEmpty(const visualization_msgs::Marker& marker);
-const char* checkPointsEmpty(const visualization_msgs::Marker& marker);
-
-const char* checkColors(const visualization_msgs::Marker& marker);
-const char* checkColorsEmpty(const visualization_msgs::Marker& marker);
-
-const char* checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker);
-const char* checkTextEmpty(const visualization_msgs::Marker& marker);
-
-const char* checkMesh(const visualization_msgs::Marker& marker);
-const char* checkMeshEmpty(const visualization_msgs::Marker& marker);
+void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss);
 
 
+void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+
+void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+
+void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+
+void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+
+void addCommaIfRequired(std::stringstream& ss);
 }
 
 #endif

--- a/src/rviz/default_plugin/marker_utils.h
+++ b/src/rviz/default_plugin/marker_utils.h
@@ -75,7 +75,7 @@ void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss);
 void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
 
-void addNewlineIfRequired(std::stringstream& ss);
+void addCommaAndNewlineIfRequired(std::stringstream& ss);
 }
 
 #endif

--- a/src/rviz/default_plugin/marker_utils.h
+++ b/src/rviz/default_plugin/marker_utils.h
@@ -52,28 +52,28 @@ MarkerBase* createMarker(int marker_type, MarkerDisplay *owner, DisplayContext *
 bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* owner);
 bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDisplay* owner);
 
-std::string checkQuaternion(const visualization_msgs::Marker& marker);
+const char* checkQuaternion(const visualization_msgs::Marker& marker);
 
-std::string checkScale(const visualization_msgs::Marker& marker);
-std::string checkScaleLineStripAndList(const visualization_msgs::Marker& marker);
-std::string checkScalePoints(const visualization_msgs::Marker& marker);
-std::string checkScaleText(const visualization_msgs::Marker& marker);
+const char* checkScale(const visualization_msgs::Marker& marker);
+const char* checkScaleLineStripAndList(const visualization_msgs::Marker& marker);
+const char* checkScalePoints(const visualization_msgs::Marker& marker);
+const char* checkScaleText(const visualization_msgs::Marker& marker);
 
-std::string checkColor(const visualization_msgs::Marker& marker);
+const char* checkColor(const visualization_msgs::Marker& marker);
 
 
-std::string checkPointsArrow(const visualization_msgs::Marker& marker);
-std::string checkPointsNotEmpty(const visualization_msgs::Marker& marker);
-std::string checkPointsEmpty(const visualization_msgs::Marker& marker);
+const char* checkPointsArrow(const visualization_msgs::Marker& marker);
+const char* checkPointsNotEmpty(const visualization_msgs::Marker& marker);
+const char* checkPointsEmpty(const visualization_msgs::Marker& marker);
 
-std::string checkColors(const visualization_msgs::Marker& marker);
-std::string checkColorsEmpty(const visualization_msgs::Marker& marker);
+const char* checkColors(const visualization_msgs::Marker& marker);
+const char* checkColorsEmpty(const visualization_msgs::Marker& marker);
 
-std::string checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker);
-std::string checkTextEmpty(const visualization_msgs::Marker& marker);
+const char* checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker);
+const char* checkTextEmpty(const visualization_msgs::Marker& marker);
 
-std::string checkMesh(const visualization_msgs::Marker& marker);
-std::string checkMeshEmpty(const visualization_msgs::Marker& marker);
+const char* checkMesh(const visualization_msgs::Marker& marker);
+const char* checkMeshEmpty(const visualization_msgs::Marker& marker);
 
 
 }

--- a/src/rviz/default_plugin/marker_utils.h
+++ b/src/rviz/default_plugin/marker_utils.h
@@ -75,7 +75,7 @@ void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss);
 void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
 
-void addCommaIfRequired(std::stringstream& ss);
+void addNewlineIfRequired(std::stringstream& ss);
 }
 
 #endif

--- a/src/rviz/default_plugin/marker_utils.h
+++ b/src/rviz/default_plugin/marker_utils.h
@@ -33,6 +33,7 @@
 
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
+#include "rviz/properties/status_property.h"
 
 namespace Ogre
 {
@@ -52,30 +53,31 @@ MarkerBase* createMarker(int marker_type, MarkerDisplay *owner, DisplayContext *
 bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* owner);
 bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDisplay* owner);
 
-void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 
-void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss);
-void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::stringstream& ss);
-void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstream& ss);
-void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
+void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
+void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
+void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 
-void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 
 
-void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstream& ss);
-void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
-void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
+void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
+void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 
-void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss);
-void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
+void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 
-void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std::stringstream& ss);
-void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
+void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 
-void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss);
-void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss);
+void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
+void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 
 void addCommaAndNewlineIfRequired(std::stringstream& ss);
+void increaseWarningLevel(StatusProperty::Level new_status, StatusProperty::Level& current_status);
 }
 
 #endif

--- a/src/rviz/default_plugin/marker_utils.h
+++ b/src/rviz/default_plugin/marker_utils.h
@@ -76,7 +76,7 @@ void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream&
 void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
 
-void addCommaAndNewlineIfRequired(std::stringstream& ss);
+void addSeparatorIfRequired(std::stringstream& ss);
 void increaseWarningLevel(StatusProperty::Level new_status, StatusProperty::Level& current_status);
 }
 

--- a/src/rviz/default_plugin/markers/arrow_marker.cpp
+++ b/src/rviz/default_plugin/markers/arrow_marker.cpp
@@ -71,14 +71,6 @@ void ArrowMarker::onNewMessage(const MarkerConstPtr& old_message, const MarkerCo
 
   if (!new_message->points.empty() && new_message->points.size() < 2)
   {
-    std::stringstream ss;
-    ss << "Arrow marker [" << getStringID() << "] only specified one point of a point to point arrow.";
-    if ( owner_ )
-    {
-      owner_->setMarkerStatus(getID(), StatusProperty::Error, ss.str());
-    }
-    ROS_DEBUG("%s", ss.str().c_str());
-
     delete arrow_;
     arrow_ = 0;
 
@@ -138,10 +130,6 @@ void ArrowMarker::onNewMessage(const MarkerConstPtr& old_message, const MarkerCo
       // Reset arrow to default proportions if we previously set it from points
       setDefaultProportions();
       last_arrow_set_from_points_ = false;
-    }
-    if ( owner_ && (new_message->scale.x * new_message->scale.y * new_message->scale.z == 0.0f) )
-    {
-      owner_->setMarkerStatus(getID(), StatusProperty::Warn, "Scale of 0 in one of x/y/z");
     }
     arrow_->setScale(scale);
 

--- a/src/rviz/default_plugin/markers/line_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/line_list_marker.cpp
@@ -124,16 +124,6 @@ void LineListMarker::onNewMessage(const MarkerConstPtr& old_message, const Marke
     handler_.reset( new MarkerSelectionHandler( this, MarkerID( new_message->ns, new_message->id ), context_ ));
     handler_->addTrackedObjects( lines_->getSceneNode() );
   }
-  else
-  {
-    std::stringstream ss;
-    ss << "Line list marker [" << getStringID() << "] has an odd number of points.";
-    if ( owner_ )
-    {
-      owner_->setMarkerStatus(getID(), StatusProperty::Error, ss.str());
-    }
-    ROS_DEBUG("%s", ss.str().c_str());
-  }
 }
 
 S_MaterialPtr LineListMarker::getMaterials()

--- a/src/rviz/default_plugin/markers/points_marker.cpp
+++ b/src/rviz/default_plugin/markers/points_marker.cpp
@@ -138,10 +138,6 @@ void PointsMarker::onNewMessage(const MarkerConstPtr& old_message, const MarkerC
 
   if (has_per_point_color)
   {
-    if (!has_nonzero_alpha && owner_)
-    {
-      owner_->setMarkerStatus(getID(), StatusProperty::Warn, "All points have a zero alpha value.");
-    }
     points_->setAlpha(1.0, has_per_point_alpha);
   }
   else

--- a/src/rviz/default_plugin/markers/shape_marker.cpp
+++ b/src/rviz/default_plugin/markers/shape_marker.cpp
@@ -83,13 +83,6 @@ void ShapeMarker::onNewMessage( const MarkerConstPtr& old_message,
   Ogre::Quaternion orient;
   transform(new_message, pos, orient, scale);
 
-  if (owner_ && (new_message->scale.x * new_message->scale.y
-      * new_message->scale.z == 0.0f))
-  {
-    owner_->setMarkerStatus(getID(), StatusProperty::Warn,
-        "Scale of 0 in one of x/y/z");
-  }
-
   setPosition(pos);
   setOrientation( orient * Ogre::Quaternion( Ogre::Degree(90), Ogre::Vector3(1,0,0) ) );
 

--- a/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
+++ b/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
@@ -57,6 +57,8 @@ void TextViewFacingMarker::onNewMessage(const MarkerConstPtr& old_message, const
 {
   ROS_ASSERT(new_message->type == visualization_msgs::Marker::TEXT_VIEW_FACING);
 
+  if(new_message->text.empty()|| new_message->text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
+    return;
   if (!text_)
   {
     text_ = new MovableText(new_message->text);

--- a/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
+++ b/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
@@ -57,8 +57,9 @@ void TextViewFacingMarker::onNewMessage(const MarkerConstPtr& old_message, const
 {
   ROS_ASSERT(new_message->type == visualization_msgs::Marker::TEXT_VIEW_FACING);
 
-  if(new_message->text.empty()|| new_message->text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
+  if (new_message->text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
     return;
+
   if (!text_)
   {
     text_ = new MovableText(new_message->text);

--- a/src/rviz/default_plugin/markers/triangle_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.cpp
@@ -71,21 +71,6 @@ void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const M
   size_t num_points = new_message->points.size();
   if( (num_points % 3) != 0 || num_points == 0 )
   {
-    std::stringstream ss;
-    if( num_points == 0 )
-    {
-      ss << "TriMesh marker [" << getStringID() << "] has no points.";
-    }
-    else
-    {
-      ss << "TriMesh marker [" << getStringID() << "] has a point count which is not divisible by 3 [" << num_points <<"]";
-    }
-    if ( owner_ )
-    {
-      owner_->setMarkerStatus(getID(), StatusProperty::Error, ss.str());
-    }
-    ROS_DEBUG("%s", ss.str().c_str());
-
     scene_node_->setVisible( false );
     return;
   }
@@ -119,11 +104,6 @@ void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const M
     ROS_DEBUG("Unable to transform marker message");
     scene_node_->setVisible( false );
     return;
-  }
-  
-  if ( owner_ &&  (new_message->scale.x * new_message->scale.y * new_message->scale.z == 0.0f) )
-  {
-    owner_->setMarkerStatus(getID(), StatusProperty::Warn, "Scale of 0 in one of x/y/z");
   }
 
   setPosition(pos);


### PR DESCRIPTION
Using rviz Markers for debugging is often very useful, but sometimes the developer makes mistakes when filling in the fields of the marker.
In some cases the resulting markers are not visible or not displayed as intended.
In a few cases this lead to long debugging sessions when the actual problem was the visualization...

Until now there was little and unorganized debug output from rviz to assist the developer in some of these cases.

I have implemented a systematic check of all marker types as well as marker arrays
as described [here](http://wiki.ros.org/rviz/DisplayTypes/Marker) and implemented in the Display.

During testing I found some other bugs as well:

- `TEXT_VIEW_FACING` Markers with an empty text cause rviz to segfault.
- `TEXT_VIEW_FACING` Markers with text that consists exclusively of whitespace trigger a vertex buffer overflow.

These two bugs are resolved in commit d30cda4 

- Markers with an undefined type cause rviz to crash

This is resolved in commit 9c15d9a

Apart from the bugfixes, this pull-request does not change the rendering behavior of rviz.
It simply provides additional warning output to the console and to the display status.

We would like to see this merged in kinetic&upwards, so the request intentionally targets `kinetic-devel`.


@v4hn