### PR TITLE
RobotModelDisplay: clear statuses when (re)loading a model

### DIFF
--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -140,6 +140,8 @@ void RobotModelDisplay::updateTfPrefix()
 
 void RobotModelDisplay::load()
 {
+  clearStatuses();
+
   std::string content;
   if( !update_nh_.getParam( robot_description_property_->getStdString(), content ))
   {


### PR DESCRIPTION
I observed some spurious (error) status msgs in RobotModelDisplay when loading rviz. In my situation I had a (left-over) `robot_description`, and another robot description (with a different name) on the parameter server. When loading, the RobotModelDisplay first loads the default `robot_description`, missing all the link transforms, then loads the correct robot description. The error msgs however remain.

Hence, before loading a new model, all status messages should be cleared.