### PR TITLE
Correctly detect repeated marker occurrences

### DIFF
--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -214,7 +214,7 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
 
     MarkerID current_id(marker.ns, marker.id);
     std::vector<MarkerID>::iterator search = std::lower_bound(marker_ids.begin(), marker_ids.end(), current_id);
-    if (search != marker_ids.end())
+    if (search != marker_ids.end() && *search == current_id)
     {
       addSeparatorIfRequired(ss);
       ss << "Found '" <<  marker.ns.c_str() << "/" << marker.id << "' multiple times";


### PR DESCRIPTION
Fixup to #1275 .

`std::lower_bound` was used to find the correct insertion position, which might be
somewhere within the vector. Thus, the check for MarkerID repetitions has to
perform the additional equality check.

Relevant for https://github.com/ros-visualization/rviz/issues/1414