### PR TITLE
Add ability to set alpha channel value of Axes and TF displays

### DIFF
--- a/src/rviz/default_plugin/axes_display.cpp
+++ b/src/rviz/default_plugin/axes_display.cpp
@@ -71,6 +71,12 @@ AxesDisplay::AxesDisplay()
                                         "Radius of each axis, in meters.",
                                         this, SLOT( updateShape() ));
   radius_property_->setMin( 0.0001 );
+
+  alpha_property_ = new FloatProperty( "Alpha", 1.0,
+                                       "Alpha channel value of each axis.",
+                                       this, SLOT( updateShape() ));
+  alpha_property_->setMin( 0.0 );
+  alpha_property_->setMax( 1.0 );
 }
 
 AxesDisplay::~AxesDisplay()
@@ -82,7 +88,7 @@ void AxesDisplay::onInitialize()
 {
   frame_property_->setFrameManager( context_->getFrameManager() );
 
-  axes_ = new Axes( scene_manager_, 0, length_property_->getFloat(), radius_property_->getFloat() );
+  axes_ = new Axes( scene_manager_, 0, length_property_->getFloat(), radius_property_->getFloat(), alpha_property_->getFloat() );
   axes_->getSceneNode()->setVisible( isEnabled() );
 }
 
@@ -98,7 +104,7 @@ void AxesDisplay::onDisable()
 
 void AxesDisplay::updateShape()
 {
-  axes_->set( length_property_->getFloat(), radius_property_->getFloat() );
+  axes_->set( length_property_->getFloat(), radius_property_->getFloat(), alpha_property_->getFloat() );
   context_->queueRender();
 }
 

--- a/src/rviz/default_plugin/axes_display.h
+++ b/src/rviz/default_plugin/axes_display.h
@@ -73,6 +73,7 @@ private:
 
   FloatProperty* length_property_;
   FloatProperty* radius_property_;
+  FloatProperty* alpha_property_;
   TfFrameProperty* frame_property_;
 };
 

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -174,6 +174,10 @@ TFDisplay::TFDisplay()
 
   scale_property_ = new FloatProperty( "Marker Scale", 1, "Scaling factor for all names, axes and arrows.", this );
 
+  alpha_property_ = new FloatProperty( "Marker Alpha", 1, "Alpha channel value for all axes.", this );
+  alpha_property_->setMin( 0 );
+  alpha_property_->setMax( 1 );
+
   update_rate_property_ = new FloatProperty( "Update Interval", 0,
                                              "The interval, in seconds, at which to update the frame transforms.  0 means to do so every update cycle.",
                                              this );
@@ -598,6 +602,8 @@ void TFDisplay::updateFrame( FrameInfo* frame )
   frame->axes_->getSceneNode()->setVisible( show_axes_property_->getBool() && frame_enabled);
   float scale = scale_property_->getFloat();
   frame->axes_->setScale( Ogre::Vector3( scale, scale, scale ));
+  float alpha = alpha_property_->getFloat();
+  frame->axes_->updateAlpha( alpha );
 
   frame->name_node_->setPosition( position );
   frame->name_node_->setVisible( show_names_property_->getBool() && frame_enabled );

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -118,6 +118,7 @@ private:
   BoolProperty* all_enabled_property_;
 
   FloatProperty* scale_property_;
+  FloatProperty* alpha_property_;
 
   Property* frames_category_;
   Property* tree_category_;

