### PR TITLE
correctly initialise Ogre types and check return value of 'transform'

### DIFF
--- a/src/rviz/default_plugin/markers/marker_base.cpp
+++ b/src/rviz/default_plugin/markers/marker_base.cpp
@@ -90,6 +90,8 @@ bool MarkerBase::transform(const MarkerConstPtr& message, Ogre::Vector3& pos, Og
     stamp = ros::Time();
   }
 
+  scale = Ogre::Vector3(message->scale.x, message->scale.y, message->scale.z);
+
   if (!context_->getFrameManager()->transform(message->header.frame_id, stamp, message->pose, pos, orient))
   {
     std::string error;
@@ -100,8 +102,6 @@ bool MarkerBase::transform(const MarkerConstPtr& message, Ogre::Vector3& pos, Og
     }
     return false;
   }
-
-  scale = Ogre::Vector3(message->scale.x, message->scale.y, message->scale.z);
 
   return true;
 }

--- a/src/rviz/default_plugin/markers/shape_marker.cpp
+++ b/src/rviz/default_plugin/markers/shape_marker.cpp
@@ -79,9 +79,12 @@ void ShapeMarker::onNewMessage( const MarkerConstPtr& old_message,
     handler_->addTrackedObjects( shape_->getRootNode() );
   }
 
-  Ogre::Vector3 pos, scale, scale_correct;
+  Ogre::Vector3 pos(0,0,0);
+  Ogre::Vector3 scale(0,0,0);
+  Ogre::Vector3 scale_correct(0,0,0);
   Ogre::Quaternion orient;
-  transform(new_message, pos, orient, scale);
+
+  if(!transform(new_message, pos, orient, scale)) { return; }
 
   if (owner_ && (new_message->scale.x * new_message->scale.y
       * new_message->scale.z == 0.0f))


### PR DESCRIPTION
### Description

In some sections of the code, the Ogre types where not correctly initialized and return values have not been checked. This PR resolves these issues to prevent crashes due to invalid marker scales from uninitialized memory.