### PR TITLE
ImageDisplay: report frame issues

### DIFF
--- a/src/rviz/default_plugin/camera_display.h
+++ b/src/rviz/default_plugin/camera_display.h
@@ -112,6 +112,7 @@ private:
 
   virtual void processMessage(const sensor_msgs::Image::ConstPtr& msg);
   void caminfoCallback( const sensor_msgs::CameraInfo::ConstPtr& msg );
+  void failCallback(const sensor_msgs::CameraInfo::ConstPtr &msg, tf2_ros::FilterFailureReason reason);
 
   bool updateCamera();
 
@@ -138,7 +139,7 @@ private:
   sensor_msgs::CameraInfo::ConstPtr current_caminfo_;
   boost::mutex caminfo_mutex_;
 
-  bool new_caminfo_;
+  bool caminfo_tf_ok_;
 
   bool caminfo_ok_;
 

--- a/src/rviz/default_plugin/camera_display.h
+++ b/src/rviz/default_plugin/camera_display.h
@@ -111,8 +111,7 @@ private:
   void unsubscribe();
 
   virtual void processMessage(const sensor_msgs::Image::ConstPtr& msg);
-  void caminfoCallback( const sensor_msgs::CameraInfo::ConstPtr& msg );
-  void failCallback(const sensor_msgs::CameraInfo::ConstPtr &msg, tf2_ros::FilterFailureReason reason);
+  void caminfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg);
 
   bool updateCamera();
 

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -163,7 +163,7 @@ void ImageDisplay::onDisable()
 {
   render_panel_->getRenderWindow()->setActive(false);
   ImageDisplayBase::unsubscribe();
-  clear();
+  reset();
 }
 
 void ImageDisplay::updateNormalizeOptions()
@@ -189,14 +189,13 @@ void ImageDisplay::updateNormalizeOptions()
   }
 }
 
+// TODO: In Noetic remove and integrate into reset()
 void ImageDisplay::clear()
 {
   texture_.clear();
 
   if( render_panel_->getCamera() )
-  {
     render_panel_->getCamera()->setPosition(Ogre::Vector3(999999, 999999, 999999));
-  }
 }
 
 void ImageDisplay::update( float wall_dt, float ros_dt )
@@ -239,8 +238,8 @@ void ImageDisplay::update( float wall_dt, float ros_dt )
 
 void ImageDisplay::reset()
 {
-  ImageDisplayBase::reset();
   clear();
+  ImageDisplayBase::reset();
 }
 
 /* This is called by incomingMessage(). */

--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -126,6 +126,12 @@ void ImageDisplayBase::incomingMessage(const sensor_msgs::Image::ConstPtr& msg)
 }
 
 
+void ImageDisplayBase::failedMessage(const sensor_msgs::Image::ConstPtr &msg, tf2_ros::FilterFailureReason reason)
+{
+  setStatusStd(StatusProperty::Error, "Image", context_->getFrameManager()->discoverFailureReason( msg->header.frame_id, msg->header.stamp, "", reason ));
+}
+
+
 void ImageDisplayBase::reset()
 {
   Display::reset();
@@ -192,7 +198,7 @@ void ImageDisplayBase::subscribe()
           update_nh_
         ));
         tf_filter_->registerCallback(boost::bind(&ImageDisplayBase::incomingMessage, this, _1));
-        // TODO: also register failureCallback to report about frame-resolving issues (now: "no images received")
+        tf_filter_->registerFailureCallback(boost::bind(&ImageDisplayBase::failedMessage, this, _1, _2));
       }
     }
     setStatus(StatusProperty::Ok, "Topic", "OK");

--- a/src/rviz/image/image_display_base.h
+++ b/src/rviz/image/image_display_base.h
@@ -103,6 +103,9 @@ protected:
    * processMessage(). */
   void incomingMessage(const sensor_msgs::Image::ConstPtr& msg);
 
+  /** @brief Callback for messages, whose frame_id cannot resolved */
+  void failedMessage(const sensor_msgs::Image::ConstPtr& msg, tf2_ros::FilterFailureReason reason);
+
   /** @brief Implement this to process the contents of a message.
    *
    * This is called by incomingMessage(). */

--- a/src/rviz/image/ros_image_texture.cpp
+++ b/src/rviz/image/ros_image_texture.cpp
@@ -46,11 +46,11 @@ namespace rviz
 
 ROSImageTexture::ROSImageTexture()
 : new_image_(false)
-, width_(0)
-, height_(0)
 , median_frames_(5)
 {
   empty_image_.load("no_image.png", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+  width_ = empty_image_.getWidth();
+  height_ = empty_image_.getHeight();
 
   static uint32_t count = 0;
   std::stringstream ss;
@@ -71,6 +71,8 @@ void ROSImageTexture::clear()
 
   texture_->unload();
   texture_->loadImage(empty_image_);
+  width_ = empty_image_.getWidth();
+  height_ = empty_image_.getHeight();
 
   new_image_ = false;
   current_image_.reset();

--- a/src/test/send_images.cpp
+++ b/src/test/send_images.cpp
@@ -60,7 +60,7 @@ int main( int argc, char **argv )
     int width = 100;
     int height = 1000;
     msg.data.resize( width * height * 3 );
-    msg.header.frame_id = "base_link";
+    msg.header.frame_id = "camera_frame";
     msg.height = height;
     msg.width = width;
     msg.encoding = image_format;
@@ -100,7 +100,7 @@ int main( int argc, char **argv )
     int width = 400;
     int height = 400;
     msg.data.resize( width * height * sizeof( float ));
-    msg.header.frame_id = "base_link";
+    msg.header.frame_id = "camera_frame";
     msg.height = height;
     msg.width = width;
     msg.encoding = image_format;
@@ -134,7 +134,7 @@ int main( int argc, char **argv )
     int width = 400;
     int height = 400;
     msg.data.resize( width * height * sizeof( short ));
-    msg.header.frame_id = "base_link";
+    msg.header.frame_id = "camera_frame";
     msg.height = height;
     msg.width = width;
     msg.encoding = image_format;


### PR DESCRIPTION
Currently, image displays report "no image received" - also in case images were received but had an unknown image frame. This PR adds a corresponding failure handling for TF frames.

However, for `ImageDisplay` an issue remains with `CameraInfo`: If the camera info is published latched, rviz only receives a single message (either success or failure depending on the frame status). If rviz' fixed frame changes (which probably changes the frame status of the camera as well), this change is not noticed anymore, because updates can only happen when a new TF message is received.

@wjwwood, hence my question: Should we latched CameraInfo messages be supported?
If so, we would need to memorize the latest received message in any case and validate its frame "manually" as soon as the fixed frame changes.