### PR TITLE
WIP: Adding a panel now loads it properties

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -622,6 +622,11 @@ void VisualizationFrame::openNewPanelDialog()
     if ( dock )
     {
       connect( dock, SIGNAL( dockLocationChanged( Qt::DockWidgetArea )), this, SLOT( onDockPanelChange() ) );
+      Panel* panel = qobject_cast<Panel*>( dock->widget() );
+      if( panel )
+      {
+        panel->load( config_ );
+      }
     }
   }
   manager_->startUpdate();
@@ -726,11 +731,10 @@ void VisualizationFrame::loadDisplayConfig( const QString& qpath )
   }
 
   YamlConfigReader reader;
-  Config config;
-  reader.readFile( config, QString::fromStdString( actual_load_path ));
+  reader.readFile( config_, QString::fromStdString( actual_load_path ));
   if( !reader.error() )
   {
-    load( config );
+    load( config_ );
   }
 
   markRecentConfig( path );

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -371,6 +371,10 @@ protected:
 
   /// Indicates if the toolbar should be visible outside of fullscreen mode.
   bool toolbar_visible_;
+
+  /// Config holds the window properties, what panels are displayed, where etc. and each property of the panel.
+  /// It is used when opening the application and when a new panel is added to load it's preferences.
+  Config config_;
 };
 
 }


### PR DESCRIPTION
Fixes #1172 

`openNewPanelDialog` deals with newly added panels, it now calls the `load` member of the panel to load it's properties.

To do that I needed to have access to the RViz config file so I added a new member to the class holding the data structure. `loadDisplayConfig` fills this data member so that it is available later.

Fixes https://gitlab.com/InstitutMaupertuis/ros_additive_manufacturing/issues/127