### PR TITLE
Fix opacity of Collada meshes

### DIFF
--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -632,6 +632,13 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
       {
         sub->setMaterial(default_material_);
       }
+      else
+      {
+          // create a new material copy for each instance of a RobotLink
+          Ogre::MaterialPtr mat = Ogre::MaterialPtr(new Ogre::Material(nullptr, material_name, 0, ROS_PACKAGE_NAME));
+          *mat = *sub->getMaterial();
+          sub->setMaterial(mat);
+      }
       materials_[sub] = sub->getMaterial();
     }
   }


### PR DESCRIPTION
Fixes an issue introduced in #1294 (e906f82eb2ef04e63dea03f834ae722f144bc712):
Materials of Collada mesh models need to be cloned for each instance of a robot link.
Fixes #1385. @simonschmeisser, could you please verify?