### PR TITLE
fix yaml-cpp not found on macOS (catalina)

### DIFF
--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -144,7 +144,7 @@ target_link_libraries(${PROJECT_NAME}
   ${TinyXML2_LIBRARIES}
   ${X11_X11_LIB}
   ${ASSIMP_LIBRARIES}
-  ${yaml-cpp_LIBRARIES}
+  ${YAML_CPP_LIBRARIES}
 )
 
 

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -1,4 +1,8 @@
-pkg_check_modules(YAMLCPP REQUIRED yaml-cpp>=0.5)
+if(APPLE)
+  find_package(yaml-cpp REQUIRED)
+else()
+  pkg_check_modules(YAMLCPP REQUIRED yaml-cpp>=0.5)
+endif()
 
 if(UNIX AND NOT APPLE)
   find_package(X11 REQUIRED)
@@ -145,6 +149,7 @@ target_link_libraries(${PROJECT_NAME}
   ${X11_X11_LIB}
   ${ASSIMP_LIBRARIES}
   ${YAMLCPP_LIBRARIES}
+  ${yaml-cpp_LIBRARIES}
 )
 
 

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(APPLE)
-  find_package(yaml-cpp REQUIRED)
-else()
-  pkg_check_modules(YAMLCPP REQUIRED yaml-cpp>=0.5)
-endif()
+find_package(yaml-cpp REQUIRED)
 
 if(UNIX AND NOT APPLE)
   find_package(X11 REQUIRED)
@@ -148,7 +144,6 @@ target_link_libraries(${PROJECT_NAME}
   ${TinyXML2_LIBRARIES}
   ${X11_X11_LIB}
   ${ASSIMP_LIBRARIES}
-  ${YAMLCPP_LIBRARIES}
   ${yaml-cpp_LIBRARIES}
 )
 


### PR DESCRIPTION
This fixes the issue : 
```
ld: library not found for -lyaml-cpp
clang: error: linker command failed with exit code 1 (use -v to see invocation)
````
### Description

pkg config **succeeds** in finding yaml but linker fails on macOS (tested on catalina)
Now on newer version of yamlcpp, the cmake config is installed.