### PR TITLE
Ignore special conditions when normalizing image

### DIFF
--- a/src/rviz/image/ros_image_texture.cpp
+++ b/src/rviz/image/ros_image_texture.cpp
@@ -127,6 +127,14 @@ void ROSImageTexture::normalize( T* image_data, size_t image_data_size, std::vec
     maxValue = std::numeric_limits<T>::min();
     for( unsigned i = 0; i < image_data_size; ++i )
     {
+      if (*input_ptr == std::numeric_limits<double>::infinity() ||
+          *input_ptr == -std::numeric_limits<double>::infinity() ||
+          *input_ptr == std::numeric_limits<double>::quiet_NaN())
+      {
+        input_ptr++;
+        continue;
+      }
+
       minValue = std::min( minValue, *input_ptr );
       maxValue = std::max( maxValue, *input_ptr );
       input_ptr++;


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

While working on the integration between Ignition and ROS (https://github.com/osrf/ros1_ign_bridge/pull/15), we ran into an issue where depth images were not properly displayed on RViz.

This PR makes sure that [REP 117](http://www.ros.org/reps/rep-0117.html) is followed, and values like NaN and +-inf are ignored when normalizing depth images.

Without this PR, images containing NaN / Inf display completely black when "Normalize" is checked, because those values are used to calculate the normalization boundaries. With this PR, depth images coming from [ign-sensors](https://bitbucket.org/ignitionrobotics/ign-sensors) and relayed through the [ros1_ign_bridge](https://github.com/osrf/ros1_ign_bridge) display correctly, as shown below:

![rviz_normalize](https://user-images.githubusercontent.com/5751272/58589016-cdc9f680-8215-11e9-8218-9767db0d3f39.png)

