### PR TITLE
[Windows][melodic] Fix the run_tests build breaks on Windows.

### DIFF
--- a/src/test/send_images.cpp
+++ b/src/test/send_images.cpp
@@ -76,7 +76,7 @@ int main( int argc, char **argv )
         {
           int index = (x + y * width) * 3;
           std::uniform_int_distribution<int> uniform(0, RAND_MAX);
-          auto rand = random(seed);
+          auto rand = uniform(random_generator);
           msg.data[ index ] = rand & 0xff;
           index++;
           msg.data[ index ] = (rand >> 8) & 0xff;

--- a/src/test/send_images.cpp
+++ b/src/test/send_images.cpp
@@ -67,7 +67,7 @@ int main( int argc, char **argv )
     msg.step = width * 3;
 
     int count = 0;
-    std::default_random_engine seed;
+    std::default_random_engine random_generator;
     while( ros::ok() )
     {
       for( int x = 0; x < width; x++ )

--- a/src/test/send_images.cpp
+++ b/src/test/send_images.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <string>
+#include <random>
 #include "stdlib.h"
 #include "ros/ros.h"
 #include "sensor_msgs/Image.h"
@@ -66,6 +67,7 @@ int main( int argc, char **argv )
     msg.step = width * 3;
 
     int count = 0;
+    std::default_random_engine seed;
     while( ros::ok() )
     {
       for( int x = 0; x < width; x++ )
@@ -73,7 +75,8 @@ int main( int argc, char **argv )
         for( int y = 0; y < height; y++ )
         {
           int index = (x + y * width) * 3;
-          long int rand = random();
+          std::uniform_int_distribution<int> random(0, RAND_MAX);
+          auto rand = random(seed);
           msg.data[ index ] = rand & 0xff;
           index++;
           msg.data[ index ] = (rand >> 8) & 0xff;

--- a/src/test/send_images.cpp
+++ b/src/test/send_images.cpp
@@ -75,7 +75,7 @@ int main( int argc, char **argv )
         for( int y = 0; y < height; y++ )
         {
           int index = (x + y * width) * 3;
-          std::uniform_int_distribution<int> random(0, RAND_MAX);
+          std::uniform_int_distribution<int> uniform(0, RAND_MAX);
           auto rand = random(seed);
           msg.data[ index ] = rand & 0xff;
           index++;


### PR DESCRIPTION
This change is fixing the run_tests build breaks when `catkin_make run_tests` on Windows. `random` doesn't exist on Windows so switch to C++ `<random>` library for better portability.