### PR TITLE
Fixes for #1275 and #1365

### DIFF
--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
@@ -195,7 +195,8 @@ bool InteractiveMarker::processMessage( const visualization_msgs::InteractiveMar
     boost::make_shared<InteractiveMarkerControl>( context_,
                                                   reference_node_, this );
 
-  description_control_->processMessage( interactive_markers::makeTitle( message ));
+  if (!message.description.empty())
+    description_control_->processMessage( interactive_markers::makeTitle( message ));
 
   //create menu
   menu_entries_.clear();

--- a/src/rviz/default_plugin/marker_utils.cpp
+++ b/src/rviz/default_plugin/marker_utils.cpp
@@ -40,6 +40,7 @@
 #include "rviz/display_context.h"
 #include "rviz/properties/property.h"
 #include "rviz/properties/property_tree_model.h"
+#include "rviz/properties/status_property.h"
 #include "rviz/properties/status_list.h"
 #include "rviz/validate_quaternions.h"
 #include "rviz/validate_floats.h"
@@ -83,6 +84,22 @@ MarkerBase* createMarker(int marker_type, MarkerDisplay* owner, DisplayContext* 
   }
 }
 
+namespace
+{
+void addSeparatorIfRequired(std::stringstream& ss)
+{
+  if (ss.tellp() != 0) // check if string is not empty
+  {
+    ss << " \n";
+  }
+}
+
+void increaseLevel(::ros::console::levels::Level new_status, ::ros::console::levels::Level& current_status)
+{
+  if(new_status > current_status)
+    current_status = new_status;
+}
+
 template <typename T>
 constexpr const char* fieldName();
 template <>
@@ -95,14 +112,241 @@ template <>
 constexpr const char* fieldName<::std_msgs::ColorRGBA>() { return "Color"; }
 
 template <typename T>
-void checkFloats(const T& t, std::stringstream& ss, StatusProperty::Level& level)
+void checkFloats(const T& t, std::stringstream& ss, ::ros::console::levels::Level& level)
 {
   if (!validateFloats(t))
   {
     addSeparatorIfRequired(ss);
     ss << fieldName<T>() << " contains invalid floating point values (nans or infs)";
-    increaseWarningLevel(StatusProperty::Error, level);
+    increaseLevel(::ros::console::levels::Error, level);
   }
+}
+
+void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  checkFloats(marker.pose.orientation, ss, level);
+  if (marker.pose.orientation.x == 0.0 && marker.pose.orientation.y == 0.0 && marker.pose.orientation.z == 0.0 &&
+      marker.pose.orientation.w == 0.0)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Uninitialized quaternion, assuming identity.";
+    increaseLevel(::ros::console::levels::Info, level);
+  }
+  else if(!validateQuaternions(marker.pose))
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Unnormalized quaternion in marker message.";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+}
+
+void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  checkFloats(marker.scale, ss, level);
+  // for ARROW markers, scale.z is the optional head length
+  if(marker.type == visualization_msgs::Marker::ARROW && marker.scale.x != 0.0 && marker.scale.y != 0.0)
+    return;
+
+  if(marker.scale.x == 0.0  || marker.scale.y == 0.0  || marker.scale.z == 0.0)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Scale contains 0.0 in x, y or z.";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+}
+
+void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(marker.scale.x == 0.0)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Width LINE_LIST or LINE_STRIP is 0.0 (scale.x).";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+  else if(marker.scale.y != 0.0 || marker.scale.z != 0.0)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "scale.y and scale.z of LINE_LIST or LINE_STRIP are ignored.";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+}
+
+void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(marker.scale.x == 0.0 || marker.scale.y == 0.0)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Width and/or height of POINTS is 0.0 (scale.x, scale.y).";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+  else if(marker.scale.z != 0.0)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "scale.z of POINTS is ignored.";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+}
+
+void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(marker.scale.z == 0.0)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Text height of TEXT_VIEW_FACING is 0.0 (scale.z).";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+  else if(marker.scale.x != 0.0 || marker.scale.y != 0.0)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "scale.x and scale.y of TEXT_VIEW_FACING are ignored.";
+    increaseLevel(::ros::console::levels::Debug, level);
+  }
+}
+
+void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  checkFloats(marker.color, ss, level);
+  if(marker.color.a == 0.0 &&
+     // Mesh markers use a color of (0,0,0,0) to indicate that the original color of the mesh should be used as is
+     !(marker.type == visualization_msgs::Marker::MESH_RESOURCE && marker.mesh_use_embedded_materials
+       && marker.color.r == 0.0 && marker.color.g == 0.0 && marker.color.b == 0.0))
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Marker is fully transparent (color.a is 0.0).";
+    increaseLevel(::ros::console::levels::Info, level);
+  }
+}
+
+void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(marker.points.size() != 0 && marker.points.size() != 2)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Number of points for an ARROW marker should be either 0 or 2.";
+    increaseLevel(::ros::console::levels::Error, level);
+  }
+}
+
+void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(marker.points.empty())
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Points should not be empty for specified marker type.";
+    increaseLevel(::ros::console::levels::Error, level);
+  }
+  switch (marker.type)
+  {
+    case visualization_msgs::Marker::TRIANGLE_LIST:
+      if (marker.points.size() % 3 != 0)
+      {
+        addSeparatorIfRequired(ss);
+        ss << "Number of points should be a multiple of 3 for TRIANGLE_LIST marker.";
+        increaseLevel(::ros::console::levels::Error, level);
+      }
+      break;
+    case visualization_msgs::Marker::LINE_LIST:
+      if (marker.points.size() % 2 != 0)
+      {
+        addSeparatorIfRequired(ss);
+        ss << "Number of points should be a multiple of 2 for LINE_LIST marker.";
+        increaseLevel(::ros::console::levels::Error, level);
+      }
+      break;
+    case visualization_msgs::Marker::LINE_STRIP:
+      if (marker.points.size() <= 1)
+      {
+        addSeparatorIfRequired(ss);
+        ss << "At least two points are required for a LINE_STRIP marker.";
+        increaseLevel(::ros::console::levels::Error, level);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(!marker.points.empty())
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Non-empty points array is ignored.";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+}
+
+void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level, unsigned int multiple)
+{
+  if(marker.colors.size() == 0)
+  {
+    checkColor(marker, ss, level);
+    return;
+  }
+  if(marker.colors.size() != marker.points.size() && (multiple == 1 || multiple * marker.colors.size() != marker.points.size()))
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Number of colors doesn't match number of points.";
+    increaseLevel(::ros::console::levels::Error, level);
+  }
+}
+
+void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(!marker.colors.empty())
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Non-empty colors array is ignored.";
+    increaseLevel(::ros::console::levels::Warn, level);
+  }
+}
+
+void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(marker.text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Text is empty or only consists of whitespace.";
+    increaseLevel(::ros::console::levels::Error, level);
+  }
+}
+
+void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(!marker.text.empty())
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Non-empty text is ignored.";
+    increaseLevel(::ros::console::levels::Info, level);
+  }
+}
+
+void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if(marker.mesh_resource.empty())
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Empty mesh_resource path.";
+    increaseLevel(::ros::console::levels::Error, level);
+  }
+}
+
+void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, ::ros::console::levels::Level& level)
+{
+  if (!marker.mesh_resource.empty())
+  {
+    addSeparatorIfRequired(ss);
+    ss << "Non-empty mesh_resource is ignored.";
+    increaseLevel(::ros::console::levels::Info, level);
+  }
+  if (marker.mesh_use_embedded_materials)
+  {
+    addSeparatorIfRequired(ss);
+    ss << "mesh_use_embedded_materials is ignored.";
+    increaseLevel(::ros::console::levels::Info, level);
+  }
+}
+
 }
 
 bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* owner)
