### PR TITLE
Fix for material_name = "" bug

### DIFF
--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -628,7 +628,7 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
       Ogre::SubEntity* sub = entity->getSubEntity(i);
       const std::string& material_name = sub->getMaterialName();
 
-      if (material_name == "BaseWhite" || material_name == "BaseWhiteNoLighting")
+      if (material_name == "BaseWhite" || material_name == "BaseWhiteNoLighting" || material_name.empty())
       {
         sub->setMaterial(default_material_);
       }


### PR DESCRIPTION
Found this while debugging mesh loading - if the material name is empty, a segfault happened. This also defaults to the default material.