### PR TITLE
Fix compatibility with Ogre 1.10, 1.11, 1.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,12 @@ if(NOT OGRE_OV_FOUND)
   pkg_check_modules(OGRE_OV REQUIRED OGRE)
 endif(NOT OGRE_OV_FOUND)
 
+# TODO: adapt version for Noetic release
+# Disable deprecation warnings for OGRE >= 1.10
+if(NOT OGRE_OV_OGRE_VERSION VERSION_LESS "1.10.0")
+  add_compile_options(-Wno-deprecated-declarations)
+endif()
+
 ## Find OGRE Plugin path (not necessarily platform-independent, I guess)
 if(NOT DEFINED OGRE_PLUGIN_PATH)
   execute_process(COMMAND

--- a/ogre_media/fonts/liberation_sans.fontdef
+++ b/ogre_media/fonts/liberation_sans.fontdef
@@ -5,3 +5,12 @@ Liberation Sans
   size 18
   resolution 96
 }
+
+# Ogre >= 1.10 has changed the format
+font "Liberation Sans"
+{
+  type truetype
+  source liberation-sans/LiberationSans-Regular.ttf
+  size 18
+  resolution 96
+}

--- a/ogre_media/materials/glsl120/glsl120.program
+++ b/ogre_media/materials/glsl120/glsl120.program
@@ -1,8 +1,8 @@
 
 //includes:
-fragment_program rviz/glsl120/include/circle_impl.frag glsl { source include/circle_impl.frag }
-fragment_program rviz/glsl120/include/pack_depth.frag glsl { source include/pack_depth.frag }
-vertex_program rviz/glsl120/include/pass_depth.vert glsl { source include/pass_depth.vert }
+fragment_program rviz/glsl120/include/circle_impl.frag glsl { source circle_impl.frag }
+fragment_program rviz/glsl120/include/pack_depth.frag glsl { source pack_depth.frag }
+vertex_program rviz/glsl120/include/pass_depth.vert glsl { source pass_depth.vert }
 
 //all shaders, sorted by name
 

--- a/ogre_media/materials/glsl120/nogp/nogp.program
+++ b/ogre_media/materials/glsl120/nogp/nogp.program
@@ -4,7 +4,7 @@
 // and each one is offset according to its texture coords.
 
 //includes:
-vertex_program rviz/glsl120/nogp/pass_depth.vert glsl { source ../include/pass_depth.vert }
+vertex_program rviz/glsl120/nogp/pass_depth.vert glsl { source pass_depth.vert }
 
 vertex_program rviz/glsl120/nogp/billboard_tile.vert glsl
 {

--- a/src/image_view/image_view.cpp
+++ b/src/image_view/image_view.cpp
@@ -33,6 +33,7 @@
 
 #include "rviz/ogre_helpers/qt_ogre_render_window.h"
 #include "rviz/ogre_helpers/initialization.h"
+#include "rviz/ogre_helpers/compatibility.h"
 #include "rviz/image/ros_image_texture.h"
 
 #include "ros/ros.h"
@@ -114,7 +115,7 @@ void ImageView::showEvent( QShowEvent* event )
 
   Ogre::Rectangle2D* rect = new Ogre::Rectangle2D(true);
   rect->setCorners(-1.0f, 1.0f, 1.0f, -1.0f);
-  rect->setMaterial(material->getName());
+  setMaterial(*rect, material);
   rect->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY - 1);
   Ogre::AxisAlignedBox aabb;
   aabb.setInfinite();

--- a/src/python_bindings/sip/CMakeLists.txt
+++ b/src/python_bindings/sip/CMakeLists.txt
@@ -42,7 +42,12 @@ find_package(python_qt_binding REQUIRED)
 include(${python_qt_binding_EXTRAS_DIR}/sip_helper.cmake)
 
 # maintain context for different named target
-set(rviz_sip_INCLUDE_DIRS ${rviz_INCLUDE_DIRS} "${PROJECT_SOURCE_DIR}/src" ${catkin_INCLUDE_DIRS} $<TARGET_PROPERTY:rviz,EXPORT_HEADER_DIR>)
+set(rviz_sip_INCLUDE_DIRS
+  "${PROJECT_SOURCE_DIR}/src"
+  $<TARGET_PROPERTY:rviz,EXPORT_HEADER_DIR>
+  ${OGRE_OV_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+)
 set(rviz_sip_LIBRARIES ${rviz_LIBRARIES} ${PROJECT_NAME})
 set(rviz_sip_LIBRARY_DIRS ${rviz_LIBRARY_DIRS} ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION})
 if (MSVC)

--- a/src/rviz/default_plugin/camera_display.cpp
+++ b/src/rviz/default_plugin/camera_display.cpp
@@ -57,6 +57,7 @@
 #include "rviz/bit_allocator.h"
 #include "rviz/frame_manager.h"
 #include "rviz/ogre_helpers/axes.h"
+#include "rviz/ogre_helpers/compatibility.h"
 #include "rviz/properties/enum_property.h"
 #include "rviz/properties/float_property.h"
 #include "rviz/properties/int_property.h"
@@ -128,8 +129,8 @@ CameraDisplay::~CameraDisplay()
     delete bg_screen_rect_;
     delete fg_screen_rect_;
 
