### PR TITLE
expose VisualizationFrame::addPanelByName()

### DIFF
--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -113,6 +113,11 @@ public:
                                 Qt::DockWidgetArea area = Qt::LeftDockWidgetArea,
                                 bool floating = true );
 
+  QDockWidget* addPanelByName( const QString& name,
+                               const QString& class_lookup_name,
+                               Qt::DockWidgetArea area = Qt::LeftDockWidgetArea,
+                               bool floating = true );
+
   /** @brief Load the "general" config file, which has just the few
    * things which should not be saved with a display config.
    *
@@ -271,11 +276,6 @@ protected:
 
   void markRecentConfig(const std::string& path);
   void updateRecentConfigMenu();
-
-  QDockWidget* addPanelByName( const QString& name,
-                               const QString& class_lookup_name,
-                               Qt::DockWidgetArea area = Qt::LeftDockWidgetArea,
-                               bool floating = true );
 
   /** @brief Loads custom panels from the given config node. */
   void loadPanels( const Config& config );


### PR DESCRIPTION
... to allow saving of programmatically created panels.

Otherwise, panels can only be added via addPane(), which doesn't add them to `custom_panels_`.
However, [only panels in `custom_panels_` are actually saved](https://github.com/ros-visualization/rviz/blob/melodic-devel/src/rviz/visualization_frame.cpp#L931-L934).

Would be great to backport this to Kinetic too.