### PR TITLE
MessageFilterDisplay: add queue-size property

### DIFF
--- a/src/rviz/default_plugin/effort_display.h
+++ b/src/rviz/default_plugin/effort_display.h
@@ -536,23 +536,23 @@ public:
 
   virtual void onInitialize()
     {
-    	// TODO(wjwwood): remove this and use tf2 interface instead
+      // TODO(wjwwood): remove this and use tf2 interface instead
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-		  auto tf_client = context_->getTFClient();
+      auto tf_client = context_->getTFClient();
 
 #ifndef _WIN32
 # pragma GCC diagnostic pop
 #endif
       tf_filter_ = new tf::MessageFilterJointState( *tf_client,
-                                                    fixed_frame_.toStdString(), 10, update_nh_ );
+                                                    fixed_frame_.toStdString(), queue_size_property_->getInt(), update_nh_ );
 
       tf_filter_->connectInput( sub_ );
       tf_filter_->registerCallback( boost::bind( &MessageFilterJointStateDisplay::incomingMessage, this, _1 ));
-     	// TODO(wjwwood): remove this and use tf2 interface instead
+      // TODO(wjwwood): remove this and use tf2 interface instead
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -587,6 +587,12 @@ protected:
       context_->queueRender();
     }
 
+  virtual void updateQueueSize()
+    {
+      tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
+      subscribe();
+    }
+
   virtual void subscribe()
     {
       if( !isEnabled() )
@@ -596,7 +602,7 @@ protected:
 
       try
       {
-        sub_.subscribe( update_nh_, topic_property_->getTopicStd(), 10 );
+        sub_.subscribe( update_nh_, topic_property_->getTopicStd(), queue_size_property_->getInt() );
         setStatus( StatusProperty::Ok, "Topic", "OK" );
       }
       catch( ros::Exception& e )

--- a/src/rviz/default_plugin/fluid_pressure_display.cpp
+++ b/src/rviz/default_plugin/fluid_pressure_display.cpp
@@ -48,12 +48,6 @@ namespace rviz
 FluidPressureDisplay::FluidPressureDisplay()
   : point_cloud_common_( new PointCloudCommon( this ))
 {
-  queue_size_property_ = new IntProperty( "Queue Size", 10,
-                                          "Advanced: set the size of the incoming FluidPressure message queue. "
-                                          " Increasing this is useful if your incoming TF data is delayed significantly "
-                                          "from your FluidPressure data, but it can greatly increase memory usage if the messages are big.",
-                                          this, SLOT( updateQueueSize() ));
-
   // PointCloudCommon sets up a callback queue with a thread for each
   // instance.  Use that for processing incoming messages.
   update_nh_.setCallbackQueue( point_cloud_common_->getCallbackQueue() );
@@ -74,11 +68,6 @@ void FluidPressureDisplay::onInitialize()
   subProp("Autocompute Intensity Bounds")->setValue(false);
   subProp("Min Intensity")->setValue(98000); // Typical 'low' atmosphereic pressure in Pascal
   subProp("Max Intensity")->setValue(105000); // Typica 'high' atmosphereic pressure in Pascal
-}
-
-void FluidPressureDisplay::updateQueueSize()
-{
-  tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
 }
 
 void FluidPressureDisplay::processMessage( const sensor_msgs::FluidPressureConstPtr& msg )

--- a/src/rviz/default_plugin/fluid_pressure_display.h
+++ b/src/rviz/default_plugin/fluid_pressure_display.h
@@ -57,17 +57,12 @@ public:
 
   virtual void update( float wall_dt, float ros_dt );
 
-private Q_SLOTS:
-  void updateQueueSize();
-
 protected:
   /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   virtual void onInitialize();
 
   /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   virtual void processMessage( const sensor_msgs::FluidPressureConstPtr& msg );
-
-  IntProperty* queue_size_property_;
 
   PointCloudCommon* point_cloud_common_;
 };

