### PR TITLE
[Windows][melodic] Add Ogre::PF_R8G8B8 support in selection_manager

### DIFF
--- a/src/rviz/selection/forwards.h
+++ b/src/rviz/selection/forwards.h
@@ -68,7 +68,7 @@ typedef boost::unordered_map<CollObjectHandle, Picked> M_Picked;
 inline uint32_t colorToHandle(Ogre::PixelFormat fmt, uint32_t col)
 {
   uint32_t handle = 0;
-  if (fmt == Ogre::PF_A8R8G8B8 || fmt == Ogre::PF_X8R8G8B8)
+  if (fmt == Ogre::PF_A8R8G8B8 || fmt == Ogre::PF_X8R8G8B8 || fmt == Ogre::PF_R8G8B8)
   {
     handle = col & 0x00ffffff;
   }

--- a/src/rviz/selection/selection_manager.cpp
+++ b/src/rviz/selection/selection_manager.cpp
@@ -782,6 +782,8 @@ void SelectionManager::publishDebugImage( const Ogre::PixelBox& pixel_box, const
   int post_pixel_padding = 0;
   switch( pixel_box.format )
   {
+  case Ogre::PF_R8G8B8:
+    break;
   case Ogre::PF_A8R8G8B8:
   case Ogre::PF_X8R8G8B8:
     post_pixel_padding = 1;


### PR DESCRIPTION
## Problem
- Users are not able to interact with interactive markers when running this [tutorial](http://wiki.ros.org/rviz/Tutorials/Interactive%20Markers%3A%20Getting%20Started).
- Meanwhile, `Incompatible pixel format [10]` are printed in RViz verbose mode.

## Analysis & Solution
On Windows, PF_R8G8B8 could be returned by pixel_buffer in `selection_manager`:
https://github.com/ros-visualization/rviz/blob/26ffa641a8e325aa7ced426c543a4433b8077684/src/rviz/selection/selection_manager.cpp#L735

However, `colorToHandle()` doesn't support PF_R8G8B8, so it errors out with `handle=0`. Add the proper case to fix it.

BTW, on Windows, it does honor the pixel format passed at the below line:
https://github.com/ros-visualization/rviz/blob/26ffa641a8e325aa7ced426c543a4433b8077684/src/rviz/selection/selection_manager.cpp#L396

After changing it to a valid & currently supported pixel format (e.g., PF_A8R8G8B8), the issue went away too.