### PR TITLE
replace tinyxml2  ErrorStr() -> ErrorName()

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -623,7 +623,7 @@ float getMeshUnitRescale(const std::string& resource_path)
   }
   else
   {
-    ROS_ERROR("XML parse error [%s]: %s", resource_path.c_str(), xmlDoc.ErrorStr());
+    ROS_ERROR("XML parse error [%s]: %s", resource_path.c_str(), xmlDoc.ErrorName());
   }
   return unit_scale;
 }


### PR DESCRIPTION
Fixed #1352. ErrorStr() was only introduced in tinyxml2 6.x, and is not yet available on Debian Stretch.
This leaves us with a less detailed error string.
