### PR TITLE
[Windows][melodic] Use portable uint32_t from <cstdint> in depth_cloud_display.h

### DIFF
--- a/src/rviz/default_plugin/depth_cloud_display.h
+++ b/src/rviz/default_plugin/depth_cloud_display.h
@@ -205,7 +205,7 @@ protected:
   BoolProperty* use_occlusion_compensation_property_;
   FloatProperty* occlusion_shadow_timeout_property_;
 
-  u_int32_t queue_size_;
+  uint32_t queue_size_;
 
   MultiLayerDepth* ml_depth_data_;
 


### PR DESCRIPTION
Use portable uint32_t from <cstdint> in depth_cloud_display.h for better cross-compiling.