### PR TITLE
Add display: Add button to append topic name after display name

### DIFF
--- a/src/rviz/add_display_dialog.cpp
+++ b/src/rviz/add_display_dialog.cpp
@@ -170,6 +170,7 @@ AddDisplayDialog::AddDisplayDialog( DisplayFactory* factory,
                                     const QStringList& disallowed_class_lookup_names,
                                     QString* lookup_name_output,
                                     QString* display_name_output,
+                                    bool* append_topic_name_output,
                                     QString* topic_output,
                                     QString* datatype_output,
                                     QWidget* parent )
@@ -179,6 +180,7 @@ AddDisplayDialog::AddDisplayDialog( DisplayFactory* factory,
 , disallowed_class_lookup_names_( disallowed_class_lookup_names )
 , lookup_name_output_( lookup_name_output )
 , display_name_output_( display_name_output )
+, append_topic_name_output_( append_topic_name_output )
 , topic_output_( topic_output )
 , datatype_output_( datatype_output )
 {
@@ -215,8 +217,11 @@ AddDisplayDialog::AddDisplayDialog( DisplayFactory* factory,
   {
     name_box = new QGroupBox( "Display Name" );
     name_editor_ = new QLineEdit;
+    append_topic_name_ = new QCheckBox( "Append topic name after display name" );
+    append_topic_name_->setToolTip( "Display name won't be renamed if the topic is changed!" );
     QVBoxLayout* name_layout = new QVBoxLayout;
     name_layout->addWidget( name_editor_ );
+    name_layout->addWidget( append_topic_name_ );
     name_box->setLayout( name_layout );
   }
 
@@ -352,9 +357,10 @@ void AddDisplayDialog::accept()
   if( isValid() )
   {
     *lookup_name_output_ = lookup_name_;
-    if( display_name_output_ )
+    if( display_name_output_ && append_topic_name_output_)
     {
       *display_name_output_ = name_editor_->text();
+      *append_topic_name_output_ = append_topic_name_->isChecked();
     }
     QDialog::accept();
   }

--- a/src/rviz/add_display_dialog.h
+++ b/src/rviz/add_display_dialog.h
@@ -86,6 +86,7 @@ public:
                     const QStringList& disallowed_class_lookup_names,
                     QString* lookup_name_output,
                     QString* display_name_output = 0,
+                    bool* append_topic_name_output = 0,
                     QString* topic_output = 0,
                     QString* datatype_output = 0,
                     QWidget* parent = 0 );
@@ -122,6 +123,7 @@ private:
 
   QString* lookup_name_output_;
   QString* display_name_output_;
+  bool *append_topic_name_output_;
   QString* topic_output_;
   QString* datatype_output_;
 
@@ -140,6 +142,7 @@ private:
   QTextBrowser* description_;
 
   QLineEdit* name_editor_;
+  QCheckBox* append_topic_name_;
 
   /** Widget with OK and CANCEL buttons. */
   QDialogButtonBox* button_box_;

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -105,6 +105,7 @@ void DisplaysPanel::onNewDisplay()
 {
   QString lookup_name;
   QString display_name;
+  bool append_topic_name;
   QString topic;
   QString datatype;
 
@@ -116,6 +117,7 @@ void DisplaysPanel::onNewDisplay()
                                                    empty, empty,
                                                    &lookup_name,
                                                    &display_name,
+                                                   &append_topic_name,
                                                    &topic,
                                                    &datatype );
   QApplication::restoreOverrideCursor();
@@ -123,7 +125,11 @@ void DisplaysPanel::onNewDisplay()
   vis_manager_->stopUpdate();
   if( dialog->exec() == QDialog::Accepted )
   {
-    Display *disp = vis_manager_->createDisplay( lookup_name, display_name, true );
+    Display *disp;
+    if ( append_topic_name  && !topic.isEmpty() )
+      disp = vis_manager_->createDisplay( lookup_name, display_name + " - " + topic, true );
+    else
+      disp = vis_manager_->createDisplay( lookup_name, display_name, true );
     if ( !topic.isEmpty() && !datatype.isEmpty() )
     {
       disp->setTopic( topic, datatype );


### PR DESCRIPTION
## Add display widget before modifications

![Screenshot_20191216_162629](https://user-images.githubusercontent.com/5566160/70919255-d7d00d00-2020-11ea-9aca-19d390c0906b.png)

### Description

I have added a button (bottom of the widget) when adding a display type. This button (when checked) appends the name of the topic after the name of the display.

![Screenshot_20191216_161708](https://user-images.githubusercontent.com/5566160/70919040-66905a00-2020-11ea-85c3-d431a478209f.png)

![Screenshot_20191216_161726](https://user-images.githubusercontent.com/5566160/70919039-66905a00-2020-11ea-9d9b-3764e85610a8.png)

This allows to easily get the topic name in the display name:

![Screenshot_20191216_162110](https://user-images.githubusercontent.com/5566160/70919036-66905a00-2020-11ea-86b7-fab821e69bab.png)

The display name will not be updated if the topic changes and the user is warned about that in the tooltip:
![Screenshot_20191216_161743](https://user-images.githubusercontent.com/5566160/70919038-66905a00-2020-11ea-8c9c-a7b58ad20229.png)

This feature is meant to be an easy way to add the topic name without having to type it; not a way to automatically display the topic name in a display widget. It is very useful to me when adding a lot of image topics; it saves a lot of typing.

### Checklist

- [x] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [ ] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
