### PR TITLE
always forward keystrokes in display view to property editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ catkin_package(
     roslib
     sensor_msgs
     std_msgs
+    std_srvs
     tf
     urdf
     visualization_msgs

--- a/src/rviz/properties/property_tree_widget.cpp
+++ b/src/rviz/properties/property_tree_widget.cpp
@@ -41,6 +41,21 @@
 namespace rviz
 {
 
+PropertySelectionModel::PropertySelectionModel(QAbstractItemModel* model)
+  : QItemSelectionModel(model)
+{}
+
+void PropertySelectionModel::setCurrentIndex(const QModelIndex &index, QItemSelectionModel::SelectionFlags command){
+  QModelIndex property_index = index.sibling(index.row(), 1);
+  if( index.flags() & Qt::ItemIsEditable || !property_index.isValid()) {
+    QItemSelectionModel::setCurrentIndex(index, command);
+  }
+  else
+  {
+    QItemSelectionModel::setCurrentIndex(property_index, command);
+  }
+}
+
 PropertyTreeWidget::PropertyTreeWidget( QWidget* parent )
   : QTreeView( parent )
   , model_( NULL )
@@ -53,6 +68,7 @@ PropertyTreeWidget::PropertyTreeWidget( QWidget* parent )
   setDragEnabled( true );
   setAcceptDrops( true );
   setAnimated( true );
+  setAllColumnsShowFocus( true );
   setSelectionMode( QAbstractItemView::ExtendedSelection );
   setEditTriggers( QAbstractItemView::AllEditTriggers );
   setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
@@ -87,6 +103,9 @@ void PropertyTreeWidget::setModel( PropertyTreeModel* model )
   }
   model_ = model;
   QTreeView::setModel( model_ );
+  QItemSelectionModel *m = selectionModel();
+  setSelectionModel( new PropertySelectionModel( model_ ) );
+  m->deleteLater();
   if( model_ )
   {
     connect( model_, SIGNAL( propertyHiddenChanged( const Property* )),

--- a/src/rviz/properties/property_tree_widget.h
+++ b/src/rviz/properties/property_tree_widget.h
@@ -41,9 +41,9 @@ namespace rviz
 class Property;
 class SplitterHandle;
 
-/* Custom selection model for property tree
-   always focus right column when selecting a row
-	to make sure keystrokes are forwarded there */
+/** Custom selection model for PropertyTreeWidget to always focus right column
+
+	... to make sure keystrokes are forwarded there. */
 class RVIZ_EXPORT PropertySelectionModel : public QItemSelectionModel
 {
 Q_OBJECT

--- a/src/rviz/properties/property_tree_widget.h
+++ b/src/rviz/properties/property_tree_widget.h
@@ -41,6 +41,18 @@ namespace rviz
 class Property;
 class SplitterHandle;
 
+/* Custom selection model for property tree
+   always focus right column when selecting a row
+	to make sure keystrokes are forwarded there */
+class RVIZ_EXPORT PropertySelectionModel : public QItemSelectionModel
+{
+Q_OBJECT
+public:
+  PropertySelectionModel(QAbstractItemModel* model = 0);
+
+  void setCurrentIndex(const QModelIndex &index, QItemSelectionModel::SelectionFlags command);
+};
+
 class RVIZ_EXPORT PropertyTreeWidget: public QTreeView
 {
 Q_OBJECT


### PR DESCRIPTION
Current behavior without this patch:
- Open RViz with any display added
- click on the right column in the display view, in the same row as the checkbox to enable/disable the display
=> pressing spacebar can toggle the checkbox
- click on the left column of the same row (the name of the display)
=> pressing spacebar has no effect

Additionally, a visible indicator of the current focus (not the current selection)
highlights the corresponding cell.

This patch modifies selection requests to always focus the right column (if available)
and achieve the first behavior consistently.

This allows to go through a long list of displays by keyboard and toggle them with spacebar.