--- a/src/rviz/default_plugin/illuminance_display.cpp
+++ b/src/rviz/default_plugin/illuminance_display.cpp
@@ -48,12 +48,6 @@ namespace rviz
 IlluminanceDisplay::IlluminanceDisplay()
   : point_cloud_common_( new PointCloudCommon( this ))
 {
-  queue_size_property_ = new IntProperty( "Queue Size", 10,
-                                          "Advanced: set the size of the incoming Illuminance message queue. "
-                                          " Increasing this is useful if your incoming TF data is delayed significantly "
-                                          "from your Illuminance data, but it can greatly increase memory usage if the messages are big.",
-                                          this, SLOT( updateQueueSize() ));
-
   // PointCloudCommon sets up a callback queue with a thread for each
   // instance.  Use that for processing incoming messages.
   update_nh_.setCallbackQueue( point_cloud_common_->getCallbackQueue() );
@@ -74,11 +68,6 @@ void IlluminanceDisplay::onInitialize()
   subProp("Autocompute Intensity Bounds")->setValue(false);
   subProp("Min Intensity")->setValue(0);
   subProp("Max Intensity")->setValue(1000);
-}
-
-void IlluminanceDisplay::updateQueueSize()
-{
-  tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
 }
 
 void IlluminanceDisplay::processMessage( const sensor_msgs::IlluminanceConstPtr& msg )

--- a/src/rviz/default_plugin/illuminance_display.h
+++ b/src/rviz/default_plugin/illuminance_display.h
@@ -57,17 +57,12 @@ public:
 
   virtual void update( float wall_dt, float ros_dt );
 
-private Q_SLOTS:
-  void updateQueueSize();
-
 protected:
   /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   virtual void onInitialize();
 
   /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   virtual void processMessage( const sensor_msgs::IlluminanceConstPtr& msg );
-
-  IntProperty* queue_size_property_;
 
   PointCloudCommon* point_cloud_common_;
 };

