### PR TITLE
Properly free allocated memory

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -285,7 +285,7 @@ MapDisplay::~MapDisplay()
 
 unsigned char* makeMapPalette()
 {
-  unsigned char* palette = new unsigned char[256*4];
+  unsigned char* palette = OGRE_ALLOC_T(unsigned char, 256*4, Ogre::MEMCATEGORY_GENERAL);
   unsigned char* palette_ptr = palette;
   // Standard gray map palette values
   for( int i = 0; i <= 100; i++ )
@@ -323,7 +323,7 @@ unsigned char* makeMapPalette()
 
 unsigned char* makeCostmapPalette()
 {
-  unsigned char* palette = new unsigned char[256*4];
+  unsigned char* palette = OGRE_ALLOC_T(unsigned char, 256*4, Ogre::MEMCATEGORY_GENERAL);
   unsigned char* palette_ptr = palette;
 
   // zero values have alpha=0
@@ -378,7 +378,7 @@ unsigned char* makeCostmapPalette()
 
 unsigned char* makeRawPalette()
 {
-  unsigned char* palette = new unsigned char[256*4];
+  unsigned char* palette = OGRE_ALLOC_T(unsigned char, 256*4, Ogre::MEMCATEGORY_GENERAL);
   unsigned char* palette_ptr = palette;
   // Standard gray map palette values
   for( int i = 0; i < 256; i++ )
@@ -395,7 +395,7 @@ unsigned char* makeRawPalette()
 Ogre::TexturePtr makePaletteTexture( unsigned char *palette_bytes )
 {
   Ogre::DataStreamPtr palette_stream;
-  palette_stream.bind( new Ogre::MemoryDataStream( palette_bytes, 256*4 ));
+  palette_stream.bind( new Ogre::MemoryDataStream( palette_bytes, 256*4, true ));
 
   static int palette_tex_count = 0;
   std::stringstream ss;


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

Memory allocated by `make*Palette()` was not freed by anyone.
It is now allocated with Ogre's `OGRE_ALLOC_T` to be freed directly by `MemoryDataStream`.

Fix #1391