### PR TITLE
Poll at 1Hz for robot description until it is found.

### DIFF
--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -88,6 +88,7 @@ RobotModelDisplay::RobotModelDisplay()
                                             "Robot Model normally assumes the link name is the same as the tf frame name. "
                                             " This option allows you to set a prefix.  Mainly useful for multi-robot situations.",
                                             this, SLOT( updateTfPrefix() ));
+
 }
 
 RobotModelDisplay::~RobotModelDisplay()
@@ -141,6 +142,12 @@ void RobotModelDisplay::updateTfPrefix()
 }
 
 void RobotModelDisplay::load()
+{
+  timer_ = update_nh_.createTimer(ros::Duration(1.0),
+      &RobotModelDisplay::lookForDescription, this, false, true);
+}
+
+void RobotModelDisplay::lookForDescription(const ros::TimerEvent & event)
 {
   std::string content;
   if( !update_nh_.getParam( robot_description_property_->getStdString(), content ))
@@ -196,6 +203,9 @@ void RobotModelDisplay::load()
   robot_->update( TFLinkUpdater( context_->getFrameManager(),
                                  boost::bind( linkUpdaterStatusFunction, _1, _2, _3, this ),
                                  tf_prefix_property_->getStdString() ));
+
+  // We have now found the description, so no need to keep looking
+  timer_.stop();
 }
 
 void RobotModelDisplay::onEnable()

--- a/src/rviz/default_plugin/robot_model_display.h
+++ b/src/rviz/default_plugin/robot_model_display.h
@@ -82,10 +82,14 @@ private Q_SLOTS:
   void updateRobotDescription();
 
 protected:
+  /** @brief Sets up a timer to keep looking for a description, and
+   * only stops when one is ultimately found. */
+  virtual void load();
+
   /** @brief Loads a URDF from the ros-param named by our
    * "Robot Description" property, iterates through the links, and
    * loads any necessary models. */
-  virtual void load();
+  void lookForDescription(const ros::TimerEvent & event);
 
   // overrides from Display
   virtual void onEnable();
@@ -96,6 +100,8 @@ protected:
   bool has_new_transforms_;      ///< Callback sets this to tell our update function it needs to update the transforms
 
   float time_since_last_transform_;
+
+  ros::Timer timer_;             ///< A timer for polling for description until found
 
   std::string robot_description_;
 
@@ -110,4 +116,3 @@ protected:
 } // namespace rviz
 
  #endif
-


### PR DESCRIPTION
This commit safeguards against the case where a robot description only becomes available as a ROS parameter **after** rviz loads. A timer is used to poll for the robot description at 1Hz until it is found. As soon as the robot description is found, then the timer is stopped.