### PR TITLE
Add ability to set Orbit camera field of view

### DIFF
--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
@@ -52,6 +52,7 @@
 static const float PITCH_START = Ogre::Math::HALF_PI / 2.0;
 static const float YAW_START = Ogre::Math::HALF_PI * 0.5;
 static const float DISTANCE_START = 10;
+static const float FOV_START = Ogre::Math::HALF_PI / 2.0;
 static const float FOCAL_SHAPE_SIZE_START = 0.05;
 static const bool FOCAL_SHAPE_FIXED_SIZE = true;
 
@@ -74,6 +75,10 @@ OrbitViewController::OrbitViewController()
   pitch_property_ = new FloatProperty( "Pitch", PITCH_START, "How much the camera is tipped downward.", this );
   pitch_property_->setMax( Ogre::Math::HALF_PI - 0.001 );
   pitch_property_->setMin( -pitch_property_->getMax() );
+
+  fov_property_ = new FloatProperty( "Field of View", FOV_START, "The field of view of the camera.", this );
+  fov_property_->setMin( 0.001 );
+  fov_property_->setMax( Ogre::Math::HALF_PI );
 
   focal_point_property_ = new VectorProperty( "Focal Point", Ogre::Vector3::ZERO, "The center point which the camera orbits.", this );
 }
@@ -101,6 +106,7 @@ void OrbitViewController::reset()
   yaw_property_->setFloat( YAW_START );
   pitch_property_->setFloat( PITCH_START );
   distance_property_->setFloat( DISTANCE_START );
+  fov_property_->setFloat( FOV_START );
   focal_shape_size_property_->setFloat( FOCAL_SHAPE_SIZE_START );
   focal_shape_fixed_size_property_->setBool( false );
   updateFocalShapeSize();
@@ -262,6 +268,7 @@ void OrbitViewController::updateCamera()
   float distance = distance_property_->getFloat();
   float yaw = yaw_property_->getFloat();
   float pitch = pitch_property_->getFloat();
+  float fov = fov_property_->getFloat();
   Ogre::Vector3 camera_z = Ogre::Vector3::UNIT_Z;
 
   // If requested, turn the world upside down.
@@ -284,6 +291,7 @@ void OrbitViewController::updateCamera()
   camera_->setPosition(pos);
   camera_->setFixedYawAxis(true, target_scene_node_->getOrientation() * camera_z);
   camera_->setDirection(target_scene_node_->getOrientation() * (focal_point - pos));
+  camera_->setFOVy(Ogre::Radian(fov));
 
   focal_shape_->setPosition( focal_point );
 }

--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.h
@@ -112,6 +112,7 @@ protected:
   FloatProperty* yaw_property_;                         ///< The camera's yaw (rotation around the y-axis), in radians
   FloatProperty* pitch_property_;                       ///< The camera's pitch (rotation around the x-axis), in radians
   FloatProperty* distance_property_;                    ///< The camera's distance from the focal point
+  FloatProperty* fov_property_;                         ///< The camera's vertical field of view, in radians
   VectorProperty* focal_point_property_; ///< The point around which the camera "orbits".
   BoolProperty* focal_shape_fixed_size_property_;       ///< Whether the focal shape size is fixed or not
   FloatProperty* focal_shape_size_property_;            ///< The focal shape size


### PR DESCRIPTION
### Description

This change adds a Property to the Orbit camera to change the field of view.

I found this change useful for visualization as it makes rviz more configurable.

I can also add this to the other cameras if this will be merged in / is desirable.