### PR TITLE
[Windows][melodic] Use portable TARGET_LINKER_FILE_NAME to get shared lib name.

### DIFF
--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -89,7 +89,7 @@ install(TARGETS ${rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME}
 # Generate to the devel space so the extras file can include it from the devel space.
 file(GENERATE
   OUTPUT "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/default_plugin_location.cmake"
-  CONTENT "set(rviz_DEFAULT_PLUGIN_FILE_NAME $<TARGET_FILE_NAME:${rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME}>)"
+  CONTENT "set(rviz_DEFAULT_PLUGIN_FILE_NAME $<TARGET_LINKER_FILE_NAME:${rviz_DEFAULT_PLUGIN_LIBRARY_TARGET_NAME}>)"
 )
 # Install from the devel space to the install space.
 install(FILES "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake/default_plugin_location.cmake"


### PR DESCRIPTION
In CMake, `TARGET_FILE_NAME` returns `.so` on Linux but `.lib` on Windows. However, `.lib` is the extension for imported library, and `.dll` is the expected extension to return (for shared libraries).

Using `TARGET_LINKER_FILE_NAME` makes sure that it returns `.so` and `.dll` for both platforms.