-    bg_scene_node_->getParentSceneNode()->removeAndDestroyChild( bg_scene_node_->getName() );
-    fg_scene_node_->getParentSceneNode()->removeAndDestroyChild( fg_scene_node_->getName() );
+    removeAndDestroyChildNode(bg_scene_node_->getParentSceneNode(), bg_scene_node_);
+    removeAndDestroyChildNode(fg_scene_node_->getParentSceneNode(), fg_scene_node_);
 
     context_->visibilityBits()->freeBits(vis_bit_);
   }
@@ -172,7 +173,7 @@ void CameraDisplay::onInitialize()
 
     bg_screen_rect_->setRenderQueueGroup(Ogre::RENDER_QUEUE_BACKGROUND);
     bg_screen_rect_->setBoundingBox(aabInf);
-    bg_screen_rect_->setMaterial(bg_material_->getName());
+    setMaterial(*bg_screen_rect_, bg_material_);
 
     bg_scene_node_->attachObject(bg_screen_rect_);
     bg_scene_node_->setVisible(false);
@@ -183,7 +184,7 @@ void CameraDisplay::onInitialize()
 
     fg_material_ = bg_material_->clone( ss.str()+"fg" );
     fg_screen_rect_->setBoundingBox(aabInf);
-    fg_screen_rect_->setMaterial(fg_material_->getName());
+    setMaterial(*fg_screen_rect_, fg_material_);
 
     fg_material_->setSceneBlending( Ogre::SBT_TRANSPARENT_ALPHA );
     fg_screen_rect_->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY - 1);

--- a/src/rviz/default_plugin/covariance_visual.cpp
+++ b/src/rviz/default_plugin/covariance_visual.cpp
@@ -267,17 +267,17 @@ CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::Sce
 CovarianceVisual::~CovarianceVisual()
 {
   delete position_shape_;
-  scene_manager_->destroySceneNode( position_node_->getName() );
+  scene_manager_->destroySceneNode( position_node_ );
 
   for(int i = 0; i < kNumOriShapes; i++)
   {
     delete orientation_shape_[i];
-    scene_manager_->destroySceneNode( orientation_offset_node_[i]->getName() );
+    scene_manager_->destroySceneNode( orientation_offset_node_[i] );
   }
 
-  scene_manager_->destroySceneNode( position_scale_node_->getName() );
-  scene_manager_->destroySceneNode( fixed_orientation_node_->getName() );
-  scene_manager_->destroySceneNode( root_node_->getName() );
+  scene_manager_->destroySceneNode( position_scale_node_ );
+  scene_manager_->destroySceneNode( fixed_orientation_node_ );
+  scene_manager_->destroySceneNode( root_node_ );
 }
 
 void CovarianceVisual::setCovariance( const geometry_msgs::PoseWithCovariance& pose )
@@ -587,9 +587,9 @@ void CovarianceVisual::setRotatingFrame( bool is_local_rotation )
   local_rotation_ = is_local_rotation;
 
   if(local_rotation_)
-    root_node_->addChild( fixed_orientation_node_->removeChild( orientation_root_node_->getName() ) );
+    root_node_->addChild( fixed_orientation_node_->removeChild( orientation_root_node_ ) );
   else
-    fixed_orientation_node_->addChild( root_node_->removeChild( orientation_root_node_->getName() ) );
+    fixed_orientation_node_->addChild( root_node_->removeChild( orientation_root_node_ ) );
 
 }
 

--- a/src/rviz/default_plugin/effort_visual.h
+++ b/src/rviz/default_plugin/effort_visual.h
@@ -3,11 +3,7 @@
 
 #include <sensor_msgs/JointState.h>
 
-namespace Ogre
-{
-    class Vector3;
-    class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace urdf
 {

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -58,6 +58,7 @@
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"
+#include "rviz/ogre_helpers/compatibility.h"
 #include "rviz/render_panel.h"
 #include "rviz/validate_floats.h"
 
@@ -123,7 +124,7 @@ void ImageDisplay::onInitialize()
     Ogre::AxisAlignedBox aabInf;
     aabInf.setInfinite();
     screen_rect_->setBoundingBox(aabInf);
-    screen_rect_->setMaterial(material_->getName());
+    setMaterial(*screen_rect_, material_);
     img_scene_node_->attachObject(screen_rect_);
   }
 
@@ -149,7 +150,7 @@ ImageDisplay::~ImageDisplay()
   {
     delete render_panel_;
     delete screen_rect_;
-    img_scene_node_->getParentSceneNode()->removeAndDestroyChild( img_scene_node_->getName() );
+    removeAndDestroyChildNode(img_scene_node_->getParentSceneNode(), img_scene_node_);
   }
 }
 

--- a/src/rviz/default_plugin/markers/marker_base.h
+++ b/src/rviz/default_plugin/markers/marker_base.h
@@ -39,13 +39,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-namespace Ogre
-{
-class SceneNode;
-class Vector3;
-class Quaternion;
-class Entity;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
@@ -77,7 +77,6 @@ void MeshResourceMarker::reset()
     Ogre::MaterialPtr material = *it;
     if (!material.isNull())
     {
-      material->unload();
       Ogre::MaterialManager::getSingleton().remove(material->getName());
     }
   }
@@ -131,7 +130,7 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
     
     // create a default material for any sub-entities which don't have their own.
     ss << "Material";
