### PR TITLE
assimp importer: repair invalid normals

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -706,7 +706,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path)
     {
       Assimp::Importer importer;
       importer.SetIOHandler(new ResourceIOSystem());
-      const aiScene* scene = importer.ReadFile(resource_path, aiProcess_SortByPType|aiProcess_GenNormals|aiProcess_Triangulate|aiProcess_GenUVCoords|aiProcess_FlipUVs);
+      const aiScene* scene = importer.ReadFile(resource_path, aiProcess_SortByPType|aiProcess_FindInvalidData|aiProcess_GenNormals|aiProcess_Triangulate|aiProcess_GenUVCoords|aiProcess_FlipUVs);
       if (!scene)
       {
         ROS_ERROR("Could not load resource [%s]: %s", resource_path.c_str(), importer.GetErrorString());


### PR DESCRIPTION
Fixes #1451. Some mesh exporters generate zero normals, which results in black visualizations.
Assimp's postprocess option [FindInvalidData](http://assimp.sourceforge.net/lib_html/postprocess_8h.html#a64795260b95f5a4b3f3dc1be4f52e410a42a93fc16a7a3b6df509bab503945421) allows to find and remove this invalid data. Subsequently the data is correctly re-generated by another assimp post-processor.
