### PR TITLE
Fix compatibility with boost 1.69.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,6 @@ if (POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
-find_package(Boost REQUIRED
-  COMPONENTS
-  filesystem
-  program_options
-  signals
-  system
-  thread
-)
-
 find_package(urdfdom_headers REQUIRED)
 
 find_package(PkgConfig REQUIRED)
@@ -141,9 +132,14 @@ find_package(catkin REQUIRED
   urdfdom_headers
 )
 
+set(RVIZ_BOOST_COMPONENTS filesystem program_options system thread)
+
 if(${tf_VERSION} VERSION_LESS "1.11.3")
   add_definitions("-DRVIZ_USE_BOOST_SIGNAL_1")
+  list(APPEND RVIZ_BOOST_COMPONENTS signals)
 endif()
+
+find_package(Boost REQUIRED COMPONENTS ${RVIZ_BOOST_COMPONENTS})
 
 find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 


### PR DESCRIPTION
The old signals library has been removed from boost 1.69. Because of that, `find_package(Boost COMPONENTS signals ...)` doesn't work anymore. The newer signals2 library is header only and does not need to be listed as boost component at all.

Since `rviz` seems to still want to be compatible with the old `signals` library, this PR makes the inclusion of `signals` as boost component optional, depending on whether `signals` or `signals2` will be used.