### PR TITLE
Mouse move

### DIFF
--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -54,6 +54,7 @@ RenderPanel::RenderPanel( QWidget* parent )
   , scene_manager_( 0 )
   , view_controller_( 0 )
   , context_menu_visible_(false)
+  //TODO(simonschmeisser) remove this in noetic
   , fake_mouse_move_event_timer_( new QTimer() )
   , default_camera_(0)
 {
@@ -64,6 +65,7 @@ RenderPanel::RenderPanel( QWidget* parent )
 
 RenderPanel::~RenderPanel()
 {
+    //TODO(simonschmeisser) remove this in noetic
   delete fake_mouse_move_event_timer_;
   if( scene_manager_ && default_camera_ )
   {
@@ -92,6 +94,7 @@ void RenderPanel::initialize(Ogre::SceneManager* scene_manager, DisplayContext* 
   setCamera( default_camera_ );
 }
 
+//TODO(simonschmeisser) remove this in noetic
 void RenderPanel::sendMouseMoveEvent()
 {
   QPoint cursor_pos = QCursor::pos();
@@ -122,6 +125,7 @@ void RenderPanel::sendMouseMoveEvent()
     onRenderWindowMouseEvents( &fake_event );
   }
 }
+
 void RenderPanel::leaveEvent ( QEvent * event )
 {
   setCursor( Qt::ArrowCursor );

--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -59,6 +59,7 @@ RenderPanel::RenderPanel( QWidget* parent )
 {
   setFocusPolicy(Qt::WheelFocus);
   setFocus( Qt::OtherFocusReason );
+  setMouseTracking(true);
 }
 
 RenderPanel::~RenderPanel()
@@ -89,9 +90,6 @@ void RenderPanel::initialize(Ogre::SceneManager* scene_manager, DisplayContext* 
   default_camera_->lookAt(0, 0, 0);
 
   setCamera( default_camera_ );
-
-  connect( fake_mouse_move_event_timer_, SIGNAL( timeout() ), this, SLOT( sendMouseMoveEvent() ));
-  fake_mouse_move_event_timer_->start( 33 /*milliseconds*/ );
 }
 
 void RenderPanel::sendMouseMoveEvent()

--- a/src/rviz/render_panel.h
+++ b/src/rviz/render_panel.h
@@ -147,10 +147,12 @@ protected:
   Display* display_;
 
 private Q_SLOTS:
+  //TODO(simonschmeisser) remove this in noetic
   void sendMouseMoveEvent();
   void onContextMenuHide();
 
 private:
+  //TODO(simonschmeisser) remove this in noetic
   QTimer* fake_mouse_move_event_timer_;
   Ogre::Camera* default_camera_; ///< A default camera created in initialize().
 };


### PR DESCRIPTION
This addresses #1175 

enable mouse tracking for render_panel

when mouseTracking is enabled for a QWidget it will get mouseMoveEvents even though no mouse button is pressed. This behavior was faked in rviz with a 30Hz timer.

This is currently preserving API/ABI but could just as well be non preserving and go to noetic only. I did not observe any positive or negative impact from this change, just cleaner code (eventually).