### PR TITLE
noetic release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11.2)
+cmake_minimum_required(VERSION 3.0.2)
 project(rviz)
 
 if (POLICY CMP0042)
@@ -94,7 +94,7 @@ endif(NOT DEFINED OGRE_OV_LIBRARIES_ABS)
 if(APPLE)
   FIND_LIBRARY(Cocoa_LIBRARIES Cocoa)
   set(rviz_ADDITIONAL_LIBRARIES ${Cocoa_LIBRARIES})
-  
+
   # This definition prevents an Apple header from defining a macro called "check", which if
   # present, collides with another function in the rviz code. See:
   # https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/AssertMacros.h

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
-  Use setuptools instead of distutils 

Since ros/catkin#1048 catkin prefers to use setuptools instead of distutils. The package.xml doesn't need to include python3-setuptools because [catkin exports that dependency](https://github.com/ros/catkin/blob/86439ec5d2010d5c47c30b815aa97e525037930f/package.xml#L32) for the convenience of all downstream python packages.

-  Bump CMake version to avoid CMP0048

This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.