### PR TITLE
feat: Configurable tool button style kinetic

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -119,7 +119,7 @@ VisualizationFrame::VisualizationFrame( QWidget* parent )
   , splash_( NULL )
   , toolbar_actions_( NULL )
   , show_choose_new_master_option_( false )
-  , add_tool_action_( NULL )
+  , toolbar_button_separator_( NULL )
   , remove_tool_menu_( NULL )
   , initialized_( false )
   , geom_change_detector_( new WidgetGeometryChangeDetector( this ))
@@ -503,11 +503,13 @@ void VisualizationFrame::initToolbars()
   connect( toolbar_actions_, SIGNAL( triggered( QAction* )), this, SLOT( onToolbarActionTriggered( QAction* )));
   view_menu_->addAction( toolbar_->toggleViewAction() );
 
-  add_tool_action_ = new QAction( "", toolbar_actions_ );
-  add_tool_action_->setToolTip( "Add a new tool" );
-  add_tool_action_->setIcon( loadPixmap( "package://rviz/icons/plus.png" ) );
-  toolbar_->addAction( add_tool_action_ );
-  connect( add_tool_action_, SIGNAL( triggered() ), this, SLOT( openNewToolDialog() ));
+  toolbar_button_separator_ = toolbar_->addSeparator();
+
+  QToolButton* add_tool_button = new QToolButton();
+  add_tool_button->setToolTip( "Add a new tool" );
+  add_tool_button->setIcon( loadPixmap( "package://rviz/icons/plus.png" ) );
+  toolbar_->addWidget( add_tool_button );
+  connect(add_tool_button, SIGNAL(clicked()), this, SLOT(openNewToolDialog()));
 
   remove_tool_menu_ = new QMenu();
   QToolButton* remove_tool_button = new QToolButton();
@@ -519,18 +521,18 @@ void VisualizationFrame::initToolbars()
   connect( remove_tool_menu_, SIGNAL( triggered( QAction* )), this, SLOT( onToolbarRemoveTool( QAction* )));
 
   QMenu* button_style_menu = new QMenu();
-  QAction* actionToolButtonIconOnly = new QAction( "Icon only", toolbar_actions_ );
-  actionToolButtonIconOnly->setData(Qt::ToolButtonIconOnly);
-  button_style_menu->addAction(actionToolButtonIconOnly);
-  QAction* actionToolButtonTextOnly = new QAction( "Text only", toolbar_actions_ );
-  actionToolButtonTextOnly->setData(Qt::ToolButtonTextOnly);
-  button_style_menu->addAction(actionToolButtonTextOnly);
-  QAction* actionToolButtonTextBesideIcon = new QAction( "Text beside icon", toolbar_actions_ );
-  actionToolButtonTextBesideIcon->setData(Qt::ToolButtonTextBesideIcon);
-  button_style_menu->addAction(actionToolButtonTextBesideIcon);
-  QAction* actionToolButtonTextUnderIcon = new QAction( "Text under icon", toolbar_actions_ );
-  actionToolButtonTextUnderIcon->setData(Qt::ToolButtonTextUnderIcon);
-  button_style_menu->addAction(actionToolButtonTextUnderIcon);
+  QAction* action_tool_button_icon_only = new QAction( "Icon only", toolbar_actions_ );
+  action_tool_button_icon_only->setData(Qt::ToolButtonIconOnly);
+  button_style_menu->addAction(action_tool_button_icon_only);
+  QAction* action_tool_button_text_only = new QAction( "Text only", toolbar_actions_ );
+  action_tool_button_text_only->setData(Qt::ToolButtonTextOnly);
+  button_style_menu->addAction(action_tool_button_text_only);
+  QAction* action_tool_button_text_beside_icon = new QAction( "Text beside icon", toolbar_actions_ );
+  action_tool_button_text_beside_icon->setData(Qt::ToolButtonTextBesideIcon);
+  button_style_menu->addAction(action_tool_button_text_beside_icon);
+  QAction* action_tool_button_text_under_icon = new QAction( "Text under icon", toolbar_actions_ );
+  action_tool_button_text_under_icon->setData(Qt::ToolButtonTextUnderIcon);
+  button_style_menu->addAction(action_tool_button_text_under_icon);
 
   QToolButton* button_style_button = new QToolButton();
   button_style_button->setMenu( button_style_menu );
