### PR TITLE
Overload FailedDisplay::save for proper override

### DIFF
--- a/src/rviz/failed_display.cpp
+++ b/src/rviz/failed_display.cpp
@@ -71,6 +71,11 @@ void FailedDisplay::load( const Config& config )
 
 void FailedDisplay::save( Config config )
 {
+  save(config);
+}
+
+void FailedDisplay::save( Config config ) const
+{
   if( saved_config_.isValid() )
   {
     config.copy( saved_config_ );

--- a/src/rviz/failed_display.cpp
+++ b/src/rviz/failed_display.cpp
@@ -71,7 +71,7 @@ void FailedDisplay::load( const Config& config )
 
 void FailedDisplay::save( Config config )
 {
-  const_cast<FailedDisplay*>(this)->save(config);
+  const_cast<const FailedDisplay*>(this)->save(config);
 }
 
 void FailedDisplay::save( Config config ) const

--- a/src/rviz/failed_display.cpp
+++ b/src/rviz/failed_display.cpp
@@ -71,7 +71,7 @@ void FailedDisplay::load( const Config& config )
 
 void FailedDisplay::save( Config config )
 {
-  save(config);
+  const_cast<FailedDisplay*>(this)->save(config);
 }
 
 void FailedDisplay::save( Config config ) const

--- a/src/rviz/failed_display.h
+++ b/src/rviz/failed_display.h
@@ -60,6 +60,11 @@ public:
   /** @brief Save Config equivalent to the last which was sent to load(). */
   virtual void save( Config config );
 
+  /** @brief Save Config equivalent to the last which was sent to load().
+   *
+   * Overridden from Display::save(). */
+  virtual void save( Config config ) const;
+
 private:
   Config saved_config_;
   QString error_message_;


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

Overload `FailedDisplay::save` for properly overriding `Display::save` without breaking ABI.

Fix #1390

