### PR TITLE
Improve color support for themes

### DIFF
--- a/help/help.html
+++ b/help/help.html
@@ -8,8 +8,8 @@
 <html>
 <head>
 <style type="text/css">
-.odd { background-color: #e0e0e0 }
-.even { background-color: #f0f0f0 }
+.odd { background-color: transparent }
+.even { background-color: transparent }
 .key { font-weight: bold; color: #04597f }
 p { margin-left: 10px }
 </style>

--- a/src/rviz/display.cpp
+++ b/src/rviz/display.cpp
@@ -108,16 +108,6 @@ QVariant Display::getViewData( int column, int role ) const
 {
   switch( role )
   {
-  case Qt::BackgroundRole:
-  {
-    /*
-    QLinearGradient q( 0,0, 0,5 );
-    q.setColorAt( 0.0, QColor(230,230,230) );
-    q.setColorAt( 1.0, Qt::white );
-    return QBrush( q );
-    */
-    return QColor( Qt::white );
-  }
   case Qt::ForegroundRole:
   {
     // if we're item-enabled (not greyed out) and in warn/error state, set appropriate color
@@ -137,7 +127,7 @@ QVariant Display::getViewData( int column, int role ) const
       }
       else
       {
-        return QColor( Qt::black );
+        return QApplication::palette().color( QPalette::Text );
       }
     }
     break;
@@ -199,7 +189,7 @@ void Display::setStatusInternal( int level, const QString& name, const QString& 
     addChild( status_, 0 );
   }
   StatusProperty::Level old_level = status_->getLevel();
-  
+
   status_->setStatus( (StatusProperty::Level) level, name, text );
   if( model_ && old_level != status_->getLevel() )
   {

--- a/src/rviz/failed_display.cpp
+++ b/src/rviz/failed_display.cpp
@@ -51,7 +51,6 @@ QVariant FailedDisplay::getViewData( int column, int role ) const
   {
     switch( role )
     {
-    case Qt::BackgroundRole: return QColor( Qt::white );
     case Qt::ForegroundRole: return StatusProperty::statusColor( StatusProperty::Error );
     default: break;
     }

--- a/src/rviz/panel_dock_widget.cpp
+++ b/src/rviz/panel_dock_widget.cpp
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <QApplication>
 #include <QChildEvent>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -46,7 +47,7 @@ PanelDockWidget::PanelDockWidget( const QString& name )
   QWidget *title_bar = new QWidget(this);
 
   QPalette pal(palette());
-  pal.setColor(QPalette::Background, QColor( 200,200,200 ) );
+  pal.setColor(QPalette::Background, QApplication::palette().color( QPalette::Mid ) );
   title_bar->setAutoFillBackground(true);
   title_bar->setPalette(pal);
   title_bar->setContentsMargins(0,0,0,0);

--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -30,6 +30,8 @@
 #include <stdio.h> // for printf()
 #include <limits.h> // for INT_MIN and INT_MAX
 
+#include <QApplication>
+#include <QPalette>
 #include <QLineEdit>
 #include <QSpinBox>
 
@@ -235,15 +237,8 @@ void Property::setParent( Property* new_parent )
 
 QVariant Property::getViewData( int column, int role ) const
 {
-  if ( role == Qt::TextColorRole &&
-       ( parent_ && parent_->getDisableChildren() ) )
-  {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    return Qt::gray;
-#else
-    return QColor(Qt::gray);
-#endif
-  }
+  if ( role == Qt::TextColorRole && parent_ && parent_->getDisableChildren() )
+    return QApplication::palette().brush(QPalette::Disabled, QPalette::Text);
 
   switch( column )
   {

--- a/src/rviz/properties/property_tree_with_help.cpp
+++ b/src/rviz/properties/property_tree_with_help.cpp
@@ -68,7 +68,7 @@ void PropertyTreeWithHelp::showHelpForProperty( const Property* property )
   {
     QString body_text = property->getDescription();
     QString heading = property->getName();
-    QString html = "<html><body bgcolor=\"#EFEBE7\"><strong>" + heading + "</strong><br>" + body_text + "</body></html>";
+    QString html = "<html><body><strong>" + heading + "</strong><br>" + body_text + "</body></html>";
     help_->setHtml( html );
   }
   else

--- a/src/rviz/properties/status_property.cpp
+++ b/src/rviz/properties/status_property.cpp
@@ -27,7 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <QApplication>
 #include <QColor>
+#include <QPalette>
 
 #include "rviz/properties/property_tree_model.h"
 
@@ -48,6 +50,9 @@ StatusProperty::StatusProperty( const QString& name, const QString& text, Level 
   status_icons_[0] = loadPixmap( "package://rviz/icons/ok.png" );
   status_icons_[1] = loadPixmap( "package://rviz/icons/warning.png" );
   status_icons_[2] = loadPixmap( "package://rviz/icons/error.png" );
+
+  if (!status_colors_[0].isValid())  // initialize default text color once
+    status_colors_[0] = QApplication::palette().color( QPalette::Text );
 }
 
 bool StatusProperty::setValue( const QVariant& new_value )

--- a/src/rviz/properties/status_property.h
+++ b/src/rviz/properties/status_property.h
@@ -56,10 +56,7 @@ public:
    * 1) for this StatusProperty. */
   virtual Qt::ItemFlags getViewFlags( int column ) const;
 
-  /** @brief Return the color appropriate for the given status level.
-   *
-   * Returns an invalid QColor for Ok status, meaning we should use
-   * the default text color. */
+  /** @brief Return the color appropriate for the given status level. */
   static QColor statusColor( Level level );
 
   /** @brief Return the word appropriate for the given status level:

--- a/src/rviz/view_controller.cpp
+++ b/src/rviz/view_controller.cpp
@@ -144,18 +144,12 @@ QString ViewController::formatClassId( const QString& class_id )
 QVariant ViewController::getViewData( int column, int role ) const
 {
   if ( role == Qt::TextColorRole )
-  {
     return QVariant();
-  }
 
   if( is_active_ )
   {
     switch( role )
     {
-    case Qt::BackgroundRole:
-    {
-      return QColor( 0xba, 0xad, 0xa4 );
-    }
     case Qt::FontRole:
     {
       QFont font;


### PR DESCRIPTION
This improves readability when using dark or other themes in RViz.

# Before
## White theme
![before_white](https://user-images.githubusercontent.com/5566160/50601765-736e7900-0eb5-11e9-8c6c-36f8d0e3f08b.png)

## Dark theme
![before_dark](https://user-images.githubusercontent.com/5566160/50601772-76696980-0eb5-11e9-81f6-0e29b5f7d32c.png)

There are some other colors that might be improved but this fixes the main issues I have seen.

---

Does someone know where the color is set for the status tree and similar entries?
![status tree](https://user-images.githubusercontent.com/5566160/50601492-9ba9a800-0eb4-11e9-99a1-0f5a28d1cb7a.png)