-    Ogre::MaterialPtr default_material = Ogre::MaterialManager::getSingleton().create(ss.str(), ROS_PACKAGE_NAME);
+    Ogre::MaterialPtr default_material = Ogre::MaterialManager::getSingleton().create(ss.str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     default_material->setReceiveShadows(false);
     default_material->getTechnique(0)->setLightingEnabled(true);
     default_material->getTechnique(0)->setAmbient(0.5, 0.5, 0.5);

--- a/src/rviz/default_plugin/markers/triangle_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.cpp
@@ -59,7 +59,6 @@ TriangleListMarker::~TriangleListMarker()
   if (manual_object_)
   {
     context_->getSceneManager()->destroyManualObject(manual_object_);
-    material_->unload();
     Ogre::MaterialManager::getSingleton().remove(material_->getName());
   }
 }
@@ -89,7 +88,7 @@ void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const M
 
     ss << "Material";
     material_name_ = ss.str();
-    material_ = Ogre::MaterialManager::getSingleton().create( material_name_, ROS_PACKAGE_NAME );
+    material_ = Ogre::MaterialManager::getSingleton().create( material_name_, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
     material_->setReceiveShadows(false);
     material_->getTechnique(0)->setLightingEnabled(true);
     material_->setCullingMode(Ogre::CULL_NONE);

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -456,7 +456,7 @@ void PathDisplay::processMessage( const nav_msgs::Path::ConstPtr& msg )
   {
   case LINES:
     manual_object->estimateVertexCount( num_points );
-    manual_object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP );
+    manual_object->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME );
     for( uint32_t i=0; i < num_points; ++i)
     {
       const geometry_msgs::Point& pos = msg->poses[ i ].pose.position;

--- a/src/rviz/default_plugin/point_visual.h
+++ b/src/rviz/default_plugin/point_visual.h
@@ -3,11 +3,7 @@
 
 #include <geometry_msgs/PointStamped.h>
 
-namespace Ogre
-{
-    class Vector3;
-    class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/polygon_display.cpp
+++ b/src/rviz/default_plugin/polygon_display.cpp
@@ -114,7 +114,7 @@ void PolygonDisplay::processMessage(const geometry_msgs::PolygonStamped::ConstPt
   if( num_points > 0 )
   {
     manual_object_->estimateVertexCount( num_points );
-    manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP );
+    manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_STRIP, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME );
     for( uint32_t i=0; i < num_points + 1; ++i )
     {
       const geometry_msgs::Point32& msg_point = msg->polygon.points[ i % num_points ];

--- a/src/rviz/default_plugin/pose_array_display.cpp
+++ b/src/rviz/default_plugin/pose_array_display.cpp
@@ -196,7 +196,7 @@ void PoseArrayDisplay::updateArrows2d()
   float length = arrow2d_length_property_->getFloat();
   size_t num_poses = poses_.size();
   manual_object_->estimateVertexCount( num_poses * 6 );
-  manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_LIST );
+  manual_object_->begin( "BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_LIST, Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME );
   for( size_t i=0; i < num_poses; ++i )
   {
     const Ogre::Vector3 & pos = poses_[i].position;

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -717,7 +717,7 @@ TFDisplay::M_FrameInfo::iterator TFDisplay::deleteFrame( M_FrameInfo::iterator i
   context_->getSelectionManager()->removeObject( frame->axes_coll_ );
   delete frame->parent_arrow_;
   delete frame->name_text_;
-  scene_manager_->destroySceneNode( frame->name_node_->getName() );
+  scene_manager_->destroySceneNode( frame->name_node_ );
   if( delete_properties )
   {
     delete frame->enabled_property_;

--- a/src/rviz/default_plugin/wrench_visual.h
+++ b/src/rviz/default_plugin/wrench_visual.h
@@ -3,11 +3,7 @@
 
 #include <geometry_msgs/Wrench.h>
 
-namespace Ogre
-{
-    class Vector3;
-    class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/geometry.h
+++ b/src/rviz/geometry.h
@@ -30,12 +30,7 @@
 #ifndef GEOMETRY_H
 #define GEOMETRY_H
 
-namespace Ogre
-{
-class Plane;
-class Vector3;
-class Vector2;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -377,7 +377,8 @@ void buildMesh( const aiScene* scene, const aiNode* node,
     }
     vbuf->unlock();
 
-    submesh->setMaterialName(material_table[input_mesh->mMaterialIndex]->getName());
+    Ogre::MaterialPtr const & material = material_table[input_mesh->mMaterialIndex];
+    submesh->setMaterialName(material->getName(), material->getGroup());
   }
 
   for (uint32_t i=0; i < node->mNumChildren; ++i)
@@ -452,7 +453,7 @@ void loadMaterials(const std::string& resource_path,
   {
     std::stringstream ss;
     ss << resource_path << "Material" << i;
-    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(ss.str(), ROS_PACKAGE_NAME, true);
+    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(ss.str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, true);
     material_table_out.push_back(mat);
 
     Ogre::Technique* tech = mat->getTechnique(0);
@@ -645,7 +646,7 @@ Ogre::MeshPtr meshFromAssimpScene(const std::string& name, const aiScene* scene)
   std::vector<Ogre::MaterialPtr> material_table;
   loadMaterials(name, scene, material_table);
 
-  Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(name, ROS_PACKAGE_NAME);
+  Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 
   Ogre::AxisAlignedBox aabb(Ogre::AxisAlignedBox::EXTENT_NULL);
   float radius = 0.0f;
@@ -697,7 +698,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path)
 
       Ogre::MeshSerializer ser;
       Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));
-      Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(resource_path, ROS_PACKAGE_NAME);
+      Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(resource_path, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
       ser.importMesh(stream, mesh.get());
 
       return mesh;

--- a/src/rviz/ogre_helpers/arrow.cpp
+++ b/src/rviz/ogre_helpers/arrow.cpp
@@ -65,7 +65,7 @@ Arrow::~Arrow()
   delete shaft_;
   delete head_;
 
-  scene_manager_->destroySceneNode( scene_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
 }
 
 void Arrow::set( float shaft_length, float shaft_diameter, float head_length, float head_diameter )

--- a/src/rviz/ogre_helpers/arrow.h
+++ b/src/rviz/ogre_helpers/arrow.h
@@ -32,15 +32,13 @@
 #ifndef OGRE_TOOLS_ARROW_H
 #define OGRE_TOOLS_ARROW_H
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class SceneNode;
-class Vector3;
-class Quaternion;
-class ColourValue;
 class Any;
 }
+
 
 namespace rviz
 {

--- a/src/rviz/ogre_helpers/axes.cpp
+++ b/src/rviz/ogre_helpers/axes.cpp
@@ -67,7 +67,7 @@ Axes::~Axes()
   delete y_axis_;
   delete z_axis_;
 
-  scene_manager_->destroySceneNode( scene_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
 }
 
 void Axes::set( float length, float radius, float alpha )

--- a/src/rviz/ogre_helpers/axes.h
+++ b/src/rviz/ogre_helpers/axes.h
@@ -38,14 +38,11 @@
 
 #include <vector>
 
+#include <OgrePrerequisites.h>
 #include <OgreColourValue.h>
 
 namespace Ogre
 {
-class SceneManager;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
 }
 

--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -84,7 +84,7 @@ BillboardLine::~BillboardLine()
     scene_manager_->destroyBillboardChain(*it);
   }
 
-  scene_manager_->destroySceneNode( scene_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
 
   Ogre::MaterialManager::getSingleton().remove(material_->getName());
 }
@@ -95,7 +95,7 @@ Ogre::BillboardChain* BillboardLine::createChain()
   static int count = 0;
   ss << "BillboardLine chain" << count++;
   Ogre::BillboardChain* chain = scene_manager_->createBillboardChain(ss.str());
-  chain->setMaterialName( material_->getName() );
+  chain->setMaterialName( material_->getName(), material_->getGroup() );
   scene_node_->attachObject( chain );
 
   chains_.push_back(chain);

--- a/src/rviz/ogre_helpers/compatibility.h
+++ b/src/rviz/ogre_helpers/compatibility.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018, Fizyr BV
+ * Copyright (c) 2019, Bielefeld University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OGRE_HELPERS_COMPATIBILITY_H
+#define OGRE_HELPERS_COMPATIBILITY_H
+
+#include "rviz/ogre_helpers/version_check.h"
+#include <OgreSimpleRenderable.h>
+
+#if OGRE_VERSION < OGRE_VERSION_CHECK(1,10,0)
+#include <OgreSceneManager.h>
+#else
+#include <OgreMaterialManager.h>
+#include <OgreSceneNode.h>
+#endif
+
+#include <string>
+
+namespace rviz {
+
+/* This header provides helper functions to maintain compatibility with Ogre versions 1.9 ... 1.12+.
+ *
+ * setMaterial() allows setting the material of a renderable by either name or MaterialPtr.
+ * OGRE 1.10 added:   renderable.setMaterial(const Ogre::MaterialPtr &)
+ * OGRE 1.11 removed: renderable.setMaterial(const std::string       &)
+ *
+ * removeAndDestroyChildNode(parent, child) allows removal of a SceneNode*.
+ * OGRE 1.10 added: SceneNode::removeAndDestroyChild(SceneNode* child)
+ */
+
+#if OGRE_VERSION < OGRE_VERSION_CHECK(1,10,0)
+inline void setMaterial(Ogre::SimpleRenderable & renderable, const std::string & material_name)
+{
+  renderable.setMaterial(material_name);
+}
+
+inline void setMaterial(Ogre::SimpleRenderable & renderable, const Ogre::MaterialPtr & material)
+{
+  renderable.setMaterial(material->getName());
+}
+#else
+inline void setMaterial(Ogre::SimpleRenderable & renderable, const std::string & material_name)
+{
+  Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().getByName(material_name);
+  // OGRE 1.11 also deprecated their own SharedPtr class and switched to std::shared_ptr.
+  // Checking for nullptr with .get() works in both versions.
+  if (!material.get())
+  {
+    OGRE_EXCEPT(Ogre::Exception::ERR_ITEM_NOT_FOUND, "Could not find material " + material_name, "SimpleRenderable::setMaterial");
+  }
+  renderable.setMaterial(material);
+}
+
+inline void setMaterial(Ogre::SimpleRenderable & renderable, const Ogre::MaterialPtr & material)
+{
+  renderable.setMaterial(material);
+}
+#endif
+
+#if OGRE_VERSION < OGRE_VERSION_CHECK(1,10,0)
+inline void removeAndDestroyChildNode(Ogre::SceneNode* parent, Ogre::SceneNode* child)
+{
+  child->removeAndDestroyAllChildren();
+  parent->removeChild(child);
+  child->getCreator()->destroySceneNode(child);
+}
+#else
+inline void removeAndDestroyChildNode(Ogre::SceneNode* parent, Ogre::SceneNode* child)
+{
+  parent->removeAndDestroyChild(child);
+}
+#endif
+}
+
+#endif

--- a/src/rviz/ogre_helpers/grid.cpp
+++ b/src/rviz/ogre_helpers/grid.cpp
@@ -80,10 +80,9 @@ Grid::~Grid()
 {
   delete billboard_line_;
 
-  scene_manager_->destroySceneNode( scene_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
   scene_manager_->destroyManualObject( manual_object_ );
-
-  material_->unload();
+  Ogre::MaterialManager::getSingleton().remove(material_->getName());
 }
 
 void Grid::setCellCount(uint32_t count)

--- a/src/rviz/ogre_helpers/line.cpp
+++ b/src/rviz/ogre_helpers/line.cpp
@@ -56,7 +56,7 @@ Line::Line( Ogre::SceneManager* manager, Ogre::SceneNode* parent_node )
 
   // NOTE: The second parameter to the create method is the resource group the material will be added to.
   // If the group you name does not exist (in your resources.cfg file) the library will assert() and your program will crash
-  manual_object_material_ = Ogre::MaterialManager::getSingleton().create(ss.str(),"rviz");
+  manual_object_material_ = Ogre::MaterialManager::getSingleton().create(ss.str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
   manual_object_material_->setReceiveShadows(false);
   manual_object_material_->getTechnique(0)->setLightingEnabled(true);
   manual_object_material_->getTechnique(0)->getPass(0)->setDiffuse(0,0,0,0);

--- a/src/rviz/ogre_helpers/line.h
+++ b/src/rviz/ogre_helpers/line.h
@@ -35,15 +35,11 @@
 #include <OgreSceneNode.h>
 #include <OgreMaterial.h>
 #include <OgreSharedPtr.h>
+#include <OgrePrerequisites.h>
 
 namespace Ogre
 {
-class SceneManager;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class ColourValue;
 }
 
 namespace rviz

--- a/src/rviz/ogre_helpers/mesh_shape.cpp
+++ b/src/rviz/ogre_helpers/mesh_shape.cpp
@@ -127,7 +127,7 @@ void MeshShape::endTriangles()
     entity_ = scene_manager_->createEntity(name);
     if (entity_)
     {
-      entity_->setMaterialName(material_name_);
+      entity_->setMaterial(material_);
       offset_node_->attachObject(entity_);
     }
     else

--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -95,36 +95,24 @@ MovableText::~MovableText()
 {
   if (mRenderOp.vertexData)
     delete mRenderOp.vertexData;
-  // May cause crashing... check this and comment if it does
-  if (!mpMaterial.isNull())
-    MaterialManager::getSingletonPtr()->remove(mpMaterial->getName());
+  MaterialManager::getSingletonPtr()->remove(mpMaterial->getName());
 }
 
 void MovableText::setFontName(const String &fontName)
 {
-  if ((Ogre::MaterialManager::getSingletonPtr()->resourceExists(mName + "Material")))
-  {
-    Ogre::MaterialManager::getSingleton().remove(mName + "Material");
-  }
-
   if (mFontName != fontName || mpMaterial.isNull() || !mpFont)
   {
     mFontName = fontName;
-    mpFont
-        = (Font *) FontManager::getSingleton().getByName(mFontName).getPointer();
+    mpFont = static_cast<Font*>(FontManager::getSingleton().getByName(mFontName, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME).get());
     if (!mpFont)
-      throw Exception(Exception::ERR_ITEM_NOT_FOUND, "Could not find font "
-          + fontName, "MovableText::setFontName");
+      throw Exception(Exception::ERR_ITEM_NOT_FOUND, "Could not find font " + fontName, "MovableText::setFontName");
 
     // to support non-ascii letters, setup the codepoint range before loading
     mpFont->addCodePointRange(std::make_pair<Ogre::Font::CodePoint>(0, 999));
     mpFont->load();
-    if (!mpMaterial.isNull())
-    {
-      MaterialManager::getSingletonPtr()->remove(mpMaterial->getName());
-      mpMaterial.setNull();
-    }
 
+    if (mpMaterial.get())
+      MaterialManager::getSingletonPtr()->remove(mpMaterial->getName());
     mpMaterial = mpFont->getMaterial()->clone(mName + "Material");
     if (!mpMaterial->isLoaded())
       mpMaterial->load();

--- a/src/rviz/ogre_helpers/movable_text.h
+++ b/src/rviz/ogre_helpers/movable_text.h
@@ -43,11 +43,9 @@
 #define OGRE_TOOLS_MOVABLE_TEXT_H
 
 #include <rviz/ogre_helpers/version_check.h>
+#include <OgrePrerequisites.h>
 #include <OgreMovableObject.h>
 #include <OgreRenderable.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreSharedPtr.h>
 
 
 namespace Ogre

--- a/src/rviz/ogre_helpers/object.h
+++ b/src/rviz/ogre_helpers/object.h
@@ -31,13 +31,10 @@
 #define OGRE_TOOLS_OBJECT_H
 
 #include "rviz/rviz_export.h"
+#include <OgrePrerequisites.h>
 
 namespace Ogre
 {
-class SceneManager;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
 }
 

--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -48,6 +48,7 @@
 
 #include "rviz/ogre_helpers/custom_parameter_indices.h"
 #include "rviz/selection/forwards.h"
+#include "rviz/ogre_helpers/compatibility.h"
 
 #define VERTEX_BUFFER_CAPACITY (36 * 1024 * 10)
 
@@ -177,13 +178,6 @@ static void removeMaterial(Ogre::MaterialPtr& material)
 PointCloud::~PointCloud()
 {
   clear();
-
-  point_material_->unload();
-  square_material_->unload();
-  flat_square_material_->unload();
-  sphere_material_->unload();
-  tile_material_->unload();
-  box_material_->unload();
 
   removeMaterial(point_material_);
   removeMaterial(square_material_);
@@ -337,7 +331,7 @@ void PointCloud::setRenderMode(RenderMode mode)
   V_PointCloudRenderable::iterator end = renderables_.end();
   for (; it != end; ++it)
   {
-    (*it)->setMaterial(current_material_->getName());
+    setMaterial(**it, current_material_);
   }
 
   regenerateAll();
@@ -765,7 +759,7 @@ void PointCloud::setPickColor(const Ogre::ColourValue& color)
 PointCloudRenderablePtr PointCloud::createRenderable( int num_points )
 {
   PointCloudRenderablePtr rend(new PointCloudRenderable(this, num_points, !current_mode_supports_geometry_shader_));
-  rend->setMaterial(current_material_->getName());
+  setMaterial(*rend, current_material_);
   Ogre::Vector4 size(width_, height_, depth_, 0.0f);
   Ogre::Vector4 alpha(alpha_, 0.0f, 0.0f, 0.0f);
   Ogre::Vector4 highlight(0.0f, 0.0f, 0.0f, 0.0f);

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -185,6 +185,9 @@ void RenderSystem::loadOgrePlugins()
   ogre_root_->loadPlugin( plugin_prefix + "RenderSystem_GL" );
   ogre_root_->loadPlugin( plugin_prefix + "Plugin_OctreeSceneManager" );
   ogre_root_->loadPlugin( plugin_prefix + "Plugin_ParticleFX" );
+#if OGRE_VERSION >= OGRE_VERSION_CHECK(1,11,0)
+  ogre_root_->loadPlugin( plugin_prefix + "Codec_FreeImage" );
+#endif
 }
 
 void RenderSystem::detectGlVersion()
@@ -283,25 +286,26 @@ void RenderSystem::setupRenderSystem()
 void RenderSystem::setupResources()
 {
   std::string rviz_path = ros::package::getPath(ROS_PACKAGE_NAME);
-  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media", "FileSystem", ROS_PACKAGE_NAME );
-  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/textures", "FileSystem", ROS_PACKAGE_NAME );
-  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/fonts", "FileSystem", ROS_PACKAGE_NAME );
-  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/models", "FileSystem", ROS_PACKAGE_NAME );
-  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials", "FileSystem", ROS_PACKAGE_NAME );
-  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/scripts", "FileSystem", ROS_PACKAGE_NAME );
-  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl120", "FileSystem", ROS_PACKAGE_NAME );
-  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl120/nogp", "FileSystem", ROS_PACKAGE_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/textures", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/fonts", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, true );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/models", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/scripts", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl120", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl120/nogp", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+  Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl120/include", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
   // Add resources that depend on a specific glsl version.
   // Unfortunately, Ogre doesn't have a notion of glsl versions so we can't go
   // the 'official' way of defining multiple schemes per material and let Ogre decide which one to use.
   if ( getGlslVersion() >= 150  )
   {
-    Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl150", "FileSystem", ROS_PACKAGE_NAME );
-    Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/scripts150", "FileSystem", ROS_PACKAGE_NAME );
+    Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/glsl150", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
+    Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/scripts150", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
   }
   else if ( getGlslVersion() >= 120  )
   {
-    Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/scripts120", "FileSystem", ROS_PACKAGE_NAME );
+    Ogre::ResourceGroupManager::getSingleton().addResourceLocation( rviz_path + "/ogre_media/materials/scripts120", "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
   }
   else
   {
@@ -327,13 +331,13 @@ void RenderSystem::setupResources()
       {
         path = iter->substr( pos1, pos2 - pos1 );
         ROS_DEBUG("adding resource location: '%s'\n", path.c_str());
-        Ogre::ResourceGroupManager::getSingleton().addResourceLocation( path, "FileSystem", ROS_PACKAGE_NAME );
+        Ogre::ResourceGroupManager::getSingleton().addResourceLocation( path, "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
         pos1 = pos2 + 1;
         pos2 = iter->find( delim, pos2 + 1 );
       }
       path = iter->substr( pos1, iter->size() - pos1 );
       ROS_DEBUG("adding resource location: '%s'\n", path.c_str());
-      Ogre::ResourceGroupManager::getSingleton().addResourceLocation( path, "FileSystem", ROS_PACKAGE_NAME );
+      Ogre::ResourceGroupManager::getSingleton().addResourceLocation( path, "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
     }
   }
 }

--- a/src/rviz/ogre_helpers/render_widget.cpp
+++ b/src/rviz/ogre_helpers/render_widget.cpp
@@ -130,6 +130,7 @@ void RenderWidget::resizeEvent(QResizeEvent *e)
      * So here we just always force it to be even. */
     const int w = width() * pixel_ratio_;
     render_window_->resize(w + (w % 2), height() * pixel_ratio_);
+    render_window_->windowMovedOrResized();
   }
 }
 

--- a/src/rviz/ogre_helpers/shape.cpp
+++ b/src/rviz/ogre_helpers/shape.cpp
@@ -97,13 +97,13 @@ Shape::Shape( Type type, Ogre::SceneManager* scene_manager, Ogre::SceneNode* par
 
   ss << "Material";
   material_name_ = ss.str();
-  material_ = Ogre::MaterialManager::getSingleton().create( material_name_, ROS_PACKAGE_NAME );
+  material_ = Ogre::MaterialManager::getSingleton().create( material_name_, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
   material_->setReceiveShadows(false);
   material_->getTechnique(0)->setLightingEnabled(true);
   material_->getTechnique(0)->setAmbient( 0.5, 0.5, 0.5 );
 
   if (entity_)
-    entity_->setMaterialName(material_name_);
+    entity_->setMaterial(material_);
 
 #if OGRE_VERSION < OGRE_VERSION_CHECK(1,5,0)
   if (entity_)
@@ -113,13 +113,12 @@ Shape::Shape( Type type, Ogre::SceneManager* scene_manager, Ogre::SceneNode* par
 
 Shape::~Shape()
 {
-  scene_manager_->destroySceneNode( scene_node_->getName() );
-  scene_manager_->destroySceneNode( offset_node_->getName() );
+  scene_manager_->destroySceneNode( scene_node_ );
+  scene_manager_->destroySceneNode( offset_node_ );
 
   if (entity_)
     scene_manager_->destroyEntity( entity_ );
 
-  material_->unload();
   Ogre::MaterialManager::getSingleton().remove(material_->getName());
 }
 

--- a/src/rviz/robot/link_updater.h
+++ b/src/rviz/robot/link_updater.h
@@ -33,11 +33,7 @@
 #include <string>
 #include "rviz/properties/status_property.h"
 
-namespace Ogre
-{
-class Vector3;
-class Quaternion;
-}
+#include <OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -120,9 +120,9 @@ Robot::~Robot()
 {
   clear();
 
-  scene_manager_->destroySceneNode( root_visual_node_->getName() );
-  scene_manager_->destroySceneNode( root_collision_node_->getName() );
-  scene_manager_->destroySceneNode( root_other_node_->getName() );
+  scene_manager_->destroySceneNode( root_visual_node_ );
+  scene_manager_->destroySceneNode( root_collision_node_ );
+  scene_manager_->destroySceneNode( root_other_node_ );
   delete link_factory_;
 }
 

--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -41,16 +41,11 @@
 
 #include <urdf/model.h> // can be replaced later by urdf_model/types.h
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class Entity;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class RibbonTrail;
-class SceneNode;
 }
 
 namespace rviz

--- a/src/rviz/robot/robot_joint.h
+++ b/src/rviz/robot/robot_joint.h
@@ -48,16 +48,11 @@
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class Entity;
-class SubEntity;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class RibbonTrail;
 }
 
 namespace rviz

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -65,10 +65,6 @@
 
 namespace fs=boost::filesystem;
 
-#ifndef ROS_PACKAGE_NAME
-# define ROS_PACKAGE_NAME "rviz"
-#endif
-
 namespace rviz
 {
 
@@ -206,7 +202,7 @@ RobotLink::RobotLink( Robot* robot,
   collision_node_ = robot_->getCollisionNode()->createChildSceneNode();
 
   // create material for coloring links
-  color_material_ = Ogre::MaterialPtr(new Ogre::Material(nullptr, "robot link color material", 0, ROS_PACKAGE_NAME));
+  color_material_ = Ogre::MaterialPtr(new Ogre::Material(nullptr, "robot link color material", 0, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME));
   color_material_->setReceiveShadows(false);
   color_material_->getTechnique(0)->setLightingEnabled(true);
 
@@ -440,7 +436,7 @@ void RobotLink::updateVisibility()
 
 Ogre::MaterialPtr RobotLink::getMaterialForLink( const urdf::LinkConstSharedPtr& link, urdf::MaterialConstSharedPtr material )
 {
-  Ogre::MaterialPtr mat = Ogre::MaterialPtr(new Ogre::Material(nullptr, "robot link material", 0, ROS_PACKAGE_NAME));
+  Ogre::MaterialPtr mat = Ogre::MaterialPtr(new Ogre::Material(nullptr, "robot link material", 0, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME));
 
   // only the first visual's material actually comprises color values, all others only have the name
   // hence search for the first visual with given material name (better fix the bug in urdf parser)
@@ -635,7 +631,7 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
       else
       {
           // create a new material copy for each instance of a RobotLink
-          Ogre::MaterialPtr mat = Ogre::MaterialPtr(new Ogre::Material(nullptr, material_name, 0, ROS_PACKAGE_NAME));
+          Ogre::MaterialPtr mat = Ogre::MaterialPtr(new Ogre::Material(nullptr, material_name, 0, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME));
           *mat = *sub->getMaterial();
           sub->setMaterial(mat);
       }
@@ -862,11 +858,11 @@ void RobotLink::setToErrorMaterial()
 {
   for( size_t i = 0; i < visual_meshes_.size(); i++ )
   {
-    visual_meshes_[ i ]->setMaterialName("BaseWhiteNoLighting");
+    visual_meshes_[ i ]->setMaterialName("BaseWhiteNoLighting", Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
   }
   for( size_t i = 0; i < collision_meshes_.size(); i++ )
   {
-    collision_meshes_[ i ]->setMaterialName("BaseWhiteNoLighting");
+    collision_meshes_[ i ]->setMaterialName("BaseWhiteNoLighting", Ogre::ResourceGroupManager::INTERNAL_RESOURCE_GROUP_NAME);
   }
 }
 

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -49,16 +49,11 @@
 #include "rviz/ogre_helpers/object.h"
 #include "rviz/selection/forwards.h"
 
+#include <OgrePrerequisites.h>
+
 namespace Ogre
 {
-class SceneManager;
-class Entity;
-class SubEntity;
-class SceneNode;
-class Vector3;
-class Quaternion;
 class Any;
-class RibbonTrail;
 }
 
 namespace rviz

--- a/src/rviz/selection/selection_handler.cpp
+++ b/src/rviz/selection/selection_handler.cpp
@@ -42,6 +42,7 @@
 #include <OgreSubEntity.h>
 
 #include "rviz/selection/selection_manager.h"
+#include "rviz/ogre_helpers/compatibility.h"
 
 namespace rviz
 {
@@ -198,7 +199,7 @@ void SelectionHandler::createBox(const std::pair<CollObjectHandle, uint64_t>& ha
     box = it->second.second;
   }
 
-  box->setMaterial(material_name);
+  setMaterial(*box, material_name);
 
   box->setupBoundingBox(aabb);
   node->detachAllObjects();
@@ -214,10 +215,9 @@ void SelectionHandler::destroyBox(const std::pair<CollObjectHandle, uint64_t>& h
     Ogre::WireBoundingBox* box = it->second.second;
 
     node->detachAllObjects();
-    node->getParentSceneNode()->removeAndDestroyChild(node->getName());
+    removeAndDestroyChildNode(node->getParentSceneNode(), node);
 
     delete box;
-
     boxes_.erase(it);
   }
 }

--- a/src/rviz/selection/selection_manager.cpp
+++ b/src/rviz/selection/selection_manager.cpp
@@ -59,6 +59,7 @@
 #include "rviz/ogre_helpers/arrow.h"
 #include "rviz/ogre_helpers/axes.h"
 #include "rviz/ogre_helpers/custom_parameter_indices.h"
+#include "rviz/ogre_helpers/compatibility.h"
 #include "rviz/ogre_helpers/qt_ogre_render_window.h"
 #include "rviz/ogre_helpers/shape.h"
 #include "rviz/properties/property.h"
@@ -100,7 +101,7 @@ SelectionManager::~SelectionManager()
 
   setSelection(M_Picked());
 
-  highlight_node_->getParentSceneNode()->removeAndDestroyChild(highlight_node_->getName());
+  removeAndDestroyChildNode(highlight_node_->getParentSceneNode(), highlight_node_);
   delete highlight_rectangle_;
 
   for (uint32_t i = 0; i < s_num_render_textures_; ++i)
@@ -142,7 +143,7 @@ void SelectionManager::initialize()
   Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().create(ss.str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
   material->setLightingEnabled(false);
   //material->getTechnique(0)->getPass(0)->setPolygonMode(Ogre::PM_WIREFRAME);
-  highlight_rectangle_->setMaterial(material->getName());
+  setMaterial(*highlight_rectangle_, material);
   Ogre::AxisAlignedBox aabInf;
   aabInf.setInfinite();
   highlight_rectangle_->setBoundingBox(aabInf);

--- a/src/rviz/view_controller.h
+++ b/src/rviz/view_controller.h
@@ -34,18 +34,12 @@
 
 #include <QCursor>
 
+#include <OgrePrerequisites.h>
+
 #include "rviz/properties/property.h"
 #include "rviz/rviz_export.h"
 
 class QKeyEvent;
-
-namespace Ogre
-{
-class Camera;
-class SceneNode;
-class Vector3;
-class Quaternion;
-}
 
 namespace rviz
 {

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -302,7 +302,7 @@ void VisualizationManager::stopUpdate()
 
 void createColorMaterial(const std::string& name, const Ogre::ColourValue& color, bool use_self_illumination)
 {
-  Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create( name, ROS_PACKAGE_NAME );
+  Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create( name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME );
   mat->setAmbient(color * 0.5f);
   mat->setDiffuse(color);
   if( use_self_illumination )


### PR DESCRIPTION
This is a cleanup of #1242. Most work was already done by @de-vri-es, but some issues were remaining. The main API changes in Ogre are:
* The removal of `SimpleRenderable::setMaterial(const std::string & name)`.
* A _strict_ group handling in resource manager, which avoids searching resources in all available groups. Additionally, methods like `resourceExists(const std::string & name)` and `remove(const std::string & name)` expect the _correct_ group name now (but allow for a default).
To maintain compatibility with Ogre 1.9, which misses those group arguments, I had to push all resources into the default group.

Further, this PR:
* adds a cross-version compatibility function for setting materials on a `SimpleRenderable`
* loads the `freeimage` codec plugin, required to load images (and textures)
* avoids the use of relative paths in shader programs because they break in Ogre 1.11
* prevents removing anonymous scene nodes by name
* Uses OgrePrequisites.h to avoid conflict of class-forward vs. typedef for `Ogre::Vector3`
* recursively adds `ogre_media/fonts` as a resource location

As this is a huge PR with several potential side effects, it is only targeted for Noetic, but I successfully ran `marker_test`, `mesh_marker_test` and tested selection.

For compatibility with Ogre 1.9, we need to rely on now deprecated Ogre API (essentially Ogre's `SharedPtr` was replaced by `std::shared_ptr`), which is why I disabled corresponding warnings.
If a newer Ogre version is (hopefully) released into Ubuntu 20.04, this needs to be cleaned further.