### PR TITLE
[Windows][melodic] Use ${ASSIMP_LIBRARIES} in CMakeLists.txt for better portability

### DIFF
--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -142,8 +142,8 @@ target_link_libraries(${PROJECT_NAME}
   ${rviz_ADDITIONAL_LIBRARIES}
   ${TinyXML2_LIBRARIES}
   ${X11_X11_LIB}
-  assimp
-  yaml-cpp
+  ${ASSIMP_LIBRARIES}
+  ${NEW_YAMLCPP_LIBRARIES}
 )
 
 


### PR DESCRIPTION
Replace the hard-coded target names with ${ASSIMP_LIBRARIES} and ${NEW_YAMLCPP_LIBRARIES} for better portability.