### PR TITLE
Add python bindings option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,10 @@ find_package(catkin REQUIRED
   visualization_msgs
 )
 
-find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
+option(BUILD_PYTHON_BINDINGS "Build the python bindings using sip" ON)
+if(BUILD_PYTHON_BINDINGS)
+    find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
+endif()
 
 find_package(Eigen3 QUIET)
 if(NOT EIGEN3_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ find_package(catkin REQUIRED
   visualization_msgs
 )
 
-option(BUILD_PYTHON_BINDINGS "Build the python bindings using sip" ON)
+option(BUILD_PYTHON_BINDINGS "Build python bindings" ON)
 if(BUILD_PYTHON_BINDINGS)
     find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,8 @@ add_subdirectory(image_view)
 if (CATKIN_ENABLE_TESTING)
   add_subdirectory(test)
 endif()
+
 # Python bindings are only support with Qt5, PyQt5, and PySide2 for Kinetic+.
-if (UseQt5)
+if (UseQt5 AND BUILD_PYTHON_BINDINGS)
   add_subdirectory(python_bindings)
 endif()


### PR DESCRIPTION
This just adds a python binding option that defaults to *ON* to be safe.
This is in part due to https://github.com/ros-visualization/rviz/issues/1382