### PR TITLE
Fix segfault when camera dispay closed. Closes #1372.

### DIFF
--- a/src/rviz/image/image_display_base.h
+++ b/src/rviz/image/image_display_base.h
@@ -113,6 +113,7 @@ protected:
   boost::scoped_ptr<image_transport::ImageTransport> it_;
   boost::shared_ptr<image_transport::SubscriberFilter> sub_;
   boost::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::Image> > tf_filter_;
+  uint64_t tf_filter_callback_id_;
 
   std::string targetFrame_;
 


### PR DESCRIPTION
### Description

Actually segfault happens in [`CBQueueCallback::call`](https://github.com/ros/geometry2/blob/f0c6ffd465619cfeb0bf89a9fd9d0ab3fb46c80e/tf2_ros/include/tf2_ros/message_filter.h#L596) method while calling `filter_->signalMessage(event_)`:
```c++
virtual CallResult call()
{
  if (success_)
  {
    filter_->signalMessage(event_);
  }
  else
  {
    filter_->signalFailure(event_, reason_);
  }

  return Success;
}
```

`CBQueueCallback` object is constructed in [`MessageFilter::messageReady`](https://github.com/ros/geometry2/blob/f0c6ffd465619cfeb0bf89a9fd9d0ab3fb46c80e/tf2_ros/include/tf2_ros/message_filter.h#L626) method:
```c++
ros::CallbackInterfacePtr cb(new CBQueueCallback(this, evt, true, filter_failure_reasons::Unknown));
callback_queue_->addCallback(cb, (uint64_t)this);
```
and it [holds `MessageFilter` pointer](https://github.com/ros/geometry2/blob/f0c6ffd465619cfeb0bf89a9fd9d0ab3fb46c80e/tf2_ros/include/tf2_ros/message_filter.h#L584) as argument:

```c++
 CBQueueCallback(MessageFilter* filter, const MEvent& event, bool success, FilterFailureReason reason)
    : event_(event)
    , filter_(filter)
    , reason_(reason)
    , success_(success)
    {}
```

At call time `filter_` object is already destroyed in https://github.com/ros-visualization/rviz/blob/57325fa075893de70f234f4676cdd08b411858ff/src/rviz/image/image_display_base.cpp#L204-L208 and this leads to segfault.

`CBQueueCallback` object is called from [`callback_queue_`](https://github.com/ros/geometry2/blob/f0c6ffd465619cfeb0bf89a9fd9d0ab3fb46c80e/tf2_ros/include/tf2_ros/message_filter.h#L631):
```c++
ros::CallbackInterfacePtr cb(new CBQueueCallback(this, evt, true, filter_failure_reasons::Unknown));
callback_queue_->addCallback(cb, (uint64_t)this);
```
which actually the same as `update_nh_.getCallbackQueue()`:

* `tf_filter` constructed from `update_nh_`: https://github.com/ros-visualization/rviz/blob/57325fa075893de70f234f4676cdd08b411858ff/src/rviz/image/image_display_base.cpp#L179-L185
* `MessageFilter` ctor [init `callback_queue_` as  `callback_queue_(nh.getCallbackQueue())`](https://github.com/ros/geometry2/blob/f0c6ffd465619cfeb0bf89a9fd9d0ab3fb46c80e/tf2_ros/include/tf2_ros/message_filter.h#L145):
```c++
template<class F>
  MessageFilter(F& f, tf2::BufferCore& bc, const std::string& target_frame, uint32_t queue_size, const ros::NodeHandle& nh)
  : bc_(bc)
  , queue_size_(queue_size)
  , callback_queue_(nh.getCallbackQueue())
  {
    init();

    setTargetFrame(target_frame);

    connectInput(f);
  }
```
This all looks like a thread sync problem, but I wasn't able to track it.
I am unsure if it is bug in TF2 message filter, so I suggest to use less invasive method and fix this bug in RViz code by removing callback by id before message_filter reset.