@@ -1121,7 +1123,7 @@ void VisualizationFrame::addTool( Tool* tool )
   action->setIcon( tool->getIcon() );
   action->setIconText( tool->getName() );
   action->setCheckable( true );
-  toolbar_->insertAction( add_tool_action_, action );
+  toolbar_->insertAction(toolbar_button_separator_, action);
   action_to_tool_map_[ action ] = tool;
   tool_to_action_map_[ tool ] = action;
 

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -518,6 +518,27 @@ void VisualizationFrame::initToolbars()
   toolbar_->addWidget( remove_tool_button );
   connect( remove_tool_menu_, SIGNAL( triggered( QAction* )), this, SLOT( onToolbarRemoveTool( QAction* )));
 
+  QMenu* button_style_menu = new QMenu();
+  QAction* actionToolButtonIconOnly = new QAction( "Icon only", toolbar_actions_ );
+  actionToolButtonIconOnly->setData(Qt::ToolButtonIconOnly);
+  button_style_menu->addAction(actionToolButtonIconOnly);
+  QAction* actionToolButtonTextOnly = new QAction( "Text only", toolbar_actions_ );
+  actionToolButtonTextOnly->setData(Qt::ToolButtonTextOnly);
+  button_style_menu->addAction(actionToolButtonTextOnly);
+  QAction* actionToolButtonTextBesideIcon = new QAction( "Text beside icon", toolbar_actions_ );
+  actionToolButtonTextBesideIcon->setData(Qt::ToolButtonTextBesideIcon);
+  button_style_menu->addAction(actionToolButtonTextBesideIcon);
+  QAction* actionToolButtonTextUnderIcon = new QAction( "Text under icon", toolbar_actions_ );
+  actionToolButtonTextUnderIcon->setData(Qt::ToolButtonTextUnderIcon);
+  button_style_menu->addAction(actionToolButtonTextUnderIcon);
+
+  QToolButton* button_style_button = new QToolButton();
+  button_style_button->setMenu( button_style_menu );
+  button_style_button->setPopupMode( QToolButton::InstantPopup );
+  button_style_button->setToolTip( "Set toolbar style" );
+  button_style_button->setIcon( loadPixmap( "package://rviz/icons/visibility.svg" ) );
+  toolbar_->addWidget( button_style_button );
+  connect( button_style_menu, SIGNAL( triggered( QAction* )), this, SLOT( onButtonStyleTool( QAction* )));
 }
 
 void VisualizationFrame::hideDockImpl( Qt::DockWidgetArea area, bool hide )
@@ -790,6 +811,7 @@ void VisualizationFrame::save( Config config )
   manager_->save( config.mapMakeChild( "Visualization Manager" ));
   savePanels( config.mapMakeChild( "Panels" ));
   saveWindowGeometry( config.mapMakeChild( "Window Geometry" ));
+  saveToolbars( config.mapMakeChild( "Toolbars" ));
 }
 
 void VisualizationFrame::load( const Config& config )
@@ -797,6 +819,7 @@ void VisualizationFrame::load( const Config& config )
   manager_->load( config.mapGetChild( "Visualization Manager" ));
   loadPanels( config.mapGetChild( "Panels" ));
   loadWindowGeometry( config.mapGetChild( "Window Geometry" ));
+  configureToolbars( config.mapGetChild( "Toolbars" ));
 }
 
 void VisualizationFrame::loadWindowGeometry( const Config& config )
@@ -841,6 +864,20 @@ void VisualizationFrame::loadWindowGeometry( const Config& config )
   config.mapGetBool( "Hide Right Dock", &b );
   hideRightDock(b);
   hide_right_dock_button_->setChecked( b );
+}
+
+void VisualizationFrame::configureToolbars( const Config& config )
+{
+  int tool_button_style;
+  if ( config.mapGetInt( "toolButtonStyle", &tool_button_style) )
+  {
+    toolbar_->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(tool_button_style));
+  }
+}
+
+void VisualizationFrame::saveToolbars( Config config )
+{
+  config.mapSetValue( "toolButtonStyle", static_cast<int>(toolbar_->toolButtonStyle()) );
 }
 
 void VisualizationFrame::saveWindowGeometry( Config config )
