### PR TITLE
Fix segfault in Camera plugin

### DIFF
--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -203,6 +203,10 @@ void ImageDisplayBase::subscribe()
 
 void ImageDisplayBase::unsubscribe()
 {
+  // Quick fix for #1372. Can be removed if https://github.com/ros/geometry2/pull/402 is released
+  if (tf_filter_)
+    update_nh_.getCallbackQueue()->removeByID((uint64_t)tf_filter_.get());
+
   tf_filter_.reset();
   sub_.reset();
 }

--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -204,7 +204,7 @@ void ImageDisplayBase::subscribe()
 void ImageDisplayBase::unsubscribe()
 {
   tf_filter_.reset();
-  sub_.reset(new image_transport::SubscriberFilter());
+  sub_.reset();
 }
 
 void ImageDisplayBase::fixedFrameChanged()


### PR DESCRIPTION
Fixes #1372. As https://github.com/ros/geometry2/pull/402 isn't released yet, I'm going to merge this quick fix here. Thanks to @hexonxons, who analyzed the bug in detail in #1393 and originally proposed a solution.