### PR TITLE
Fix compilation with Qt4 (#1369)

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1250,10 +1250,13 @@ void VisualizationFrame::onHelpAbout()
 
 void VisualizationFrame::onDockPanelChange()
 {
-  QList<QTabBar *> tab_bars = findChildren<QTabBar *>(QString(), Qt::FindDirectChildrenOnly);
+  QList<QTabBar *> tab_bars = findChildren<QTabBar *>(QString());
   for ( QList<QTabBar *>::iterator it = tab_bars.begin(); it != tab_bars.end(); it++ )
   {
-    (*it)->setElideMode( Qt::ElideNone );
+	if((*it)->parent() == this)
+	{
+		(*it)->setElideMode( Qt::ElideNone );
+	}
   }
 }
 

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1250,10 +1250,17 @@ void VisualizationFrame::onHelpAbout()
 
 void VisualizationFrame::onDockPanelChange()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+  QList<QTabBar *> tab_bars = findChildren<QTabBar *>(QString(), Qt::FindDirectChildrenOnly);
+#else
   QList<QTabBar *> tab_bars = findChildren<QTabBar *>(QString());
+#endif
+
   for ( QList<QTabBar *>::iterator it = tab_bars.begin(); it != tab_bars.end(); it++ )
   {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 	if((*it)->parent() == this)
+#endif
 	{
 		(*it)->setElideMode( Qt::ElideNone );
 	}


### PR DESCRIPTION
Fixes #1369.

This fix does not revert dock text eliding disabling as introduced in #1168 for Qt4.
Tested with Qt4 v4.8.7.