@@ -111,7 +355,7 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
     return true;
 
   std::stringstream ss;
-  StatusProperty::Level level = StatusProperty::Ok;
+  ::ros::console::levels::Level level = ::ros::console::levels::Debug;
   checkFloats(marker.pose.position, ss, level);
 
   switch (marker.type) {
@@ -143,7 +387,7 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
     checkQuaternion(marker, ss, level);
     checkScaleLineStripAndList(marker, ss, level);
     checkPointsNotEmpty(marker, ss, level);
-    checkColors(marker, ss, level);
+    checkColors(marker, ss, level, 1);
     checkTextEmpty(marker, ss, level);
     checkMeshEmpty(marker, ss, level);
     break;
@@ -154,7 +398,7 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
     checkQuaternion(marker, ss, level);
     checkScale(marker, ss, level);
     checkPointsNotEmpty(marker, ss, level);
-    checkColors(marker, ss, level);
+    checkColors(marker, ss, level, marker.type == visualization_msgs::Marker::TRIANGLE_LIST ? 3 : 1);
     checkTextEmpty(marker, ss, level);
     checkMeshEmpty(marker, ss, level);
     break;
@@ -162,7 +406,7 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
   case visualization_msgs::Marker::POINTS:
     checkScalePoints(marker, ss, level);
     checkPointsNotEmpty(marker, ss, level);
-    checkColors(marker, ss, level);
+    checkColors(marker, ss, level, 1);
     checkTextEmpty(marker, ss, level);
     checkMeshEmpty(marker, ss, level);
     break;
@@ -187,19 +431,20 @@ bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* own
 
   default:
     ss << "Unknown marker type: " << marker.type << '.' ;
-    level = StatusProperty::Error;
+    level = ::ros::console::levels::Error;
   }
 
   if(ss.tellp() != 0) //stringstream is not empty
   {
     std::string warning = ss.str();
 
+    bool fatal = level >= ::ros::console::levels::Error;
     if (owner)
-      owner->setMarkerStatus(MarkerID(marker.ns, marker.id), level, warning);
-    ROS_LOG((level == StatusProperty::Warn ? ::ros::console::levels::Warn : ::ros::console::levels::Error),
-            ROSCONSOLE_DEFAULT_NAME, "Marker '%s/%d': %s", marker.ns.c_str(), marker.id, warning.c_str());
+      owner->setMarkerStatus(MarkerID(marker.ns, marker.id), fatal ? StatusProperty::Error : StatusProperty::Warn, warning);
+    else
+      ROS_LOG(level, ROSCONSOLE_DEFAULT_NAME ".marker", "Marker '%s/%d': %s", marker.ns.c_str(), marker.id, warning.c_str());
 
-    return level != StatusProperty::Error;
+    return !fatal;
   }
 
   if (owner)
