### PR TITLE
switch libogre-dev to build_depend

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>libogre-dev</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>libqt5-opengl-dev</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
@@ -30,7 +31,7 @@
   <depend>image_transport</depend>
   <depend>interactive_markers</depend>
   <depend>laser_geometry</depend>
-  <depend>libogre-dev</depend>
+  <depend>libogre</depend>
   <depend>map_msgs</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>


### PR DESCRIPTION
this removes the runtime dependency on libogre-dev and therefore simplifies working with multiple ogre versions installed (once they make it into Debian/Ubuntu ...). It also reduces installation size by a few kb