### PR TITLE
Add TF aligned view controller

### DIFF
--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -279,5 +279,10 @@
       Orthographic projection, seen from the top.
     </description>
   </class>
+  <class name="rviz/TfAligned" type="rviz::TfAlignedViewController" base_class_type="rviz::ViewController">
+    <description>
+      Align the camera with a TF frame.
+    </description>
+  </class>
 
 </library>

--- a/src/rviz/default_plugin/CMakeLists.txt
+++ b/src/rviz/default_plugin/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SOURCE_FILES
   view_controllers/third_person_follower_view_controller.cpp
   view_controllers/fixed_orientation_ortho_view_controller.cpp
   view_controllers/fps_view_controller.cpp
+  view_controllers/tf_aligned_view_controller.cpp
   wrench_display.cpp
   wrench_visual.cpp
 )

--- a/src/rviz/default_plugin/view_controllers/tf_aligned_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/tf_aligned_view_controller.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019, PickNik, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of PickNik, LLC nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <OgreQuaternion.h>
+#include <OgreVector3.h>
+#include <OgreCamera.h>
+
+#include "rviz/viewport_mouse_event.h"
+#include "rviz/properties/bool_property.h"
+#include "rviz/properties/enum_property.h"
+#include "rviz/properties/float_property.h"
+
+#include "tf_aligned_view_controller.h"
+
+namespace rviz
+{
+
+TfAlignedViewController::TfAlignedViewController()
+{
+  axis_property_ = new EnumProperty("Align to", "z-axis", "Align the camera to this axis.", this);
+  axis_property_->addOptionStd("x-axis", 1);
+  axis_property_->addOptionStd("y-axis", 2);
+  axis_property_->addOptionStd("z-axis", 3);
+
+  invert_axis_ = new BoolProperty("Invert Axis", true, "Align camera with the negative axis.", this);
+  camera_roll_property_ = new FloatProperty("Camera Roll", 0, "Roll about the camera's view axis.", this);
+}
+
+TfAlignedViewController::~TfAlignedViewController()
+{
+}
+
+void TfAlignedViewController::onInitialize()
+{
+  FramePositionTrackingViewController::onInitialize();
+  camera_->setProjectionType( Ogre::PT_PERSPECTIVE );
+  invert_z_->hide();
+}
+
+void TfAlignedViewController::reset()
+{
+  camera_->setOrientation(reference_orientation_);
+  camera_->setPosition(reference_position_);
+  updateCamera();
+}
+
+void TfAlignedViewController::update(float dt, float ros_dt)
+{
+  FramePositionTrackingViewController::update( dt, ros_dt );
+  updateCamera();
+}
+
+void TfAlignedViewController::onTargetFrameChanged(const Ogre::Vector3& /* old_reference_position */,
+                                                   const Ogre::Quaternion& /* old_reference_orientation */)
+{
+  camera_->setOrientation(reference_orientation_);
+  camera_->setPosition(reference_position_);
+}
+
+void TfAlignedViewController::updateCamera()
+{
+  Ogre::Quaternion q_offset;
+  int view_direction = invert_axis_->getBool() ? -1 : 1;
+  int view_axis = axis_property_->getOptionInt() * view_direction;
+
+  // reference_orientation_ will be aligned to -z-axis by default.
+  switch (view_axis) {
+  case -3: // -z-axis
+    // Do nothing, this is the default case
+    break;
+  case -2: // -y-axis
+    q_offset = q_offset * Ogre::Quaternion(Ogre::Degree(-90), Ogre::Vector3::UNIT_X);
+    q_offset = q_offset * Ogre::Quaternion(Ogre::Degree(180), Ogre::Vector3::UNIT_Z);
+    break;
+  case -1: // -x-axis
+    q_offset = q_offset * Ogre::Quaternion(Ogre::Degree(90), Ogre::Vector3::UNIT_X);
+    q_offset = q_offset * Ogre::Quaternion(Ogre::Degree(90), Ogre::Vector3::UNIT_Y);
+    break;
+  case 1: // x-axis
+    q_offset = q_offset * Ogre::Quaternion(Ogre::Degree(90), Ogre::Vector3::UNIT_X);
+    q_offset = q_offset * Ogre::Quaternion(Ogre::Degree(-90), Ogre::Vector3::UNIT_Y);
+    break;
+  case 2: // y-axis
+    q_offset = q_offset * Ogre::Quaternion(Ogre::Degree(90), Ogre::Vector3::UNIT_X);
+    break;
+  case 3: // z-axis
+    q_offset = q_offset * Ogre::Quaternion(Ogre::Degree(180), Ogre::Vector3::UNIT_Y);
+    break;
+  }
+
+  // Add camera roll, clockwise positive for all axes
+  q_offset = q_offset * Ogre::Quaternion(Ogre::Radian(camera_roll_property_->getFloat()),
+                                         Ogre::Vector3::UNIT_Z);
+
+  camera_->setOrientation(reference_orientation_ * q_offset);
+  camera_->setPosition(Ogre::Vector3::ZERO);
+}
+
+} // end namespace rviz
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS( rviz::TfAlignedViewController, rviz::ViewController )

--- a/src/rviz/default_plugin/view_controllers/tf_aligned_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/tf_aligned_view_controller.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019, PickNik, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of PickNik, LLC nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RVIZ_TF_ALIGNED_VIEW_CONTROLLER_H
+#define RVIZ_TF_ALIGNED_VIEW_CONTROLLER_H
+
+#include <OgreVector3.h>
+#include <OgreQuaternion.h>
+
+#include "rviz/frame_position_tracking_view_controller.h"
+
+namespace rviz
+{
+class EnumProperty;
+class FloatProperty;
+class BoolPropery;
+
+/** @brief A camera tied to a given frame. */
+class TfAlignedViewController : public FramePositionTrackingViewController
+{
+Q_OBJECT
+public:
+  TfAlignedViewController();
+  virtual ~TfAlignedViewController();
+
+  virtual void onInitialize();
+  virtual void reset();
+  virtual void update(float dt, float ros_dt);
+
+protected:
+  virtual void onTargetFrameChanged(const Ogre::Vector3& /* old_reference_position */,
+                                    const Ogre::Quaternion& /* old_reference_orientation */);
+
+  void updateCamera();
+
+  EnumProperty* axis_property_;  // The axis that the camera aligns to
+  BoolProperty* invert_axis_;  // Flag for positive or negative direction along axis
+  FloatProperty* camera_roll_property_;  // Amount to roll the camera from default position
+};
+
+} // end namespace rviz
+
+#endif // RVIZ_TF_ALIGNED_VIEW_CONTROLLER_H


### PR DESCRIPTION
### Description

This PR adds a view controller that aligns the camera to an axis of a published TF frame. The user is able to select the frame, select which axis the camera should be aligned to, and also change the roll angle.

View Panel before:
![tf_aligned_view_before](https://user-images.githubusercontent.com/1350297/63527949-44962900-c4bf-11e9-959b-f0c26baecf46.gif)

View Panel after:
![tf_aligned_view_after](https://user-images.githubusercontent.com/1350297/63527808-013bba80-c4bf-11e9-8b1f-23a6bbaed8d9.gif)

Gif showing how the camera view can be aligned to a frame and how it follows that frame as it is moved around: (Note that I'm using [tf_visual_tools](https://github.com/PickNikRobotics/tf_visual_tools) to move the TF around)
![tf_aligned_view](https://user-images.githubusercontent.com/1350297/63474631-18cf6080-c437-11e9-8e58-a4fe302d1ed4.gif)