--- a/src/rviz/ogre_helpers/axes.cpp
+++ b/src/rviz/ogre_helpers/axes.cpp
@@ -40,8 +40,12 @@
 namespace rviz
 {
 
-Axes::Axes( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, float length, float radius )
-    : Object( scene_manager )
+Axes::Axes( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, float length, float radius, float alpha )
+    : Object( scene_manager ),
+      default_x_color_( 1, 0, 0, alpha ),
+      default_y_color_( 0, 1, 0, alpha ),
+      default_z_color_( 0, 0, 1, alpha )
+
 {
   if ( !parent_node )
   {
@@ -54,7 +58,7 @@ Axes::Axes( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, flo
   y_axis_ = new Shape( Shape::Cylinder, scene_manager_, scene_node_ );
   z_axis_ = new Shape( Shape::Cylinder, scene_manager_, scene_node_ );
 
-  set( length, radius );
+  set( length, radius, alpha );
 }
 
 Axes::~Axes()
@@ -66,7 +70,7 @@ Axes::~Axes()
   scene_manager_->destroySceneNode( scene_node_->getName() );
 }
 
-void Axes::set( float length, float radius )
+void Axes::set( float length, float radius, float alpha )
 {
   x_axis_->setScale(Ogre::Vector3( radius, length, radius ));
   y_axis_->setScale(Ogre::Vector3( radius, length, radius ));
@@ -78,6 +82,7 @@ void Axes::set( float length, float radius )
   z_axis_->setPosition( Ogre::Vector3( 0.0, 0.0f, length/2.0f ) );
   z_axis_->setOrientation( Ogre::Quaternion( Ogre::Degree( 90 ), Ogre::Vector3::UNIT_X ) );
 
+  updateAlpha(alpha);
   setToDefaultColors();
 }
 
@@ -134,16 +139,19 @@ void Axes::setZColor(const Ogre::ColourValue& col)
   z_axis_->setColor(col.r, col.g, col.b, col.a);
 }
 
-void Axes::setToDefaultColors()
+void Axes::updateAlpha(float alpha)
 {
-  x_axis_->setColor( 1.0f, 0.0f, 0.0f, 1.0f );
-  y_axis_->setColor( 0.0f, 1.0f, 0.0f, 1.0f );
-  z_axis_->setColor( 0.0f, 0.0f, 1.0f, 1.0f );
+  default_x_color_.a = alpha;
+  default_y_color_.a = alpha;
+  default_z_color_.a = alpha;
 }
 
-const Ogre::ColourValue Axes::default_x_color_( 1, 0, 0, 1 );
-const Ogre::ColourValue Axes::default_y_color_( 0, 1, 0, 1 );
-const Ogre::ColourValue Axes::default_z_color_( 0, 0, 1, 1 );
+void Axes::setToDefaultColors()
+{
+  x_axis_->setColor(default_x_color_);
+  y_axis_->setColor(default_y_color_);
+  z_axis_->setColor(default_z_color_);
+}
 
 const Ogre::ColourValue& Axes::getDefaultXColor()
 {

--- a/src/rviz/ogre_helpers/axes.h
+++ b/src/rviz/ogre_helpers/axes.h
@@ -38,6 +38,8 @@
 
 #include <vector>
 
+#include <OgreColourValue.h>
+
 namespace Ogre
 {
 class SceneManager;
@@ -45,7 +47,6 @@ class SceneNode;
 class Vector3;
 class Quaternion;
 class Any;
-class ColourValue;
 }
 
 namespace rviz
@@ -65,8 +66,9 @@ public:
    * @param parent_node A scene node to use as the parent of this object.  If NULL, uses the root scene node.
    * @param length Length of the axes
    * @param radius Radius of the axes
+   * @param alpha Alpha channel value of the axes
    */
-  Axes( Ogre::SceneManager* manager, Ogre::SceneNode* parent_node = NULL, float length = 1.0f, float radius = 0.1f );
+  Axes( Ogre::SceneManager* manager, Ogre::SceneNode* parent_node = NULL, float length = 1.0f, float radius = 0.1f, float alpha = 1.0f );
   virtual ~Axes();
 
   /**
@@ -74,8 +76,9 @@ public:
    *
    * @param length Length of the axes
    * @param radius Radius of the axes
+   * @param alpha Alpha channel value of the axes
    */
-  void set( float length, float radius );
+  void set( float length, float radius , float alpha = 1.0f );
 
   virtual void setOrientation( const Ogre::Quaternion& orientation );
   virtual void setPosition( const Ogre::Vector3& position );
@@ -102,10 +105,12 @@ public:
   void setXColor(const Ogre::ColourValue& col);
   void setYColor(const Ogre::ColourValue& col);
   void setZColor(const Ogre::ColourValue& col);
+  void updateAlpha(float alpha);
   void setToDefaultColors();
-  static const Ogre::ColourValue& getDefaultXColor();
-  static const Ogre::ColourValue& getDefaultYColor();
-  static const Ogre::ColourValue& getDefaultZColor();
+  const Ogre::ColourValue& getDefaultXColor();
+  const Ogre::ColourValue& getDefaultYColor();
+  const Ogre::ColourValue& getDefaultZColor();
+
 
 private:
 
@@ -119,9 +124,9 @@ private:
   Shape* y_axis_;      ///< Cylinder for the Y-axis
   Shape* z_axis_;      ///< Cylinder for the Z-axis
 
-  static const Ogre::ColourValue default_x_color_;
-  static const Ogre::ColourValue default_y_color_;
-  static const Ogre::ColourValue default_z_color_;
+  Ogre::ColourValue default_x_color_;
+  Ogre::ColourValue default_y_color_;
+  Ogre::ColourValue default_z_color_;
 };
 
 } // namespace rviz


### PR DESCRIPTION
### Description

This adds a property named alpha to the Axes and TF displays that
changes the alpha channel value of the axes colors.

An updateAlpha method is added to Axes so that TF display can easily
change the default alpha value of the axes.

The default axes colors in the Axes object are changed to be fields
instead of static objects so that different axes objects can have
different alpha values.

It may be useful to make partially transparent axes for visualization purposes.

I am happy to make any requested changes.