### PR TITLE
fix: + include yaml cpp include directory

### DIFF
--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -1,5 +1,7 @@
 find_package(yaml-cpp REQUIRED)
 
+include_directories(${YAML_CPP_INCLUDE_DIR})
+
 if(UNIX AND NOT APPLE)
   find_package(X11 REQUIRED)
 endif()

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(yaml-cpp REQUIRED)
 
-include_directories(${YAML_CPP_INCLUDE_DIR})
+include_directories(SYSTEM ${YAML_CPP_INCLUDE_DIR})
 
 if(UNIX AND NOT APPLE)
   find_package(X11 REQUIRED)


### PR DESCRIPTION
### Description

Added missing cmake command to include yaml-cpp include directory. My source build requires this include to complete correctly with yaml-cpp 0.6.2.

### Checklist

None apply