@@ -212,25 +457,21 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
   std::vector<MarkerID> marker_ids;
   marker_ids.reserve(array.markers.size());
 
-  StatusProperty::Level level = StatusProperty::Ok;
+  ::ros::console::levels::Level level = ::ros::console::levels::Debug;
   std::stringstream ss;
-  bool markers_added = false;
 
   for(const visualization_msgs::Marker& marker : array.markers)
   {
-    if (marker.action == visualization_msgs::Marker::ADD)
-      markers_added = true;
-
-    else if (marker.action == visualization_msgs::Marker::DELETEALL)
+    if (marker.action == visualization_msgs::Marker::DELETEALL)
     {
-      if (markers_added)
+      if (!marker_ids.empty())
       {
           addSeparatorIfRequired(ss);
-          ss << "Found a DELETEALL after having markers added. These markers will never show";
-          increaseWarningLevel(StatusProperty::Warn, level);
+          ss << "DELETEALL after having markers added. These will never show.";
+          increaseLevel(::ros::console::levels::Warn, level);
       }
-      markers_added = false;
-      // marker_ids.clear();
+      marker_ids.clear();
+      continue;
     }
 
     MarkerID current_id(marker.ns, marker.id);
@@ -238,8 +479,14 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
     if (search != marker_ids.end() && *search == current_id)
     {
       addSeparatorIfRequired(ss);
-      ss << "Found '" <<  marker.ns.c_str() << "/" << marker.id << "' multiple times";
-      increaseWarningLevel(StatusProperty::Warn, level);
+      increaseLevel(::ros::console::levels::Warn, level);
+      if (marker.action == visualization_msgs::Marker::DELETE)
+      {
+        ss << "Deleting just added marker '" <<  marker.ns.c_str() << "/" << marker.id << "'.";
+        marker_ids.erase(search);
+      }
+      else
+        ss << "Adding marker '" <<  marker.ns.c_str() << "/" << marker.id << "' multiple times.";
     }
     else
     {
@@ -251,12 +498,13 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
   {
     std::string warning = ss.str();
 
+    bool fatal = level >= ::ros::console::levels::Error;
     if (owner)
-      owner->setStatusStd(level, "marker_array", warning);
-    ROS_LOG((level == StatusProperty::Warn ? ::ros::console::levels::Warn : ::ros::console::levels::Error),
-            ROSCONSOLE_DEFAULT_NAME, "MarkerArray: %s", warning.c_str());
+      owner->setStatusStd(fatal ? StatusProperty::Error : StatusProperty::Warn, "marker_array", warning);
+    else
+      ROS_LOG(level, ROSCONSOLE_DEFAULT_NAME ".marker", "MarkerArray: %s", warning.c_str());
 
-    return false;
+    return !fatal;
   }
 
   if (owner)
@@ -264,240 +512,4 @@ bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDis
   return true;
 }
 
-
-void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  checkFloats(marker.pose.orientation, ss, level);
-  if (marker.pose.orientation.x == 0.0 && marker.pose.orientation.y == 0.0 && marker.pose.orientation.z == 0.0 &&
-      marker.pose.orientation.w == 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Uninitialized quaternion assuming identity.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-  else if(!validateQuaternions(marker.pose))
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Unnormalized quaternion in marker message.";
-    increaseWarningLevel(StatusProperty::Error, level);
-  }
-}
-
-void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  checkFloats(marker.scale, ss, level);
-  // for ARROW markers, scale.z is the optional head length
-  if(marker.type == visualization_msgs::Marker::ARROW && marker.scale.x != 0.0 && marker.scale.y != 0.0)
-    return;
-
-  if(marker.scale.x == 0.0  || marker.scale.y == 0.0  || marker.scale.z == 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Scale contains 0.0 in x, y or z.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(marker.scale.x == 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Width LINE_LIST or LINE_STRIP is 0.0 (scale.x).";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-  else if(marker.scale.y != 0.0 || marker.scale.z != 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "scale.y and scale.z of LINE_LIST or LINE_STRIP are ignored.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(marker.scale.x == 0.0 || marker.scale.y == 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Width and/or height of POINTS is 0.0 (scale.x, scale.y).";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-  else if(marker.scale.z != 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "scale.z of POINTS is ignored.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(marker.scale.z == 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Text height of TEXT_VIEW_FACING is 0.0 (scale.z).";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-  else if(marker.scale.x != 0.0 || marker.scale.y != 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "scale.x and scale.y of TEXT_VIEW_FACING are ignored.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  checkFloats(marker.color, ss, level);
-  if(marker.color.a == 0.0)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Marker is fully transparent (color.a is 0.0).";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(marker.points.size() != 0 && marker.points.size() != 2)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Number of points for an ARROW marker should be either 0 or 2.";
-    increaseWarningLevel(StatusProperty::Error, level);
-  }
-}
-
-void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(marker.points.empty())
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Points should not be empty for specified marker type.";
-    increaseWarningLevel(StatusProperty::Error, level);
-  }
-  switch (marker.type)
-  {
-    case visualization_msgs::Marker::TRIANGLE_LIST:
-      if (marker.points.size() % 3 != 0)
-      {
-        addSeparatorIfRequired(ss);
-        ss << "Number of points should be a multiple of 3 for TRIANGLE_LIST Marker.";
-        increaseWarningLevel(StatusProperty::Error, level);
-      }
-      break;
-    case visualization_msgs::Marker::LINE_LIST:
-      if (marker.points.size() % 2 != 0)
-      {
-        addSeparatorIfRequired(ss);
-        ss << "Number of points should be a multiple of 2 for LINE_LIST Marker.";
-        increaseWarningLevel(StatusProperty::Error, level);
-      }
-      break;
-    case visualization_msgs::Marker::LINE_STRIP:
-      if (marker.points.size() <= 1)
-      {
-        addSeparatorIfRequired(ss);
-        ss << "At least two points are required for a LINE_STRIP Marker.";
-        increaseWarningLevel(StatusProperty::Error, level);
-      }
-      break;
-    default:
-      break;
-  }
-}
-
-void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(!marker.points.empty())
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Points array is ignored by specified marker type.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(marker.colors.size() == 0)
-  {
-    checkColor(marker, ss, level);
-    return;
-  }
-  if(marker.colors.size() != marker.points.size())
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Number of colors is not equal to number of points or 0.";
-    increaseWarningLevel(StatusProperty::Error, level);
-  }
-}
-
-void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(!marker.colors.empty())
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Colors array is ignored by specified marker type.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(marker.text.find_first_not_of(" \t\n\v\f\r") == std::string::npos)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Text is empty or only consists whitespace.";
-    increaseWarningLevel(StatusProperty::Error, level);
-  }
-}
-
-void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(!marker.text.empty())
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Text is ignored for specified marker type.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if(marker.mesh_resource.empty())
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Path to mesh resource is empty for MESH_RESOURCE marker.";
-    increaseWarningLevel(StatusProperty::Error, level);
-  }
-}
-
-void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level)
-{
-  if (!marker.mesh_resource.empty())
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Mesh_resource is ignored for specified marker type.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-  if (marker.mesh_use_embedded_materials)
-  {
-    addSeparatorIfRequired(ss);
-    ss << "Using embedded materials is not supported for markers other than MESH_RESOURCE.";
-    increaseWarningLevel(StatusProperty::Warn, level);
-  }
-}
-
-void addSeparatorIfRequired(std::stringstream& ss)
-{
-  if (ss.tellp() != 0) // check if string is not empty
-  {
-    ss << " \n";
-  }
-}
-
-void increaseWarningLevel(StatusProperty::Level new_status, StatusProperty::Level& current_status)
-{
-    if(new_status > current_status)
-        current_status = new_status;
-}
 } // namespace rviz

