### PR TITLE
Allow to zoom more in orbit view controllers

### DIFF
--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
@@ -62,7 +62,7 @@ OrbitViewController::OrbitViewController()
   : dragging_( false )
 {
   distance_property_ = new FloatProperty( "Distance", DISTANCE_START, "Distance from the focal point.", this );
-  distance_property_->setMin( 0.01 );
+  distance_property_->setMin( 0.001 );
 
   focal_shape_size_property_ = new FloatProperty( "Focal Shape Size", FOCAL_SHAPE_SIZE_START, "Focal shape size.", this );
   focal_shape_size_property_->setMin( 0.001 );


### PR DESCRIPTION
This allows to zoom more on tiny objects in RViz. The user must lower the near clipping distance in order to zoom a lot.