### PR TITLE
Replace display error assert with warning, fallback and error 

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -142,7 +142,7 @@ void RenderSystem::setupDummyWindowId()
 
     if (display == NULL) {
       ROS_FATAL("Can't open default or :0 display. Try setting DISPLAY environment variable.");
-      std::runtime_error( "Can't open default or :0 display!\n");
+      throw std::runtime_error("Can't open default or :0 display!\n");
     }
 
   }

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -134,7 +134,18 @@ void RenderSystem::setupDummyWindowId()
   dummy_window_id_ = 0;
 #else
   Display *display = XOpenDisplay(0);
-  assert( display );
+
+  if (display == NULL) {
+
+    ROS_WARN("$DISPLAY is invalid, falling back on default :0");
+    display = XOpenDisplay(":0");
+
+    if (display == NULL) {
+      ROS_FATAL("Can't open default or :0 display. Try setting DISPLAY environment variable.");
+      std::runtime_error( "Can't open default or :0 display!\n");
+    }
+
+  }
 
   int screen = DefaultScreen( display );
 


### PR DESCRIPTION
Replace assert with warning, fallback and error so that when in release mode, librviz does not segfault with a misconfigured DISPLAY env.

In our use of librviz, RenderSystem::setupDummyWindowId() was segfaulting since display was not set correctly. This will provide warnings, fallback and a useful error in such cases.