### PR TITLE
The data size is missing in Collada loader

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -598,7 +598,7 @@ float getMeshUnitRescale(const std::string& resource_path)
 
   // Use the resource retriever to get the data.
   const char * data = reinterpret_cast<const char * > (res.data.get());
-  xmlDoc.Parse(data);
+  xmlDoc.Parse(data, res.size);
 
   // Find the appropriate element if it exists
   if(!xmlDoc.Error())

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -620,6 +620,10 @@ float getMeshUnitRescale(const std::string& resource_path)
       }
     }
   }
+  else
+  {
+    ROS_ERROR("XML parse error [%s]: %s", resource_path.c_str(), xmlDoc.ErrorName());
+  }
   return unit_scale;
 }
 


### PR DESCRIPTION
I found that my robot does't show propelly due to XML parse error in Collada loader. The data size is missing after converting from array to cstring, this led to garbage at the end of XML structure. This patch fixes this error. Also I added error message.