### PR TITLE
Build depends

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>libogre-dev</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>libqt5-opengl-dev</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
@@ -30,7 +31,7 @@
   <depend>image_transport</depend>
   <depend>interactive_markers</depend>
   <depend>laser_geometry</depend>
-  <depend>libogre-dev</depend>
+  <depend>libogre</depend>
   <depend>map_msgs</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,8 @@
   <build_depend>liburdfdom-dev</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
 
+  <build_export_depend>libogre-dev</build_export_depend>
+
   <depend>assimp-dev</depend>
   <depend>geometry_msgs</depend>
   <depend>image_transport</depend>


### PR DESCRIPTION
This is a fixup of #1482 that unfortunately had to be reverted, it now also sets `build_export_depend`

Should ideally also be backported to melodic-devel

side-note: ogre-1.12.4 is now in Debian sid and there is still hope and an open request to get it into Ubuntu 20.04