### PR TITLE
fix crash on empty text in Interactive Marker

### DIFF
--- a/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
+++ b/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
@@ -44,7 +44,7 @@ namespace rviz
 
 TextViewFacingMarker::TextViewFacingMarker(MarkerDisplay* owner, DisplayContext* context, Ogre::SceneNode* parent_node)
 : MarkerBase(owner, context, parent_node)
-, text_(0)
+, text_(nullptr)
 {
 }
 
@@ -59,7 +59,9 @@ void TextViewFacingMarker::onNewMessage(const MarkerConstPtr& old_message, const
 
   if (new_message->text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
   {
+    handler_.reset();
     delete text_;
+    text_ = nullptr;
     return;
   }
 

--- a/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
+++ b/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
@@ -58,7 +58,10 @@ void TextViewFacingMarker::onNewMessage(const MarkerConstPtr& old_message, const
   ROS_ASSERT(new_message->type == visualization_msgs::Marker::TEXT_VIEW_FACING);
 
   if (new_message->text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
+  {
+    delete text_;
     return;
+  }
 
   if (!text_)
   {
@@ -83,9 +86,9 @@ void TextViewFacingMarker::onNewMessage(const MarkerConstPtr& old_message, const
 S_MaterialPtr TextViewFacingMarker::getMaterials()
 {
   S_MaterialPtr materials;
-  if ( text_->getMaterial().get() )
+  if ( text_ && text_->getMaterial().get() )
   {
-  materials.insert( text_->getMaterial() );
+    materials.insert( text_->getMaterial() );
   }
   return materials;
 }


### PR DESCRIPTION
this fixes a regression/crash introduced in #1275 and discussed in #1414 that occurred when adding an empty text marker