--- a/src/rviz/default_plugin/laser_scan_display.cpp
+++ b/src/rviz/default_plugin/laser_scan_display.cpp
@@ -50,12 +50,6 @@ LaserScanDisplay::LaserScanDisplay()
   : point_cloud_common_( new PointCloudCommon( this ))
   , projector_( new laser_geometry::LaserProjection() )
 {
-  queue_size_property_ = new IntProperty( "Queue Size", 10,
-                                          "Advanced: set the size of the incoming LaserScan message queue. "
-                                          " Increasing this is useful if your incoming TF data is delayed significantly "
-                                          "from your LaserScan data, but it can greatly increase memory usage if the messages are big.",
-                                          this, SLOT( updateQueueSize() ));
-
   // PointCloudCommon sets up a callback queue with a thread for each
   // instance.  Use that for processing incoming messages.
   update_nh_.setCallbackQueue( point_cloud_common_->getCallbackQueue() );
@@ -71,11 +65,6 @@ void LaserScanDisplay::onInitialize()
 {
   MFDClass::onInitialize();
   point_cloud_common_->initialize( context_, scene_node_ );
-}
-
-void LaserScanDisplay::updateQueueSize()
-{
-  tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
 }
 
 void LaserScanDisplay::processMessage( const sensor_msgs::LaserScanConstPtr& scan )

--- a/src/rviz/default_plugin/laser_scan_display.h
+++ b/src/rviz/default_plugin/laser_scan_display.h
@@ -57,17 +57,12 @@ public:
 
   virtual void update( float wall_dt, float ros_dt );
 
-private Q_SLOTS:
-  void updateQueueSize();
-
 protected:
   /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   virtual void onInitialize();
 
   /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   virtual void processMessage( const sensor_msgs::LaserScanConstPtr& scan );
-
-  IntProperty* queue_size_property_;
 
   PointCloudCommon* point_cloud_common_;
 

--- a/src/rviz/default_plugin/point_cloud2_display.cpp
+++ b/src/rviz/default_plugin/point_cloud2_display.cpp
@@ -48,12 +48,6 @@ namespace rviz
 PointCloud2Display::PointCloud2Display()
   : point_cloud_common_( new PointCloudCommon( this ))
 {
-  queue_size_property_ = new IntProperty( "Queue Size", 10,
-                                          "Advanced: set the size of the incoming PointCloud2 message queue. "
-                                          " Increasing this is useful if your incoming TF data is delayed significantly "
-                                          "from your PointCloud2 data, but it can greatly increase memory usage if the messages are big.",
-                                          this, SLOT( updateQueueSize() ));
-
   // PointCloudCommon sets up a callback queue with a thread for each
   // instance.  Use that for processing incoming messages.
   update_nh_.setCallbackQueue( point_cloud_common_->getCallbackQueue() );
@@ -68,11 +62,6 @@ void PointCloud2Display::onInitialize()
 {
   MFDClass::onInitialize();
   point_cloud_common_->initialize( context_, scene_node_ );
-}
-
-void PointCloud2Display::updateQueueSize()
-{
-  tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
 }
 
 void PointCloud2Display::processMessage( const sensor_msgs::PointCloud2ConstPtr& cloud )

--- a/src/rviz/default_plugin/point_cloud2_display.h
+++ b/src/rviz/default_plugin/point_cloud2_display.h
@@ -59,17 +59,12 @@ public:
 
   virtual void update( float wall_dt, float ros_dt );
 
-private Q_SLOTS:
-  void updateQueueSize();
-
 protected:
   /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   virtual void onInitialize();
 
   /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   virtual void processMessage( const sensor_msgs::PointCloud2ConstPtr& cloud );
-
-  IntProperty* queue_size_property_;
 
   PointCloudCommon* point_cloud_common_;
 };

--- a/src/rviz/default_plugin/point_cloud_display.cpp
+++ b/src/rviz/default_plugin/point_cloud_display.cpp
@@ -46,12 +46,6 @@ namespace rviz
 PointCloudDisplay::PointCloudDisplay()
   : point_cloud_common_( new PointCloudCommon( this ))
 {
-  queue_size_property_ = new IntProperty( "Queue Size", 10,
-                                          "Advanced: set the size of the incoming PointCloud message queue. "
-                                          " Increasing this is useful if your incoming TF data is delayed significantly "
-                                          "from your PointCloud data, but it can greatly increase memory usage if the messages are big.",
-                                          this, SLOT( updateQueueSize() ));
-
   // PointCloudCommon sets up a callback queue with a thread for each
   // instance.  Use that for processing incoming messages.
   update_nh_.setCallbackQueue( point_cloud_common_->getCallbackQueue() );
@@ -66,11 +60,6 @@ void PointCloudDisplay::onInitialize()
 {
   MFDClass::onInitialize();
   point_cloud_common_->initialize( context_, scene_node_ );
-}
-
-void PointCloudDisplay::updateQueueSize()
-{
-  tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
 }
 
 void PointCloudDisplay::processMessage( const sensor_msgs::PointCloudConstPtr& cloud )

--- a/src/rviz/default_plugin/point_cloud_display.h
+++ b/src/rviz/default_plugin/point_cloud_display.h
@@ -63,17 +63,12 @@ public:
 
   virtual void update( float wall_dt, float ros_dt );
 
-private Q_SLOTS:
-  void updateQueueSize();
-
 protected:
   /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   virtual void onInitialize();
 
   /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   virtual void processMessage( const sensor_msgs::PointCloudConstPtr& cloud );
-
-  IntProperty* queue_size_property_;
 
   PointCloudCommon* point_cloud_common_;
 };

--- a/src/rviz/default_plugin/range_display.cpp
+++ b/src/rviz/default_plugin/range_display.cpp
@@ -57,10 +57,6 @@ RangeDisplay::RangeDisplay()
                                              "Number of prior measurements to display.",
                                              this, SLOT( updateBufferLength() ));
   buffer_length_property_->setMin( 1 );
