### PR TITLE
Catch exceptions when creating publishers in tools

### DIFF
--- a/src/rviz/default_plugin/tools/goal_tool.cpp
+++ b/src/rviz/default_plugin/tools/goal_tool.cpp
@@ -57,7 +57,11 @@ void GoalTool::onInitialize()
 
 void GoalTool::updateTopic()
 {
-  pub_ = nh_.advertise<geometry_msgs::PoseStamped>( topic_property_->getStdString(), 1 );
+  try {
+    pub_ = nh_.advertise<geometry_msgs::PoseStamped>( topic_property_->getStdString(), 1 );
+  } catch (const ros::Exception& e) {
+    ROS_ERROR_STREAM_NAMED("GoalTool", e.what());
+  }
 }
 
 void GoalTool::onPoseSet(double x, double y, double theta)

--- a/src/rviz/default_plugin/tools/initial_pose_tool.cpp
+++ b/src/rviz/default_plugin/tools/initial_pose_tool.cpp
@@ -64,7 +64,11 @@ void InitialPoseTool::onInitialize()
 
 void InitialPoseTool::updateTopic()
 {
-  pub_ = nh_.advertise<geometry_msgs::PoseWithCovarianceStamped>( topic_property_->getStdString(), 1 );
+  try {
+    pub_ = nh_.advertise<geometry_msgs::PoseWithCovarianceStamped>( topic_property_->getStdString(), 1 );
+  } catch (const ros::Exception& e) {
+    ROS_ERROR_STREAM_NAMED("InitialPoseTool", e.what());
+  }
 }
 
 void InitialPoseTool::onPoseSet(double x, double y, double theta)

--- a/src/rviz/default_plugin/tools/point_tool.cpp
+++ b/src/rviz/default_plugin/tools/point_tool.cpp
@@ -85,7 +85,11 @@ void PointTool::deactivate()
 
 void PointTool::updateTopic()
 {
-  pub_ = nh_.advertise<geometry_msgs::PointStamped>( topic_property_->getStdString(), 1 );
+  try {
+    pub_ = nh_.advertise<geometry_msgs::PointStamped>( topic_property_->getStdString(), 1 );
+  } catch (const ros::Exception& e) {
+    ROS_ERROR_STREAM_NAMED("PointTool", e.what());
+  }
 }
 
 void PointTool::updateAutoDeactivate()


### PR DESCRIPTION
Fix #1466: An invalid ros topic name caused rviz to crash due to the uncaught exception.