### PR TITLE
Fix rendering order for movable text

### DIFF
--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -129,7 +129,7 @@ void MovableText::setFontName(const String &fontName)
 
     mpMaterial->setDepthCheckEnabled(!mOnTop);
     mpMaterial->setDepthBias(1.0, 1.0);
-    mpMaterial->setDepthWriteEnabled(true);
+    mpMaterial->setDepthWriteEnabled(false);
     mpMaterial->setLightingEnabled(false);
     mNeedUpdate = true;
   }

--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -88,6 +88,7 @@ MovableText::MovableText(const String &caption, const String &fontName, Real cha
   mRenderOp.vertexData = NULL;
   this->setFontName(mFontName);
   this->_setupGeometry();
+  this->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
 }
 
 MovableText::~MovableText()
@@ -128,7 +129,7 @@ void MovableText::setFontName(const String &fontName)
 
     mpMaterial->setDepthCheckEnabled(!mOnTop);
     mpMaterial->setDepthBias(1.0, 1.0);
-    mpMaterial->setDepthWriteEnabled(mOnTop);
+    mpMaterial->setDepthWriteEnabled(true);
     mpMaterial->setLightingEnabled(false);
     mNeedUpdate = true;
   }


### PR DESCRIPTION
I recently had to render transparent textures for a map visualization
plugin. Traditional wisdom says that solid objects are rendered first,
and everything transparent afterwards. However, choosing a later Ogre
rendering queue overwrites all movable text elements, since they disable
depth writing for some reason.

This PR therefore moves the movable text to the latest possible
rendering queue. For always-on-top rendering, the depth check is
disabled. I decided to leave depth buffer writing always on, although it
won't make much of a difference either way.

**Edit:** I forgot about overlapping text elements, so I re-disabled depth buffer writing.