@@ -1113,6 +1150,11 @@ void VisualizationFrame::onToolbarRemoveTool( QAction* remove_tool_menu_action )
       return;
     }
   }
+}
+
+void VisualizationFrame::onButtonStyleTool( QAction* button_style_tool_menu_action )
+{
+  toolbar_->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(button_style_tool_menu_action->data().toInt()));
 }
 
 void VisualizationFrame::removeTool( Tool* tool )

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -119,7 +119,7 @@ VisualizationFrame::VisualizationFrame( QWidget* parent )
   , splash_( NULL )
   , toolbar_actions_( NULL )
   , show_choose_new_master_option_( false )
-  , toolbar_button_separator_( NULL )
+  , add_tool_action_( NULL )
   , remove_tool_menu_( NULL )
   , initialized_( false )
   , geom_change_detector_( new WidgetGeometryChangeDetector( this ))
@@ -503,7 +503,7 @@ void VisualizationFrame::initToolbars()
   connect( toolbar_actions_, SIGNAL( triggered( QAction* )), this, SLOT( onToolbarActionTriggered( QAction* )));
   view_menu_->addAction( toolbar_->toggleViewAction() );
 
-  toolbar_button_separator_ = toolbar_->addSeparator();
+  add_tool_action_ = toolbar_->addSeparator();
 
   QToolButton* add_tool_button = new QToolButton();
   add_tool_button->setToolTip( "Add a new tool" );
@@ -1123,7 +1123,7 @@ void VisualizationFrame::addTool( Tool* tool )
   action->setIcon( tool->getIcon() );
   action->setIconText( tool->getName() );
   action->setCheckable( true );
-  toolbar_->insertAction(toolbar_button_separator_, action);
+  toolbar_->insertAction(add_tool_action_, action);
   action_to_tool_map_[ action ] = tool;
   tool_to_action_map_[ tool ] = action;
 

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -353,7 +353,8 @@ protected:
   };
   QList<PanelRecord> custom_panels_;
 
-  QAction* toolbar_button_separator_;
+  //! @todo Rename to toolbar_button_separator_ in Noetic
+  QAction* add_tool_action_;
   QMenu* remove_tool_menu_;
 
   bool initialized_;

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -258,6 +258,7 @@ protected:
 
   void initMenus();
 
+  /** @brief Sets up the top toolbar with QToolbuttions for adding/deleting tools and modifiying the tool view **/
   void initToolbars();
 
   /** @brief Check for unsaved changes, prompt to save config, etc.
@@ -279,7 +280,10 @@ protected:
   /** @brief Loads custom panels from the given config node. */
   void loadPanels( const Config& config );
 
+  /** @brief Applies the user defined toolbar configuration from the given config node **/
   void configureToolbars( const Config& config );
+
+  /** @brief Saves the user configuration of the toolbar to the config node **/
   void saveToolbars( Config config );
 
   /** @brief Saves custom panels to the given config node. */
@@ -349,7 +353,7 @@ protected:
   };
   QList<PanelRecord> custom_panels_;
 
-  QAction* add_tool_action_;
+  QAction* toolbar_button_separator_;
   QMenu* remove_tool_menu_;
 
   bool initialized_;

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -187,6 +187,9 @@ protected Q_SLOTS:
   /** @brief Remove a the tool whose name is given by remove_tool_menu_action->text(). */
   void onToolbarRemoveTool( QAction* remove_tool_menu_action );
 
+  /** @brief Change the button style of the toolbar */
+  void onButtonStyleTool( QAction* button_style_tool_menu_action );
+
   /** @brief Looks up the Tool for this action and calls
    * VisualizationManager::setCurrentTool(). */
   void onToolbarActionTriggered( QAction* action );
@@ -275,6 +278,9 @@ protected:
 
   /** @brief Loads custom panels from the given config node. */
   void loadPanels( const Config& config );
+
+  void configureToolbars( const Config& config );
+  void saveToolbars( Config config );
 
   /** @brief Saves custom panels to the given config node. */
   void savePanels( Config config );


### PR DESCRIPTION
When using a lot of tools, it's annoying that not all tools fit in the default toolbar. This PR adds an additional tool menu (next to the remove tool menu) for configuring the tool button style: http://doc.qt.io/archives/qt-4.8/qt.html#ToolButtonStyle-enum