### PR TITLE
MeasureTool: hide measure line when deactivating the tool

### DIFF
--- a/src/rviz/default_plugin/tools/measure_tool.cpp
+++ b/src/rviz/default_plugin/tools/measure_tool.cpp
@@ -74,6 +74,7 @@ void MeasureTool::activate()
 
 void MeasureTool::deactivate()
 {
+  line_->setVisible(false);
 }
 
 int MeasureTool::processMouseEvent( ViewportMouseEvent& event )


### PR DESCRIPTION
Otherwise the line will hang around virtually forever.