-
-  queue_size_property_ = new IntProperty( "Queue Size", 100,
-                                          "Size of the tf message filter queue. It usually needs to be set at least as high as the number of sonar frames.",
-                                          this, SLOT( updateQueueSize() ));
 }
 
 void RangeDisplay::onInitialize()
@@ -82,11 +78,6 @@ void RangeDisplay::reset()
 {
   MFDClass::reset();
   updateBufferLength();
-}
-
-void RangeDisplay::updateQueueSize()
-{
-  tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
 }
 
 void RangeDisplay::updateColorAndAlpha()

--- a/src/rviz/default_plugin/range_display.h
+++ b/src/rviz/default_plugin/range_display.h
@@ -70,7 +70,6 @@ protected:
 private Q_SLOTS:
   void updateBufferLength();
   void updateColorAndAlpha();
-  void updateQueueSize();
 
 private:
   std::vector<Shape* > cones_;      ///< Handles actually drawing the cones
@@ -78,7 +77,6 @@ private:
   ColorProperty* color_property_;
   FloatProperty* alpha_property_;
   IntProperty* buffer_length_property_;
-  IntProperty* queue_size_property_;
 };
 
 } // namespace range_plugin

--- a/src/rviz/default_plugin/relative_humidity_display.cpp
+++ b/src/rviz/default_plugin/relative_humidity_display.cpp
@@ -48,12 +48,6 @@ namespace rviz
 RelativeHumidityDisplay::RelativeHumidityDisplay()
   : point_cloud_common_( new PointCloudCommon( this ))
 {
-  queue_size_property_ = new IntProperty( "Queue Size", 10,
-                                          "Advanced: set the size of the incoming RelativeHumidity message queue. "
-                                          " Increasing this is useful if your incoming TF data is delayed significantly "
-                                          "from your RelativeHumidity data, but it can greatly increase memory usage if the messages are big.",
-                                          this, SLOT( updateQueueSize() ));
-
   // PointCloudCommon sets up a callback queue with a thread for each
   // instance.  Use that for processing incoming messages.
   update_nh_.setCallbackQueue( point_cloud_common_->getCallbackQueue() );
@@ -74,11 +68,6 @@ void RelativeHumidityDisplay::onInitialize()
   subProp("Autocompute Intensity Bounds")->setValue(false);
   subProp("Min Intensity")->setValue(0.0); // 0% relative humidity
   subProp("Max Intensity")->setValue(1.0); // 100% relative humidity
-}
-
-void RelativeHumidityDisplay::updateQueueSize()
-{
-  tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
 }
 
 void RelativeHumidityDisplay::processMessage( const sensor_msgs::RelativeHumidityConstPtr& msg )

--- a/src/rviz/default_plugin/relative_humidity_display.h
+++ b/src/rviz/default_plugin/relative_humidity_display.h
@@ -57,17 +57,12 @@ public:
 
   virtual void update( float wall_dt, float ros_dt );
 
-private Q_SLOTS:
-  void updateQueueSize();
-
 protected:
   /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   virtual void onInitialize();
 
   /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   virtual void processMessage( const sensor_msgs::RelativeHumidityConstPtr& msg );
-
-  IntProperty* queue_size_property_;
 
   PointCloudCommon* point_cloud_common_;
 };

