### PR TITLE
[melodic] RViz panels don't always show at startup

### DIFF
--- a/src/rviz/panel_dock_widget.cpp
+++ b/src/rviz/panel_dock_widget.cpp
@@ -41,6 +41,7 @@ namespace rviz
 PanelDockWidget::PanelDockWidget( const QString& name )
   : QDockWidget( name )
   , collapsed_(false)
+  , forced_hidden_(false)
 {
   QWidget *title_bar = new QWidget(this);
 


### PR DESCRIPTION
## Problem
Sometimes, after RViz starts up, some panels are not showing, even when I toggle through `menu > panels > xyz`. On Windows, the repro rate is high, like once out of 5 ~ 10 runs. On Ubuntu, we also observe the same symptom (but with a much lower reproduce rate).

The workaround is to enter\exit fullscreen to refresh the visibility states.

This is also reported on https://answers.ros.org/question/315664/ros-not-running-well-on-windows-10/.

## Analysis & Solution
After live debugging, I noticed sometimes `forced_hidden_` are not zero at start up. And it turned out `forced_hidden_` was not zero-initialized in constructor and it could be anything left from the memory, so it messed up with the later visibility logic.

The solution is to simply initialize it.