### PR TITLE
Enable non-ascii chars for MovableText

### DIFF
--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -116,6 +116,8 @@ void MovableText::setFontName(const String &fontName)
       throw Exception(Exception::ERR_ITEM_NOT_FOUND, "Could not find font "
           + fontName, "MovableText::setFontName");
 
+    // to support non-ascii letters, setup the codepoint range before loading
+    mpFont->addCodePointRange(std::make_pair<Ogre::Font::CodePoint>(0, 999));
     mpFont->load();
     if (!mpMaterial.isNull())
     {

--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -50,6 +50,7 @@
 #include <OgreHardwareBufferManager.h>
 #include <OgreFontManager.h>
 #include <OgreFont.h>
+#include <OgreUTFString.h>
 
 #include <sstream>
 
@@ -218,17 +219,17 @@ void MovableText::showOnTop(bool show)
 
 void MovableText::_setupGeometry()
 {
+  Ogre::UTFString::utf32string utfCaption(Ogre::UTFString(mCaption).asUTF32());
+
   assert(mpFont);
   assert(!mpMaterial.isNull());
 
   unsigned int vertexCount = 0;
 
   //count letters to determine how many vertices are needed
-  std::string::iterator i = mCaption.begin();
-  std::string::iterator iend = mCaption.end();
-  for ( ; i != iend; ++i )
+  for (auto ch : utfCaption)
   {
-    if ((*i != ' ') && (*i != '\n'))
+    if ((ch != ' ') && (ch != '\n'))
     {
       vertexCount += 6;
     }
@@ -241,7 +242,7 @@ void MovableText::_setupGeometry()
     mUpdateColors = true;
   }
 
-  if (mCaption.empty())
+  if (utfCaption.empty())
   {
     return;
   }
@@ -298,11 +299,9 @@ void MovableText::_setupGeometry()
   float total_height = mCharHeight;
   float total_width = 0.0f;
   float current_width = 0.0f;
-  i = mCaption.begin();
-  iend = mCaption.end();
-  for ( ; i != iend; ++i )
+  for (auto ch : utfCaption)
   {
-    if (*i == '\n')
+    if (ch == '\n')
     {
       total_height += mCharHeight + mLineSpacing;
 
@@ -312,13 +311,13 @@ void MovableText::_setupGeometry()
       }
       current_width = 0.0;
     }
-    else if (*i == ' ')
+    else if (ch == ' ')
     {
       current_width += spaceWidth;
     }
     else
     {
-      current_width += mpFont->getGlyphAspectRatio(*i) * mCharHeight * 2.0;
+      current_width += mpFont->getGlyphAspectRatio(ch) * mCharHeight * 2.0;
     }
   }
 
@@ -360,12 +359,13 @@ void MovableText::_setupGeometry()
   Ogre::Vector3 min(9999999.0f), max(-9999999.0f), currPos(0.0f);
   Ogre::Real maxSquaredRadius = -99999999.0f;
   float largestWidth = 0.0f;
-  for (i = mCaption.begin(); i != iend; ++i)
+  auto iend = utfCaption.end();
+  for (auto i = utfCaption.begin(); i != iend; ++i)
   {
     if (newLine)
     {
       len = 0.0f;
-      for (String::iterator j = i; j != iend && *j != '\n'; j++)
+      for (auto j = i; j != iend && *j != '\n'; j++)
       {
         if (*j == ' ')
           len += spaceWidth;


### PR DESCRIPTION
As pointed out in https://github.com/ros-visualization/interactive_markers/issues/40, rviz doesn't support non-ASCII chars in rendered text. This was due to two shortcomings:
1. The std::string, which is utf8-encoded on Linux nowadays, wasn't interpreted as an utf8-encoded string, but as an ASCII string.
2. To render non-ASCII chars, the font needs to load corresponding textures. By default, it looks like only 0-127 are loaded, which makes sense to limit memory usage. 

I extended the range arbitrarily to 0-999, solving the mentioned issue:
![rviz-utf8](https://user-images.githubusercontent.com/5376030/57521823-8c82ad00-7321-11e9-918d-5285e9d5e1d2.png)

However, that's not an optimal solution at all, because it loads many textures that aren't probably used by most applications. On the other hand, still lots of chars are missing.
What would be needed, is a mechanism to explicitly specify the required codepoint range, either
- dynamically, extending the range based on required chars and reloading the font if necessary
- or statically, using e.g. some ROS parameter to list the code point range

While the first option would be the most convenient, I have no idea how to reload a font resource.