--- a/src/rviz/default_plugin/temperature_display.cpp
+++ b/src/rviz/default_plugin/temperature_display.cpp
@@ -48,12 +48,6 @@ namespace rviz
 TemperatureDisplay::TemperatureDisplay()
   : point_cloud_common_( new PointCloudCommon( this ))
 {
-  queue_size_property_ = new IntProperty( "Queue Size", 10,
-                                          "Advanced: set the size of the incoming Temperature message queue. "
-                                          " Increasing this is useful if your incoming TF data is delayed significantly "
-                                          "from your Temperature data, but it can greatly increase memory usage if the messages are big.",
-                                          this, SLOT( updateQueueSize() ));
-
   // PointCloudCommon sets up a callback queue with a thread for each
   // instance.  Use that for processing incoming messages.
   update_nh_.setCallbackQueue( point_cloud_common_->getCallbackQueue() );
@@ -75,11 +69,6 @@ void TemperatureDisplay::onInitialize()
   subProp("Invert Rainbow")->setValue(true);
   subProp("Min Intensity")->setValue(0); // Water Freezing
   subProp("Max Intensity")->setValue(100); // Water Boiling
-}
-
-void TemperatureDisplay::updateQueueSize()
-{
-  tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
 }
 
 void TemperatureDisplay::processMessage( const sensor_msgs::TemperatureConstPtr& msg )

--- a/src/rviz/default_plugin/temperature_display.h
+++ b/src/rviz/default_plugin/temperature_display.h
@@ -57,17 +57,12 @@ public:
 
   virtual void update( float wall_dt, float ros_dt );
 
-private Q_SLOTS:
-  void updateQueueSize();
-
 protected:
   /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   virtual void onInitialize();
 
   /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   virtual void processMessage( const sensor_msgs::TemperatureConstPtr& msg );
-
-  IntProperty* queue_size_property_;
 
   PointCloudCommon* point_cloud_common_;
 };

--- a/src/rviz/message_filter_display.h
+++ b/src/rviz/message_filter_display.h
@@ -39,6 +39,7 @@
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
+#include "rviz/properties/int_property.h"
 #include "rviz/properties/ros_topic_property.h"
 
 #include "rviz/display.h"
@@ -63,14 +64,22 @@ public:
                                                "Prefer UDP topic transport",
                                                this,
                                                SLOT( updateTopic() ));
+      queue_size_property_ = new IntProperty( "Queue Size", 10,
+                                              "Size of TF message filter queue.\n"
+                                              "Increasing this is useful if your TF data is delayed significantly "
+                                              "w.r.t. your data, but it can greatly increase memory usage as well.",
+                                              this, SLOT( updateQueueSize() ));
+      queue_size_property_->setMin(0);
     }
 
 protected Q_SLOTS:
   virtual void updateTopic() = 0;
+  virtual void updateQueueSize() = 0;
 
 protected:
   RosTopicProperty* topic_property_;
   BoolProperty* unreliable_property_;
+  IntProperty* queue_size_property_;
 };
 
 /** @brief Display subclass using a tf2_ros::MessageFilter, templated on the ROS message type.
@@ -102,7 +111,7 @@ public:
       tf_filter_ = new tf2_ros::MessageFilter<MessageType>(
         *context_->getTF2BufferPtr(),
         fixed_frame_.toStdString(),
-        10,
+        static_cast<uint32_t>(queue_size_property_->getInt()),
         update_nh_);
 
       tf_filter_->connectInput( sub_ );
@@ -141,6 +150,12 @@ protected:
       context_->queueRender();
     }
 
+  virtual void updateQueueSize()
+    {
+      tf_filter_->setQueueSize(static_cast<uint32_t>(queue_size_property_->getInt()));
+      subscribe();
+    }
+
   virtual void subscribe()
     {
       if( !isEnabled() )
@@ -156,7 +171,8 @@ protected:
         {
           transport_hint = ros::TransportHints().unreliable();
         }
-        sub_.subscribe( update_nh_, topic_property_->getTopicStd(), 10, transport_hint);
+        sub_.subscribe( update_nh_, topic_property_->getTopicStd(),
+                        static_cast<uint32_t>(queue_size_property_->getInt()), transport_hint);
         setStatus( StatusProperty::Ok, "Topic", "OK" );
       }
       catch( ros::Exception& e )


### PR DESCRIPTION
This is a replacement for #1113, addressing the comments listed there.
Also, it removes the now redundant `queue_size_property_` members in derived classes.
As this changes ABI, this PR targets Noetic only.