### PR TITLE
[melodic] Correct xmlDoc.Parse usage.

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -598,7 +598,8 @@ float getMeshUnitRescale(const std::string& resource_path)
 
   // Use the resource retriever to get the data.
   const char * data = reinterpret_cast<const char * > (res.data.get());
-  xmlDoc.Parse(data);
+  // Parse() expects a null-terminated string. Otherwise, the buffer size should be specified.
+  xmlDoc.Parse(data, res.size);
 
   // Find the appropriate element if it exists
   if(!xmlDoc.Error())

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -598,7 +598,7 @@ float getMeshUnitRescale(const std::string& resource_path)
 
   // Use the resource retriever to get the data.
   const char * data = reinterpret_cast<const char * > (res.data.get());
-  // Parse() expects a null-terminated string. Otherwise, the buffer size should be specified.
+  // As the data pointer provided by resource retriever is not null-terminated, also pass res.size
   xmlDoc.Parse(data, res.size);
 
   // Find the appropriate element if it exists


### PR DESCRIPTION
(This seems to me not a Windows-specific issue, so I chose directly to create a PR against `melodic-devel`.)

`MemoryResource` returns the buffer pointer and size but doesn't have the guarantee the buffer being null-terminated (which makes sense since `MemoryResource` could hold anything in binary format.)

However, `xmlDoc.Parse()` either requires a null-terminated string, or an explicit buffer size to read. Otherwise, when the parser reads the bytes beyond the actual buffer size, it will lead to unexpected behavior (In my observation, this issue will manifest as `XML_ERROR_PARSING_TEXT` error.) and a scale of 1.0 will be returned.

So, specify the buffer size when calling Parse() to make sure it only reads till the buffer end.