### PR TITLE
Adapt subscriber size with TF queue size

### DIFF
--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -145,6 +145,7 @@ void MarkerDisplay::onDisable()
 void MarkerDisplay::updateQueueSize()
 {
   tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
+  subscribe();
 }
 
 void MarkerDisplay::updateTopic()

--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -143,7 +143,10 @@ void ImageDisplayBase::updateQueueSize()
 {
   uint32_t size = queue_size_property_->getInt();
   if (tf_filter_)
+  {
     tf_filter_->setQueueSize(size);
+    subscribe();
+  }
 }
 
 void ImageDisplayBase::subscribe()

--- a/src/test/marker_test.cpp
+++ b/src/test/marker_test.cpp
@@ -13,7 +13,7 @@ void emitRow(const std::string type_name, uint32_t type, int32_t x_pos, float r,
     float sx = 1.0, float sy = 1.0, float sz = 1.0)
 {
   static uint32_t count = 0;
-  for (int i = -5; i < 5; ++i)
+  for (int i = -5; i <= 5; ++i)
   {
     visualization_msgs::Marker marker;
     marker.header.frame_id = frame_id;
@@ -41,9 +41,20 @@ void emitRow(const std::string type_name, uint32_t type, int32_t x_pos, float r,
 
     marker.lifetime = lifetime;
     marker.frame_locked = frame_locked;
-    marker.text = "This is some text\nthis is a new line\nthis is another line\nand another     adfoije    owijeoiwej\na really really really really really really really really really really long one";
-    marker.mesh_resource = "package://pr2_description/meshes/base_v0/base.dae";
-    marker.mesh_use_embedded_materials = (i > int((count / 12) % 5));
+    if (type == visualization_msgs::Marker::TEXT_VIEW_FACING)
+    {
+      marker.text = "This is some text\nthis is a new line\nthis is another line\nand another with utf8 symbols: äöüÄÖÜ\na really really really really really really really really really really long one";
+      marker.scale.x = marker.scale.y = 0.0;
+    }
+    else if (type == visualization_msgs::Marker::POINTS)
+    {
+      marker.scale.z = 0.0;
+    }
+    else if (type == visualization_msgs::Marker::MESH_RESOURCE)
+    {
+      marker.mesh_resource = "package://pr2_description/meshes/base_v0/base.dae";
+      marker.mesh_use_embedded_materials = (i > int((count / 12) % 5));
+    }
     pub.publish(marker);
   }
 
@@ -89,7 +100,7 @@ void publishCallback(const ros::TimerEvent&)
   x_pos += 3;
 
   {
-    for (int i = -5; i < 5; ++i)
+    for (int i = -5; i <= 5; ++i)
     {
       visualization_msgs::Marker marker;
       marker.header.frame_id = "/base_link";
@@ -114,10 +125,7 @@ void publishCallback(const ros::TimerEvent&)
 
       if (counter % 2 == 0)
       {
-        marker.points.resize(1);
-        marker.points[0].x = 0.0f;
-        marker.points[0].y = 0.0f;
-        marker.points[0].z = 0.0f;
+        marker.points.resize(0);
       }
       else
       {
@@ -252,6 +260,8 @@ void publishCallback(const ros::TimerEvent&)
       marker.id = type;
       marker.pose.position.x += 0.5;
       marker.type = type;
+      if (type == visualization_msgs::Marker::POINTS)
+        marker.scale.z = 0.0;
 
       for (int y = 0; y < 10; ++y)
       {
@@ -339,7 +349,7 @@ void publishCallback(const ros::TimerEvent&)
     marker.pose.position.x = x_pos;
     marker.scale.x = 0.02;
     marker.scale.y = 0.02;
-    marker.scale.z = 0.02;
+    marker.scale.z = 0.0;
     marker.color.r = 1.0;
     marker.color.g = 0.0;
     marker.color.b = 1.0;
@@ -381,7 +391,7 @@ void publishCallback(const ros::TimerEvent&)
     marker.pose.position.x = x_pos;
     marker.scale.x = 0.02;
     marker.scale.y = 0.02;
-    marker.scale.z = 0.02;
+    marker.scale.z = 0.0;
     marker.color.r = 1.0;
     marker.color.g = 0.0;
     marker.color.b = 1.0;
@@ -437,7 +447,7 @@ void publishCallback(const ros::TimerEvent&)
     marker.color.a = 1.0;
     marker.frame_locked = true;
 
-    for (int i = 0; i < count; ++i)
+    for (int i = 0; i <= count; ++i)
     {
       geometry_msgs::Point p1, p2;
       p1.x = 0;
@@ -476,7 +486,7 @@ void publishCallback(const ros::TimerEvent&)
     marker.color.a = 1.0;
     marker.frame_locked = true;
 
-    for (int i = 0; i < count; ++i)
+    for (int i = 0; i <= count; ++i)
     {
       geometry_msgs::Point p1, p2;
       p1.x = 0;
@@ -524,7 +534,7 @@ void publishCallback(const ros::TimerEvent&)
     marker.color.a = 1.0;
     marker.frame_locked = true;
 
-    for (int i = -5; i < 5; ++i)
+    for (int i = -5; i <= 5; ++i)
     {
       geometry_msgs::Point p;
       p.x = 1 + (i % 2);


### PR DESCRIPTION
Fixes #1135. Obviously, when increasing the TF filter's queue size, we also need to adapt the subscriber's queue size, i.e. re-subscribe. Otherwise, we cannot even receive enough messages.