### PR TITLE
Move sip bindings build directory into the build space.

### DIFF
--- a/src/python_bindings/sip/CMakeLists.txt
+++ b/src/python_bindings/sip/CMakeLists.txt
@@ -52,7 +52,6 @@ if(sip_helper_FOUND)
     SIP_CONFIGURE ${python_qt_binding_EXTRAS_DIR}/sip_configure.py
     SOURCE_DIR ${PROJECT_SOURCE_DIR}/src/python_bindings/sip
     LIBRARY_DIR ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/rviz
-    BINARY_DIR ${PROJECT_BINARY_DIR}/sip
     DEPENDS ${rviz_sip_DEPENDENT_FILES}
     DEPENDENCIES rviz
   )

--- a/src/python_bindings/sip/CMakeLists.txt
+++ b/src/python_bindings/sip/CMakeLists.txt
@@ -52,7 +52,7 @@ if(sip_helper_FOUND)
     SIP_CONFIGURE ${python_qt_binding_EXTRAS_DIR}/sip_configure.py
     SOURCE_DIR ${PROJECT_SOURCE_DIR}/src/python_bindings/sip
     LIBRARY_DIR ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/rviz
-    BINARY_DIR ${CATKIN_DEVEL_PREFIX}/bin
+    BINARY_DIR ${PROJECT_BINARY_DIR}/sip
     DEPENDS ${rviz_sip_DEPENDENT_FILES}
     DEPENDENCIES rviz
   )


### PR DESCRIPTION
This is a goofy one, but the "binary dir" specified in `build_sip_binding` function is not a place to put built binaries, it's a place to put generated source, object files, etc. These don't belong in the develspace, they belong in the build space. Removing the line causes it to fall back to just using `PROJECT_BINARY_DIR`, see:

https://github.com/ros-visualization/python_qt_binding/blob/0.3.3/cmake/sip_helper.cmake#L196-L198

In case there's any doubt, here's what it places in that location, in a `sip/rviz_sip` subdirectory:

```
Makefile                                 siplibrviz_siprvizPanelDockWidget.o
pyqtscripting.sbf                        siplibrviz_siprvizProperty.cpp
sipAPIlibrviz_sip.h                      siplibrviz_siprvizProperty.o
siplibrviz_sipcmodule.cpp                siplibrviz_siprvizTool.cpp
siplibrviz_sipcmodule.o                  siplibrviz_siprvizToolManager.cpp
siplibrviz_siprvizBoolProperty.cpp       siplibrviz_siprvizToolManager.o
siplibrviz_siprvizBoolProperty.o         siplibrviz_siprvizTool.o
siplibrviz_siprvizConfig.cpp             siplibrviz_siprvizViewController.cpp
siplibrviz_siprvizConfigMapIterator.cpp  siplibrviz_siprvizViewController.o
siplibrviz_siprvizConfigMapIterator.o    siplibrviz_siprvizViewManager.cpp
siplibrviz_siprvizConfig.o               siplibrviz_siprvizViewManager.o
siplibrviz_siprviz.cpp                   siplibrviz_siprvizVisualizationFrame.cpp
siplibrviz_siprvizDisplay.cpp            siplibrviz_siprvizVisualizationFrame.o
siplibrviz_siprvizDisplayGroup.cpp       siplibrviz_siprvizVisualizationManager.cpp
siplibrviz_siprvizDisplayGroup.o         siplibrviz_siprvizVisualizationManager.o
siplibrviz_siprvizDisplay.o              siplibrviz_siprvizYamlConfigReader.cpp
siplibrviz_siprviz.o                     siplibrviz_siprvizYamlConfigReader.o
siplibrviz_siprvizOgreLogging.cpp        siplibrviz_siprvizYamlConfigWriter.cpp
siplibrviz_siprvizOgreLogging.o          siplibrviz_siprvizYamlConfigWriter.o
siplibrviz_siprvizPanelDockWidget.cpp
```