### PR TITLE
remove support for tf < 1.11.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ find_package(Boost REQUIRED
   COMPONENTS
   filesystem
   program_options
-  signals
   system
   thread
 )
@@ -140,10 +139,6 @@ find_package(catkin REQUIRED
   visualization_msgs
   urdfdom_headers
 )
-
-if(${tf_VERSION} VERSION_LESS "1.11.3")
-  add_definitions("-DRVIZ_USE_BOOST_SIGNAL_1")
-endif()
 
 find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 

--- a/src/rviz/default_plugin/effort_display.h
+++ b/src/rviz/default_plugin/effort_display.h
@@ -51,11 +51,7 @@ public:
 	typedef boost::shared_ptr<M const> MConstPtr;
 	typedef ros::MessageEvent<M const> MEvent;
 	typedef boost::function<void(const MConstPtr&, FilterFailureReason)> FailureCallback;
-#ifdef RVIZ_USE_BOOST_SIGNAL_1
-	typedef boost::signal<void(const MConstPtr&, FilterFailureReason)> FailureSignal;
-#else
 	typedef boost::signals2::signal<void(const MConstPtr&, FilterFailureReason)> FailureSignal;
-#endif
 
 	// If you hit this assert your message does not have a header, or does not have the HasHeader trait defined for it
 	ROS_STATIC_ASSERT(ros::message_traits::HasHeader<M>::value);
@@ -496,11 +492,7 @@ public:
 
 	ros::Duration time_tolerance_; ///< Provide additional tolerance on time for messages which are stamped but can have associated duration
 
-#ifdef RVIZ_USE_BOOST_SIGNAL_1
-	boost::signals::connection tf_connection_;
-#else
 	boost::signals2::connection tf_connection_;
-#endif
 	message_filters::Connection message_connection_;
 
 	FailureSignal failure_signal_;


### PR DESCRIPTION
... and thus the need for boost::signals(1), which was removed from boost in version 1.69.
Resolves #1343.