--- a/src/rviz/default_plugin/marker_utils.h
+++ b/src/rviz/default_plugin/marker_utils.h
@@ -33,7 +33,6 @@
 
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
-#include "rviz/properties/status_property.h"
 
 namespace Ogre
 {
@@ -55,31 +54,6 @@ MarkerBase* createMarker(int marker_type, MarkerDisplay *owner, DisplayContext *
 bool checkMarkerMsg(const visualization_msgs::Marker& marker, MarkerDisplay* owner);
 bool checkMarkerArrayMsg(const visualization_msgs::MarkerArray& array, MarkerDisplay* owner);
 
-void checkQuaternion(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-
-void checkScale(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-void checkScaleLineStripAndList(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-void checkScalePoints(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-void checkScaleText(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-
-void checkColor(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-
-
-void checkPointsArrow(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-void checkPointsNotEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-void checkPointsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-
-void checkColors(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-void checkColorsEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-
-void checkTextNotEmptyOrWhitespace(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-void checkTextEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-
-void checkMesh(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-void checkMeshEmpty(const visualization_msgs::Marker& marker, std::stringstream& ss, StatusProperty::Level& level);
-
-void addSeparatorIfRequired(std::stringstream& ss);
-void increaseWarningLevel(StatusProperty::Level new_status, StatusProperty::Level& current_status);
 }
 
 #endif

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -31,6 +31,7 @@
 #include <resource_retriever/retriever.h>
 
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <OgreMeshManager.h>
 #include <OgreTextureManager.h>
@@ -435,6 +436,18 @@ void loadMaterials(const std::string& resource_path,
                    const aiScene* scene,
                    std::vector<Ogre::MaterialPtr>& material_table_out )
 {
+#if BOOST_FILESYSTEM_VERSION == 3
+  std::string ext = fs::path(resource_path).extension().string();
+#else
+  std::string ext = fs::path(resource_path).extension();
+#endif
+  boost::algorithm::to_lower(ext);
+  if (ext == ".stl" || ext == ".stlb")  // STL meshes don't support proper materials: use Ogre's default material
+  {
+    material_table_out.push_back(Ogre::MaterialManager::getSingleton().getByName("BaseWhiteNoLighting"));
+    return;
+  }
+
   for (uint32_t i = 0; i < scene->mNumMaterials; i++)
   {
     std::stringstream ss;
@@ -662,7 +675,8 @@ Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path)
 #else
     std::string ext = model_path.extension();
 #endif
-    if (ext == ".mesh" || ext == ".MESH")
+    boost::algorithm::to_lower(ext);
+    if (ext == ".mesh")
     {
       resource_retriever::Retriever retriever;
       resource_retriever::MemoryResource res;


### PR DESCRIPTION
This fixes some more issues of #1275:
- invalid quaternion: issue warning only
- triangle list accepts points.size()/3 colors as well (face colors)
- don't create (empty) text marker for interactive marker control with empty description 
(to avoid warning)

as well as #1365:
- use default material for .stl meshes

@v4hn and @simonschmeisser, could you please have a look?