### PR TITLE
Fix #1120 Visualization markers ignore color and show everything as white

### DIFF
--- a/src/rviz/default_plugin/markers/mesh_resource_marker.h
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.h
@@ -64,7 +64,8 @@ protected:
   //! Scaling factor to convert units. Currently relevant for Collada only.
   float unit_rescale_;
 
-
+  //! list of passes created for adding color tint to the mesh
+  std::vector<Ogre::Pass*> color_tint_passes_;
 };
 
 }


### PR DESCRIPTION

### Description
Fix #1120 Visualization markers ignore color and show everything as white using  #752 as base patch

### Checklist

- Rendering issues:
  - Attached broken rendering image: ![issue](https://user-images.githubusercontent.com/3864052/61529611-146fec00-aa22-11e9-97e7-cb102980d9cf.png)

  - Attached fixed rendering image: ![mesh_marker_fixed](https://user-images.githubusercontent.com/3864052/61529616-189c0980-aa22-11e9-836c-044432cec9ec.png)


- Source code snippet for three cases:

// display marker not using mesh material in transparent blue
          marker.color.r = 0;
          marker.color.g = 0;
          marker.color.b = 1;
          marker.color.a = 0.3;
          marker.scale.x = 1;
          marker.scale.y = 1;
          marker.scale.z = 1;
          marker.type = visualization_msgs::Marker::MESH_RESOURCE;
          marker.mesh_resource = "package://my_pkg/moonwalk.dae";
          marker.mesh_use_embedded_materials=false;

// display marker  using mesh material and tinted with transparent green 
        marker.scale.x = 1;
        marker.scale.y = 1;
        marker.scale.z = 1;
        marker.color.r = 0;
        marker.color.g = 1;
        marker.color.b = 0;
        marker.color.a = 0.5f;
        marker.type = visualization_msgs::Marker::MESH_RESOURCE;
        marker.mesh_resource = "package://my_pkg/moonwalk.dae";
        marker.mesh_use_embedded_materials=true;

// display marker  using mesh material and not tinted
        marker.scale.x = 1;
        marker.scale.y = 1;
        marker.scale.z = 1;
        marker.color.r = 0;
        marker.color.g = 0;
        marker.color.b = 0;
        marker.color.a = 0;
        marker.type = visualization_msgs::Marker::MESH_RESOURCE;
        marker.mesh_resource = "package://my_pkg/moonwalk.dae";
        marker.mesh_use_embedded_materials=true;
