### PR TITLE
Finalize tf2 migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,8 @@ find_package(catkin REQUIRED
   sensor_msgs
   std_msgs
   std_srvs
-  tf
+  tf2_ros
+  tf2_geometry_msgs
   urdf
   visualization_msgs
 )
@@ -194,7 +195,7 @@ catkin_package(
     sensor_msgs
     std_msgs
     std_srvs
-    tf
+    tf2_ros
     urdf
     visualization_msgs
 )

--- a/package.xml
+++ b/package.xml
@@ -49,7 +49,8 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>tf</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tinyxml2</depend>
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>

--- a/src/python_bindings/sip/visualization_manager.sip
+++ b/src/python_bindings/sip/visualization_manager.sip
@@ -76,9 +76,9 @@ public:
   void setFixedFrame( const QString& frame );
   
   /**
-   * @brief Convenience function: returns getFrameManager()->getTFClient().
+   * @brief Convenience function: returns getFrameManager()->getTF2BufferPtr().
    */
-//  tf::TransformListener* getTFClient() const;
+//  std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() const;
 
   /**
    * @brief Returns the Ogre::SceneManager used for the main RenderPanel.

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -7,6 +7,7 @@
 #include <rviz/properties/int_property.h>
 #include <rviz/frame_manager.h>
 #include <rviz/validate_floats.h>
+#include <rviz/helpers/tf_prefix.h>
 
 #include "effort_visual.h"
 #include "effort_display.h"
@@ -278,8 +279,7 @@ void EffortDisplay::processMessage(const sensor_msgs::JointState::ConstPtr& msg)
     int joint_type = joint->type;
     if (joint_type == urdf::Joint::REVOLUTE)
     {
-      std::string tf_prefix = tf_prefix_property_->getStdString();
-      std::string tf_frame_id = (tf_prefix.empty() ? "" : tf_prefix + "/") + joint->child_link_name;
+      std::string tf_frame_id = concat(tf_prefix_property_->getStdString(), joint->child_link_name);
       Ogre::Quaternion orientation;
       Ogre::Vector3 position;
 

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -6,367 +6,323 @@
 #include <rviz/properties/float_property.h>
 #include <rviz/properties/int_property.h>
 #include <rviz/frame_manager.h>
-
-#include <boost/foreach.hpp>
+#include <rviz/validate_floats.h>
 
 #include "effort_visual.h"
-
 #include "effort_display.h"
 
 #include <urdf/model.h>
 
 namespace rviz
 {
+JointInfo::JointInfo(const std::string& name, rviz::Property* parent_category)
+{
+  name_ = name;
+  effort_ = 0;
+  max_effort_ = 0;
 
-    JointInfo::JointInfo(const std::string& name, rviz::Property* parent_category) {
-        name_ = name;
-        effort_ = 0;
-        max_effort_ = 0;
-        last_update_ = ros::Time::now();
+  // info->category_ = new Property( QString::fromStdString( info->name_ ) , QVariant(), "", joints_category_);
+  category_ =
+      new rviz::Property(QString::fromStdString(name_), true, "", parent_category, SLOT(updateVisibility()), this);
 
-        //info->category_ = new Property( QString::fromStdString( info->name_ ) , QVariant(), "", joints_category_);
-        category_ = new rviz::Property( QString::fromStdString( name_ ) , true, "", parent_category, SLOT( updateVisibility() ), this);
+  effort_property_ = new rviz::FloatProperty("Effort", 0, "Effort value of this joint.", category_);
+  effort_property_->setReadOnly(true);
 
-        effort_property_ = new rviz::FloatProperty( "Effort", 0, "Effort value of this joint.", category_);
-        effort_property_->setReadOnly( true );
+  max_effort_property_ = new rviz::FloatProperty("Max Effort", 0, "Max Effort value of this joint.", category_);
+  max_effort_property_->setReadOnly(true);
+}
 
-        max_effort_property_ = new rviz::FloatProperty( "Max Effort", 0, "Max Effort value of this joint.", category_);
-        max_effort_property_->setReadOnly( true );
-    }
+JointInfo::~JointInfo()
+{
+}
 
-    JointInfo::~JointInfo() {
-    }
+void JointInfo::updateVisibility()
+{
+}
 
-    void JointInfo::updateVisibility() {
-    }
+void JointInfo::setEffort(double e)
+{
+  effort_property_->setFloat(e);
+  effort_ = e;
+}
+void JointInfo::setMaxEffort(double m)
+{
+  max_effort_property_->setFloat(m);
+  max_effort_ = m;
+}
 
-    void JointInfo::setEffort(double e) {
-        effort_property_->setFloat(e);
-        effort_ = e;
-    }
-    double JointInfo::getEffort() { return effort_; }
-    void JointInfo::setMaxEffort(double m) {
-        max_effort_property_->setFloat(m);
-        max_effort_ = m;
-    }
-    double JointInfo::getMaxEffort() { return max_effort_; }
+bool JointInfo::getEnabled() const
+{
+  return category_->getValue().toBool();
+}
 
-    bool JointInfo::getEnabled() const
+JointInfo* EffortDisplay::getJointInfo(const std::string& joint)
+{
+  M_JointInfo::iterator it = joints_.find(joint);
+  if (it == joints_.end())
+  {
+    return nullptr;
+  }
+
+  return it->second;
+}
+
+JointInfo* EffortDisplay::createJoint(const std::string& joint)
+{
+  JointInfo* info = new JointInfo(joint, joints_category_);
+  joints_.insert(std::make_pair(joint, info));
+  return info;
+}
+
+EffortDisplay::EffortDisplay()
+{
+  alpha_property_ = new rviz::FloatProperty("Alpha", 1.0, "0 is fully transparent, 1.0 is fully opaque.", this,
+                                            SLOT(updateColorAndAlpha()));
+
+  width_property_ =
+      new rviz::FloatProperty("Width", 0.02, "Width to drow effort circle", this, SLOT(updateColorAndAlpha()));
+
+  scale_property_ =
+      new rviz::FloatProperty("Scale", 1.0, "Scale to drow effort circle", this, SLOT(updateColorAndAlpha()));
+
+  history_length_property_ = new rviz::IntProperty("History Length", 1, "Number of prior measurements to display.",
+                                                   this, SLOT(updateHistoryLength()));
+  history_length_property_->setMin(1);
+  history_length_property_->setMax(100000);
+
+  robot_description_property_ = new rviz::StringProperty("Robot Description", "robot_description",
+                                                         "Name of the parameter to search for to load the robot "
+                                                         "description.",
+                                                         this, SLOT(updateRobotDescription()));
+
+  tf_prefix_property_ = new StringProperty(
+      "TF Prefix", "", "Robot Model normally assumes the link name is the same as the tf frame name. "
+                       "This option allows you to set a prefix.  Mainly useful for multi-robot situations.",
+      this, SLOT(updateTfPrefix()));
+
+  joints_category_ = new rviz::Property("Joints", QVariant(), "", this);
+}
+
+void EffortDisplay::onInitialize()
+{
+  MFDClass::onInitialize();
+  // skip tf_filter_ (resetting it)
+  delete tf_filter_;
+  tf_filter_ =
+      new tf2_ros::MessageFilter<sensor_msgs::JointState>(*context_->getTF2BufferPtr(), std::string(), 1, update_nh_);
+
+  // but directly process messages
+  sub_.registerCallback(boost::bind(&EffortDisplay::incomingMessage, this, _1));
+  updateHistoryLength();
+}
+
+EffortDisplay::~EffortDisplay()
+{
+}
+
+// Clear the visuals by deleting their objects.
+void EffortDisplay::reset()
+{
+  MFDClass::reset();
+  visuals_.clear();
+}
+
+void EffortDisplay::updateTfPrefix()
+{
+  clearStatuses();
+  context_->queueRender();
+}
+
+void EffortDisplay::clear()
+{
+  clearStatuses();
+  robot_description_.clear();
+}
+
+// Set the current color and alpha values for each visual.
+void EffortDisplay::updateColorAndAlpha()
+{
+  float width = width_property_->getFloat();
+  float scale = scale_property_->getFloat();
+
+  for (size_t i = 0; i < visuals_.size(); i++)
+  {
+    visuals_[i]->setWidth(width);
+    visuals_[i]->setScale(scale);
+  }
+}
+
+void EffortDisplay::updateRobotDescription()
+{
+  if (isEnabled())
+  {
+    load();
+    context_->queueRender();
+  }
+}
+
+// Set the number of past visuals to show.
+void EffortDisplay::updateHistoryLength()
+{
+  visuals_.rset_capacity(history_length_property_->getInt());
+}
+
+void EffortDisplay::load()
+{
+  // get robot_description
+  std::string content;
+  if (!update_nh_.getParam(robot_description_property_->getStdString(), content))
+  {
+    std::string loc;
+    if (update_nh_.searchParam(robot_description_property_->getStdString(), loc))
     {
-        return category_->getValue().toBool();
+      update_nh_.getParam(loc, content);
     }
-
-    JointInfo* EffortDisplay::getJointInfo( const std::string& joint)
+    else
     {
-        M_JointInfo::iterator it = joints_.find( joint );
-        if ( it == joints_.end() )
-            {
-                return nullptr;
-            }
-
-        return it->second;
+      clear();
+      setStatus(rviz::StatusProperty::Error, "URDF", "Parameter [" + robot_description_property_->getString() +
+                                                         "] does not exist, and was not found by searchParam()");
+      return;
     }
+  }
 
-    JointInfo* EffortDisplay::createJoint(const std::string &joint)
+  if (content.empty())
+  {
+    clear();
+    setStatus(rviz::StatusProperty::Error, "URDF", "URDF is empty");
+    return;
+  }
+
+  if (content == robot_description_)
+  {
+    return;
+  }
+
+  robot_description_ = content;
+
+  robot_model_ = boost::shared_ptr<urdf::Model>(new urdf::Model());
+  if (!robot_model_->initString(content))
+  {
+    ROS_ERROR("Unable to parse URDF description!");
+    setStatus(rviz::StatusProperty::Error, "URDF", "Unable to parse robot model description!");
+    return;
+  }
+  setStatus(rviz::StatusProperty::Ok, "URDF", "Robot model parsed Ok");
+  for (std::map<std::string, urdf::JointSharedPtr>::iterator it = robot_model_->joints_.begin();
+       it != robot_model_->joints_.end(); it++)
+  {
+    urdf::JointSharedPtr joint = it->second;
+    if (joint->type == urdf::Joint::REVOLUTE)
     {
-        JointInfo *info = new JointInfo(joint, joints_category_);
-        joints_.insert( std::make_pair( joint, info ) );
-        return info;
+      std::string joint_name = it->first;
+      urdf::JointLimitsSharedPtr limit = joint->limits;
+      joints_[joint_name] = createJoint(joint_name);
+      joints_[joint_name]->setMaxEffort(limit->effort);
     }
+  }
+}
 
-    ///
-    EffortDisplay::EffortDisplay()
+void EffortDisplay::onEnable()
+{
+  load();
+}
+
+void EffortDisplay::onDisable()
+{
+  clear();
+}
+
+// This is our callback to handle an incoming message.
+void EffortDisplay::processMessage(const sensor_msgs::JointState::ConstPtr& msg)
+{
+  // Robot model might not be loaded already
+  if (!robot_model_)
+  {
+    return;
+  }
+  // We are keeping a circular buffer of visual pointers.  This gets
+  // the next one, or creates and stores it if the buffer is not full
+  boost::shared_ptr<EffortVisual> visual;
+  if (visuals_.full())
+  {
+    visual = visuals_.front();
+  }
+  else
+  {
+    visual.reset(new EffortVisual(context_->getSceneManager(), scene_node_));
+  }
+  visual->setWidth(width_property_->getFloat());
+  visual->setScale(scale_property_->getFloat());
+
+  V_string joints;
+  size_t joint_num = msg->name.size();
+  if (joint_num != msg->effort.size())
+  {
+    setStatus(rviz::StatusProperty::Error, "Topic",
+              "Received a joint state msg with different joint names and efforts size!");
+    return;
+  }
+  for (size_t i = 0; i < joint_num; ++i)
+  {
+    const std::string& joint_name = msg->name[i];
+    JointInfo* joint_info = getJointInfo(joint_name);
+    if (!joint_info)
+      continue;  // skip joints..
+
+    // update effort property
+    joint_info->setEffort(msg->effort[i]);
+    joint_info->last_update_ = msg->header.stamp;
+
+    const urdf::Joint* joint = robot_model_->getJoint(joint_name).get();
+    int joint_type = joint->type;
+    if (joint_type == urdf::Joint::REVOLUTE)
     {
-	alpha_property_ =
-	    new rviz::FloatProperty( "Alpha", 1.0,
-                                     "0 is fully transparent, 1.0 is fully opaque.",
-                                     this, SLOT( updateColorAndAlpha() ));
+      std::string tf_prefix = tf_prefix_property_->getStdString();
+      std::string tf_frame_id = (tf_prefix.empty() ? "" : tf_prefix + "/") + joint->child_link_name;
+      Ogre::Quaternion orientation;
+      Ogre::Vector3 position;
 
-	width_property_ =
-	    new rviz::FloatProperty( "Width", 0.02,
-                                     "Width to drow effort circle",
-                                     this, SLOT( updateColorAndAlpha() ));
+      // Call rviz::FrameManager to get the transform from the fixed frame to the joint's frame.
+      if (!context_->getFrameManager()->getTransform(tf_frame_id, ros::Time(), position, orientation))
+      {
+        setStatus(rviz::StatusProperty::Error, QString::fromStdString(joint_name),
+                  QString("Error transforming from frame '%1' to frame '%2'")
+                      .arg(tf_frame_id.c_str(), qPrintable(fixed_frame_)));
+        continue;
+      };
+      tf2::Vector3 axis_joint(joint->axis.x, joint->axis.y, joint->axis.z);
+      tf2::Vector3 axis_z(0, 0, 1);
+      tf2::Quaternion axis_rotation(axis_joint.cross(axis_z), axis_joint.angle(axis_z));
+      if (std::isnan(axis_rotation.x()) || std::isnan(axis_rotation.y()) || std::isnan(axis_rotation.z()))
+        axis_rotation = tf2::Quaternion::getIdentity();
 
-	scale_property_ =
-	    new rviz::FloatProperty( "Scale", 1.0,
-                                     "Scale to drow effort circle",
-                                     this, SLOT( updateColorAndAlpha() ));
+      tf2::Quaternion axis_orientation(orientation.x, orientation.y, orientation.z, orientation.w);
+      tf2::Quaternion axis_rot = axis_orientation * axis_rotation;
+      Ogre::Quaternion joint_orientation(Ogre::Real(axis_rot.w()), Ogre::Real(axis_rot.x()), Ogre::Real(axis_rot.y()),
+                                         Ogre::Real(axis_rot.z()));
+      visual->setFramePosition(joint_name, position);
+      visual->setFrameOrientation(joint_name, joint_orientation);
+      visual->setFrameEnabled(joint_name, joint_info->getEnabled());
 
-	history_length_property_ =
-	    new rviz::IntProperty( "History Length", 1,
-                                   "Number of prior measurements to display.",
-                                   this, SLOT( updateHistoryLength() ));
-        history_length_property_->setMin( 1 );
-        history_length_property_->setMax( 100000 );
+      if (!validateFloats(joint_info->getEffort()))
+      {
+        setStatus(rviz::StatusProperty::Error, QString::fromStdString(joint_name),
+                  QString("Invalid effort: %1").arg(joint_info->getEffort()));
+        visual->setFrameEnabled(joint_name, false);
+      }
+      else
+        setStatus(rviz::StatusProperty::Ok, QString::fromStdString(joint_name), QString());
 
-
-        robot_description_property_ =
-            new rviz::StringProperty( "Robot Description", "robot_description",
-                                      "Name of the parameter to search for to load the robot description.",
-                                      this, SLOT( updateRobotDescription() ) );
-                                      
-        tf_prefix_property_ = new StringProperty( "TF Prefix", "",
-                                                "Robot Model normally assumes the link name is the same as the tf frame name. "
-                                                " This option allows you to set a prefix.  Mainly useful for multi-robot situations.",
-                                                this, SLOT( updateTfPrefix() ) );
-
-        joints_category_ =
-            new rviz::Property("Joints", QVariant(), "", this);
+      visual->setEffort(joint_name, joint_info->getEffort(), joint_info->getMaxEffort());
     }
+  }
+  visuals_.push_back(visual);
+}
 
-    void EffortDisplay::onInitialize()
-    {
-        MFDClass::onInitialize();
-        updateHistoryLength();
-    }
-
-    EffortDisplay::~EffortDisplay()
-    {
-        //delete robot_model_; // sharead pointer
-    }
-
-    // Clear the visuals by deleting their objects.
-    void EffortDisplay::reset()
-    {
-        MFDClass::reset();
-        visuals_.clear();
-    }
-
-    void EffortDisplay::updateTfPrefix()
-    {
-      clearStatuses();
-      context_->queueRender();
-    }
-
-    void EffortDisplay::clear()
-    {
-        clearStatuses();
-        robot_description_.clear();
-    }
-
-    // Set the current color and alpha values for each visual.
-    void EffortDisplay::updateColorAndAlpha()
-    {
-        float width = width_property_->getFloat();
-        float scale = scale_property_->getFloat();
-
-        for( size_t i = 0; i < visuals_.size(); i++ )
-            {
-                visuals_[ i ]->setWidth( width );
-                visuals_[ i ]->setScale( scale );
-            }
-    }
-
-    void EffortDisplay::updateRobotDescription()
-    {
-        if( isEnabled() )
-            {
-                load();
-                context_->queueRender();
-            }
-    }
-
-    // Set the number of past visuals to show.
-    void EffortDisplay::updateHistoryLength( )
-    {
-        visuals_.rset_capacity(history_length_property_->getInt());
-    }
-
-    void EffortDisplay::load()
-    {
-	// get robot_description
-	std::string content;
-	if (!update_nh_.getParam( robot_description_property_->getStdString(), content) )  {
-            std::string loc;
-            if( update_nh_.searchParam( robot_description_property_->getStdString(), loc ))
-                {
-                    update_nh_.getParam( loc, content );
-                }
-            else
-                {
-                    clear();
-                    setStatus( rviz::StatusProperty::Error, "URDF",
-                               "Parameter [" + robot_description_property_->getString()
-                               + "] does not exist, and was not found by searchParam()" );
-                    return;
-                }
-            }
-
-        if( content.empty() )
-            {
-                clear();
-                setStatus( rviz::StatusProperty::Error, "URDF", "URDF is empty" );
-                return;
-            }
-
-        if( content == robot_description_ )
-            {
-                return;
-            }
-
-        robot_description_ = content;
-
-
-	robot_model_ = boost::shared_ptr<urdf::Model>(new urdf::Model());
-	if (!robot_model_->initString(content))
-	{
-	    ROS_ERROR("Unable to parse URDF description!");
-            setStatus( rviz::StatusProperty::Error, "URDF", "Unable to parse robot model description!");
-	    return;
-	}
-        setStatus(rviz::StatusProperty::Ok, "URDF", "Robot model parsed Ok");
-    for (std::map<std::string, urdf::JointSharedPtr >::iterator it = robot_model_->joints_.begin(); it != robot_model_->joints_.end(); it ++ ) {
-        urdf::JointSharedPtr joint = it->second;
-	    if ( joint->type == urdf::Joint::REVOLUTE ) {
-                std::string joint_name = it->first;
-                urdf::JointLimitsSharedPtr limit = joint->limits;
-                joints_[joint_name] = createJoint(joint_name);
-                joints_[joint_name]->setMaxEffort(limit->effort);
-            }
-        }
-    }
-
-    void EffortDisplay::onEnable()
-    {
-        load();
-    }
-
-    void EffortDisplay::onDisable()
-    {
-        clear();
-    }
-
-#if 0
-    void EffortDisplay::setRobotDescription( const std::string& description_param )
-    {
-        description_param_ = description_param;
-
-        propertyChanged(robot_description_property_);
-
-        if ( isEnabled() )
-            {
-                load();
-                unsubscribe();
-                subscribe();
-                causeRender();
-            }
-    }
-
-    void EffortDisplay::setAllEnabled(bool enabled)
-    {
-        all_enabled_ = enabled;
-
-        M_JointInfo::iterator it = joints_.begin();
-        M_JointInfo::iterator end = joints_.end();
-        for (; it != end; ++it)
-            {
-                JointInfo* joint = it->second;
-
-                setJointEnabled(joint, enabled);
-            }
-
-        propertyChanged(all_enabled_property_);
-    }
-
-#endif
-    // This is our callback to handle an incoming message.
-    void EffortDisplay::processMessage( const sensor_msgs::JointState::ConstPtr& msg )
-    {
-        // Robot model might not be loaded already
-        if (!robot_model_)
-        {
-            return;
-        }
-        // We are keeping a circular buffer of visual pointers.  This gets
-        // the next one, or creates and stores it if the buffer is not full
-        boost::shared_ptr<EffortVisual> visual;
-        if (visuals_.full())
-        {
-            visual = visuals_.front();
-        }
-        else
-        {
-            visual.reset(new EffortVisual(context_->getSceneManager(), scene_node_, robot_model_));
-        }
-
-        V_string joints;
-        size_t joint_num = msg->name.size();
-        if (joint_num != msg->effort.size())
-        {
-            std::string tmp_error = "Received a joint state msg with different joint names and efforts size!";
-            ROS_ERROR("%s", tmp_error.c_str());
-            setStatus(rviz::StatusProperty::Error, "TOPIC", QString::fromStdString(tmp_error));
-            return;
-        }
-        for (size_t i = 0; i < joint_num; ++i)
-        {
-            std::string joint_name = msg->name[i];
-            JointInfo* joint_info = getJointInfo(joint_name);
-            if ( !joint_info ) continue; // skip joints..
-
-            // set effort
-            joint_info->setEffort(msg->effort[i]);
-
-            // update effort property ???
-            if ((ros::Time::now() - joint_info->last_update_) > ros::Duration(0.2))
-            {
-                joint_info->last_update_ = ros::Time::now();
-            }
-
-	    const urdf::Joint* joint = robot_model_->getJoint(joint_name).get();
-	    int joint_type = joint->type;
-	    if ( joint_type == urdf::Joint::REVOLUTE )
-	    {
-		std::string tf_prefix = tf_prefix_property_->getStdString();
-		std::string tf_frame_id = (tf_prefix.empty() ? "" : tf_prefix + "/" ) + joint->child_link_name;
-		Ogre::Quaternion orientation;
-		Ogre::Vector3 position;
-
-		// Here we call the rviz::FrameManager to get the transform from the
-		// fixed frame to the frame in the header of this Effort message.  If
-		// it fails, we can't do anything else so we return.
-		if( !context_->getFrameManager()->getTransform( tf_frame_id,
-                                                                ros::Time(),
-                                                                //msg->header.stamp, // ???
-                                                                position, orientation ))
-		{
-		    ROS_DEBUG( "Error transforming from frame '%s' to frame '%s'",
-			       tf_frame_id.c_str(), qPrintable( fixed_frame_) );
-		    continue;
-		}
-;
-		tf::Vector3 axis_joint(joint->axis.x, joint->axis.y, joint->axis.z);
-		tf::Vector3 axis_z(0,0,1);
-		tf::Quaternion axis_rotation(tf::tfCross(axis_joint, axis_z), tf::tfAngle(axis_joint, axis_z));
-		if ( std::isnan(axis_rotation.x()) ||
-		     std::isnan(axis_rotation.y()) ||
-		     std::isnan(axis_rotation.z()) ) axis_rotation = tf::Quaternion::getIdentity();
-
-		tf::Quaternion axis_orientation(orientation.x, orientation.y, orientation.z, orientation.w);
-		tf::Quaternion axis_rot = axis_orientation * axis_rotation;
-		Ogre::Quaternion joint_orientation(Ogre::Real(axis_rot.w()), Ogre::Real(axis_rot.x()), Ogre::Real(axis_rot.y()), Ogre::Real(axis_rot.z()));
-		visual->setFramePosition( joint_name, position );
-		visual->setFrameOrientation( joint_name, joint_orientation );
-                visual->setFrameEnabled( joint_name, joint_info->getEnabled() );
-	    }
-	}
-
-
-	// Now set or update the contents of the chosen visual.
-        float scale = scale_property_->getFloat();
-        float width = width_property_->getFloat();
-        visual->setWidth( width );
-        visual->setScale( scale );
-	visual->setMessage( msg );
-
-        visuals_.push_back(visual);
-    }
-
-} // end namespace rviz
+}  // end namespace rviz
 
 // Tell pluginlib about this class.  It is important to do this in
 // global scope, outside our package's namespace.
 #include <pluginlib/class_list_macros.hpp>
-PLUGINLIB_EXPORT_CLASS( rviz::EffortDisplay, rviz::Display )
-
-
+PLUGINLIB_EXPORT_CLASS(rviz::EffortDisplay, rviz::Display)

--- a/src/rviz/default_plugin/effort_display.h
+++ b/src/rviz/default_plugin/effort_display.h
@@ -10,746 +10,118 @@
 
 namespace Ogre
 {
-    class SceneNode;
+class SceneNode;
 }
 
 namespace rviz
 {
-    class FloatProperty;
-    class IntProperty;
-    class StringProperty;
-    class CategoryProperty;
-    class BoolProperty;
-    class RosTopicProperty;
-}
+class FloatProperty;
+class IntProperty;
+class StringProperty;
+class CategoryProperty;
+class BoolProperty;
+}  // namespace rviz
 
 namespace urdf
 {
-    class Model;
-}
-
-// MessageFilter to support message with out frame_id
-// https://code.ros.org/trac/ros-pkg/ticket/5467
-namespace tf
-{
-#ifdef TF_MESSAGEFILTER_DEBUG
-# undef TF_MESSAGEFILTER_DEBUG
-#endif
-#define TF_MESSAGEFILTER_DEBUG(fmt, ...) \
-  ROS_DEBUG_NAMED("message_filter", "MessageFilter [target=%s]: " fmt, getTargetFramesString().c_str(), __VA_ARGS__)
-
-#ifdef TF_MESSAGEFILTER_WARN
-# undef TF_MESSAGEFILTER_WARN
-#endif
-#define TF_MESSAGEFILTER_WARN(fmt, ...) \
-  ROS_WARN_NAMED("message_filter", "MessageFilter [target=%s]: " fmt, getTargetFramesString().c_str(), __VA_ARGS__)
-
-    class MessageFilterJointState : public MessageFilter<sensor_msgs::JointState>
-    {
-	typedef sensor_msgs::JointState M;
-public:
-	typedef boost::shared_ptr<M const> MConstPtr;
-	typedef ros::MessageEvent<M const> MEvent;
-	typedef boost::function<void(const MConstPtr&, FilterFailureReason)> FailureCallback;
-	typedef boost::signals2::signal<void(const MConstPtr&, FilterFailureReason)> FailureSignal;
-
-	// If you hit this assert your message does not have a header, or does not have the HasHeader trait defined for it
-	ROS_STATIC_ASSERT(ros::message_traits::HasHeader<M>::value);
-
-	/**
-	 * \brief Constructor
-	 *
-	 * \param tf The tf::Transformer this filter should use
-	 * \param target_frame The frame this filter should attempt to transform to.  To use multiple frames, pass an empty string here and use the setTargetFrames() function.
-	 * \param queue_size The number of messages to queue up before throwing away old ones.  0 means infinite (dangerous).
-	 * \param nh The NodeHandle to use for any necessary operations
-	 * \param max_rate The maximum rate to check for newly transformable messages
-	 */
-	MessageFilterJointState(Transformer& tf, const std::string& target_frame, uint32_t queue_size, ros::NodeHandle nh = ros::NodeHandle(), ros::Duration max_rate = ros::Duration(0.01))
-	    : MessageFilter<sensor_msgs::JointState>(tf, target_frame, queue_size, nh, max_rate)
-            , tf_(tf)
-	    , nh_(nh)
-	    , max_rate_(max_rate)
-	    , queue_size_(queue_size)
-	    {
-		init();
-
-		setTargetFrame(target_frame);
-	    }
-
-	/**
-	 * \brief Constructor
-	 *
-	 * \param f The filter to connect this filter's input to.  Often will be a message_filters::Subscriber.
-	 * \param tf The tf::Transformer this filter should use
-	 * \param target_frame The frame this filter should attempt to transform to.  To use multiple frames, pass an empty string here and use the setTargetFrames() function.
-	 * \param queue_size The number of messages to queue up before throwing away old ones.  0 means infinite (dangerous).
-	 * \param nh The NodeHandle to use for any necessary operations
-	 * \param max_rate The maximum rate to check for newly transformable messages
-	 */
-	template<class F>
-	MessageFilterJointState(F& f, Transformer& tf, const std::string& target_frame, uint32_t queue_size, ros::NodeHandle nh = ros::NodeHandle(), ros::Duration max_rate = ros::Duration(0.01))
-	    : tf_(tf)
-	    , nh_(nh)
-	    , max_rate_(max_rate)
-	    , queue_size_(queue_size)
-            , MessageFilter<sensor_msgs::JointState>(f, tf, target_frame, queue_size, nh, max_rate)
-	    {
-		init();
-
-		setTargetFrame(target_frame);
-
-		connectInput(f);
-	    }
-
-	/**
-	 * \brief Connect this filter's input to another filter's output.  If this filter is already connected, disconnects first.
-	 */
-	template<class F>
-	void connectInput(F& f)
-	    {
-		message_connection_.disconnect();
-		message_connection_ = f.registerCallback(&MessageFilterJointState::incomingMessage, this);
-	    }
-
-	/**
-	 * \brief Destructor
-	 */
-	~MessageFilterJointState()
-	    {
-		message_connection_.disconnect();
-		tf_.removeTransformsChangedListener(tf_connection_);
-
-		clear();
-
-		TF_MESSAGEFILTER_DEBUG("Successful Transforms: %llu, Failed Transforms: %llu, Discarded due to age: %llu, Transform messages received: %llu, Messages received: %llu, Total dropped: %llu",
-				       (long long unsigned int)successful_transform_count_, (long long unsigned int)failed_transform_count_,
-				       (long long unsigned int)failed_out_the_back_count_, (long long unsigned int)transform_message_count_,
-				       (long long unsigned int)incoming_message_count_, (long long unsigned int)dropped_message_count_);
-
-	    }
-
-	/**
-	 * \brief Set the frame you need to be able to transform to before getting a message callback
-	 */
-	void setTargetFrame(const std::string& target_frame)
-	    {
-		std::vector<std::string> frames;
-		frames.push_back(target_frame);
-		setTargetFrames(frames);
-	    }
-
-	/**
-	 * \brief Set the frames you need to be able to transform to before getting a message callback
-	 */
-	void setTargetFrames(const std::vector<std::string>& target_frames)
-	    {
-		boost::mutex::scoped_lock list_lock(messages_mutex_);
-		boost::mutex::scoped_lock string_lock(target_frames_string_mutex_);
-
-		target_frames_ = target_frames;
-
-		std::stringstream ss;
-		for (std::vector<std::string>::iterator it = target_frames_.begin(); it != target_frames_.end(); ++it)
-		{
-		    *it = tf::resolve(tf_.getTFPrefix(), *it);
-		    ss << *it << " ";
-		}
-		target_frames_string_ = ss.str();
-	    }
-	/**
-	 * \brief Get the target frames as a string for debugging
-	 */
-	std::string getTargetFramesString()
-	    {
-		boost::mutex::scoped_lock lock(target_frames_string_mutex_);
-		return target_frames_string_;
-	    };
-
-	/**
-	 * \brief Set the required tolerance for the notifier to return true
-	 */
-	void setTolerance(const ros::Duration& tolerance)
-	    {
-		time_tolerance_ = tolerance;
-	    }
-
-	/**
-	 * \brief Clear any messages currently in the queue
-	 */
-	void clear()
-	    {
-		boost::mutex::scoped_lock lock(messages_mutex_);
-
-		TF_MESSAGEFILTER_DEBUG("%s", "Cleared");
-
-		messages_.clear();
-		message_count_ = 0;
-
-		warned_about_unresolved_name_ = false;
-		warned_about_empty_frame_id_ = false;
-	    }
-
-	void add(const MEvent& evt)
-	    {
-		boost::mutex::scoped_lock lock(messages_mutex_);
-
-		testMessages();
-
-		if (!testMessage(evt))
-		{
-		    // If this message is about to push us past our queue size, erase the oldest message
-		    if (queue_size_ != 0 && message_count_ + 1 > queue_size_)
-		    {
-			++dropped_message_count_;
-			const MEvent& front = messages_.front();
-			TF_MESSAGEFILTER_DEBUG("Removed oldest message because buffer is full, count now %d (frame_id=%s, stamp=%f)", message_count_, front.getMessage()->header.frame_id.c_str(), front.getMessage()->header.stamp.toSec());
-			signalFailure(messages_.front(), filter_failure_reasons::Unknown);
-
-			messages_.pop_front();
-			--message_count_;
-		    }
-
-		    // Add the message to our list
-		    messages_.push_back(evt);
-		    ++message_count_;
-		}
-
-		TF_MESSAGEFILTER_DEBUG("Added message in frame %s at time %.3f, count now %d", evt.getMessage()->header.frame_id.c_str(), evt.getMessage()->header.stamp.toSec(), message_count_);
-
-		++incoming_message_count_;
-	    }
-
-	/**
-	 * \brief Manually add a message into this filter.
-	 * \note If the message (or any other messages in the queue) are immediately transformable this will immediately call through to the output callback, possibly
-	 * multiple times
-	 */
-	void add(const MConstPtr& message)
-	    {
-		boost::shared_ptr<std::map<std::string, std::string> > header(new std::map<std::string, std::string>);
-		(*header)["callerid"] = "unknown";
-		add(MEvent(message, header, ros::Time::now()));
-	    }
-
-	/**
-	 * \brief Register a callback to be called when a message is about to be dropped
-	 * \param callback The callback to call
-	 */
-	message_filters::Connection registerFailureCallback(const FailureCallback& callback)
-	    {
-		boost::mutex::scoped_lock lock(failure_signal_mutex_);
-		return message_filters::Connection(boost::bind(&MessageFilterJointState::disconnectFailure, this, _1), failure_signal_.connect(callback));
-	    }
-
-	virtual void setQueueSize( uint32_t new_queue_size )
-	    {
-		queue_size_ = new_queue_size;
-	    }
-
-	virtual uint32_t getQueueSize()
-	    {
-		return queue_size_;
-	    }
-
-    private:
-
-	void init()
-	    {
-		message_count_ = 0;
-		new_transforms_ = false;
-		successful_transform_count_ = 0;
-		failed_transform_count_ = 0;
-		failed_out_the_back_count_ = 0;
-		transform_message_count_ = 0;
-		incoming_message_count_ = 0;
-		dropped_message_count_ = 0;
-		time_tolerance_ = ros::Duration(0.0);
-		warned_about_unresolved_name_ = false;
-		warned_about_empty_frame_id_ = false;
-
-		tf_connection_ = tf_.addTransformsChangedListener(boost::bind(&MessageFilterJointState::transformsChanged, this));
-
-		max_rate_timer_ = nh_.createTimer(max_rate_, &MessageFilterJointState::maxRateTimerCallback, this);
-	    }
-
-	typedef std::list<MEvent> L_Event;
-
-	bool testMessage(const MEvent& evt)
-	    {
-		const MConstPtr& message = evt.getMessage();
-		std::string callerid = evt.getPublisherName();
-		std::string frame_id = ros::message_traits::FrameId<M>::value(*message);
-		ros::Time stamp = ros::message_traits::TimeStamp<M>::value(*message);
-
-		// FIXED
-		if (frame_id.empty()) frame_id = * (target_frames_.begin());
-		//Throw out messages which have an empty frame_id
-		if (frame_id.empty())
-		{
-		    if (!warned_about_empty_frame_id_)
-		    {
-			warned_about_empty_frame_id_ = true;
-			TF_MESSAGEFILTER_WARN("Discarding message from [%s] due to empty frame_id.  This message will only print once.", callerid.c_str());
-		    }
-		    signalFailure(evt, filter_failure_reasons::EmptyFrameID);
-		    return true;
-		}
-
-		if (frame_id[0] != '/')
-		{
-		    std::string unresolved = frame_id;
-		    frame_id = tf::resolve(tf_.getTFPrefix(), frame_id);
-
-		    if (!warned_about_unresolved_name_)
-		    {
-			warned_about_unresolved_name_ = true;
-			ROS_WARN("Message from [%s] has a non-fully-qualified frame_id [%s]. Resolved locally to [%s].  This is will likely not work in multi-robot systems.  This message will only print once.", callerid.c_str(), unresolved.c_str(), frame_id.c_str());
-		    }
-		}
-
-		//Throw out messages which are too old
-		//! \todo combine getLatestCommonTime call with the canTransform call
-		for (std::vector<std::string>::iterator target_it = target_frames_.begin(); target_it != target_frames_.end(); ++target_it)
-		{
-		    const std::string& target_frame = *target_it;
-
-		    if (target_frame != frame_id && stamp != ros::Time(0))
-		    {
-			ros::Time latest_transform_time ;
-
-			tf_.getLatestCommonTime(frame_id, target_frame, latest_transform_time, 0) ;
-			if (stamp + tf_.getCacheLength() < latest_transform_time)
-			{
-			    ++failed_out_the_back_count_;
-			    ++dropped_message_count_;
-			    TF_MESSAGEFILTER_DEBUG("Discarding Message, in frame %s, Out of the back of Cache Time(stamp: %.3f + cache_length: %.3f < latest_transform_time %.3f.  Message Count now: %d", message->header.frame_id.c_str(), message->header.stamp.toSec(),  tf_.getCacheLength().toSec(), latest_transform_time.toSec(), message_count_);
-
-			    last_out_the_back_stamp_ = stamp;
-			    last_out_the_back_frame_ = frame_id;
-
-			    signalFailure(evt, filter_failure_reasons::OutTheBack);
-			    return true;
-			}
-		    }
-
-		}
-
-		bool ready = !target_frames_.empty();
-		for (std::vector<std::string>::iterator target_it = target_frames_.begin(); ready && target_it != target_frames_.end(); ++target_it)
-		{
-		    std::string& target_frame = *target_it;
-		    if (time_tolerance_ != ros::Duration(0.0))
-		    {
-			ready = ready && (tf_.canTransform(target_frame, frame_id, stamp) &&
-					  tf_.canTransform(target_frame, frame_id, stamp + time_tolerance_) );
-		    }
-		    else
-		    {
-			ready = ready && tf_.canTransform(target_frame, frame_id, stamp);
-		    }
-		}
-
-		if (ready)
-		{
-		    TF_MESSAGEFILTER_DEBUG("Message ready in frame %s at time %.3f, count now %d", frame_id.c_str(), stamp.toSec(), message_count_);
-
-		    ++successful_transform_count_;
-
-		    signalMessage(evt);
-		}
-		else
-		{
-		    ++failed_transform_count_;
-		}
-
-		return ready;
-	    }
-
-	void testMessages()
-	    {
-		if (!messages_.empty() && getTargetFramesString() == " ")
-		{
-		    ROS_WARN_NAMED("message_notifier", "MessageFilter [target=%s]: empty target frame", getTargetFramesString().c_str());
-		}
-
-		int i = 0;
-
-		L_Event::iterator it = messages_.begin();
-		for (; it != messages_.end(); ++i)
-		{
-		    MEvent& evt = *it;
-
-		    if (testMessage(evt))
-		    {
-			--message_count_;
-			it = messages_.erase(it);
-		    }
-		    else
-		    {
-			++it;
-		    }
-		}
-	    }
-
-	void maxRateTimerCallback(const ros::TimerEvent&)
-	    {
-		boost::mutex::scoped_lock list_lock(messages_mutex_);
-		if (new_transforms_)
-		{
-		    testMessages();
-		    new_transforms_ = false;
-		}
-
-		checkFailures();
-	    }
-
-	/**
-	 * \brief Callback that happens when we receive a message on the message topic
-	 */
-	void incomingMessage(const ros::MessageEvent<M const>& evt)
-	    {
-		add(evt);
-	    }
-
-	void transformsChanged()
-	    {
-		new_transforms_ = true;
-
-		++transform_message_count_;
-	    }
-
-	void checkFailures()
-	    {
-		if (next_failure_warning_.isZero())
-		{
-		    next_failure_warning_ = ros::Time::now() + ros::Duration(15);
-		}
-
-		if (ros::Time::now() >= next_failure_warning_)
-		{
-		    if (incoming_message_count_ - message_count_ == 0)
-		    {
-			return;
-		    }
-
-		    double dropped_pct = (double)dropped_message_count_ / (double)(incoming_message_count_ - message_count_);
-		    if (dropped_pct > 0.95)
-		    {
-			TF_MESSAGEFILTER_WARN("Dropped %.2f%% of messages so far. Please turn the [%s.message_notifier] rosconsole logger to DEBUG for more information.", dropped_pct*100, ROSCONSOLE_DEFAULT_NAME);
-			next_failure_warning_ = ros::Time::now() + ros::Duration(60);
-
-			if ((double)failed_out_the_back_count_ / (double)dropped_message_count_ > 0.5)
-			{
-			    TF_MESSAGEFILTER_WARN("  The majority of dropped messages were due to messages growing older than the TF cache time.  The last message's timestamp was: %f, and the last frame_id was: %s", last_out_the_back_stamp_.toSec(), last_out_the_back_frame_.c_str());
-			}
-		    }
-		}
-	    }
-
-	void disconnectFailure(const message_filters::Connection& c)
-	    {
-		boost::mutex::scoped_lock lock(failure_signal_mutex_);
-		c.getBoostConnection().disconnect();
-	    }
-
-	void signalFailure(const MEvent& evt, FilterFailureReason reason)
-	    {
-		boost::mutex::scoped_lock lock(failure_signal_mutex_);
-		failure_signal_(evt.getMessage(), reason);
-	    }
-
-	Transformer& tf_; ///< The Transformer used to determine if transformation data is available
-	ros::NodeHandle nh_; ///< The node used to subscribe to the topic
-	ros::Duration max_rate_;
-	ros::Timer max_rate_timer_;
-	std::vector<std::string> target_frames_; ///< The frames we need to be able to transform to before a message is ready
-	std::string target_frames_string_;
-	boost::mutex target_frames_string_mutex_;
-	uint32_t queue_size_; ///< The maximum number of messages we queue up
-
-	L_Event messages_; ///< The message list
-	uint32_t message_count_; ///< The number of messages in the list.  Used because messages_.size() has linear cost
-	boost::mutex messages_mutex_; ///< The mutex used for locking message list operations
-
-	bool new_messages_; ///< Used to skip waiting on new_data_ if new messages have come in while calling back
-	volatile bool new_transforms_; ///< Used to skip waiting on new_data_ if new transforms have come in while calling back or transforming data
-
-	bool warned_about_unresolved_name_;
-	bool warned_about_empty_frame_id_;
-
-	uint64_t successful_transform_count_;
-	uint64_t failed_transform_count_;
-	uint64_t failed_out_the_back_count_;
-	uint64_t transform_message_count_;
-	uint64_t incoming_message_count_;
-	uint64_t dropped_message_count_;
-
-	ros::Time last_out_the_back_stamp_;
-	std::string last_out_the_back_frame_;
-
-	ros::Time next_failure_warning_;
-
-	ros::Duration time_tolerance_; ///< Provide additional tolerance on time for messages which are stamped but can have associated duration
-
-	boost::signals2::connection tf_connection_;
-	message_filters::Connection message_connection_;
-
-	FailureSignal failure_signal_;
-	boost::mutex failure_signal_mutex_;
-    };
+class Model;
 }
 
 #ifndef Q_MOC_RUN
 #include <message_filters/subscriber.h>
-#include <tf/message_filter.h>
 #endif
 
-#include <rviz/display_context.h>
-#include <rviz/frame_manager.h>
-#include <rviz/properties/ros_topic_property.h>
+#include <rviz/message_filter_display.h>
 
 namespace rviz
 {
-/** @brief Display subclass using a tf::MessageFilter, templated on the ROS message type.
- *
- * This class brings together some common things used in many Display
- * types.  It has a tf::MessageFilter to filter incoming messages, and
- * it handles subscribing and unsubscribing when the display is
- * enabled or disabled.  It also has an Ogre::SceneNode which  */
-class MessageFilterJointStateDisplay: public _RosTopicDisplay
+class JointInfo : public QObject
 {
-// No Q_OBJECT macro here, moc does not support Q_OBJECT in a templated class.
+  Q_OBJECT
 public:
-  /** @brief Convenience typedef so subclasses don't have to use
-   * the long templated class name to refer to their super class. */
-  typedef MessageFilterJointStateDisplay MFDClass;
+  JointInfo(const std::string& name, rviz::Property* parent_category);
+  ~JointInfo();
 
-  MessageFilterJointStateDisplay()
-    : tf_filter_( NULL )
-    , messages_received_( 0 )
-    {
-      QString message_type = QString::fromStdString( ros::message_traits::datatype<sensor_msgs::JointState>() );
-      topic_property_->setMessageType( message_type );
-      topic_property_->setDescription( message_type + " topic to subscribe to." );
-    }
+  void setEffort(double e);
+  inline double getEffort() { return effort_; }
+  void setMaxEffort(double m);
+  inline double getMaxEffort() { return max_effort_; }
+  bool getEnabled() const;
 
-  virtual void onInitialize()
-    {
-      // TODO(wjwwood): remove this and use tf2 interface instead
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
+  ros::Time last_update_;
 
-      auto tf_client = context_->getTFClient();
+public Q_SLOTS:
+  void updateVisibility();
 
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-      tf_filter_ = new tf::MessageFilterJointState( *tf_client,
-                                                    fixed_frame_.toStdString(), queue_size_property_->getInt(), update_nh_ );
+private:
+  std::string name_;
+  double effort_, max_effort_;
 
-      tf_filter_->connectInput( sub_ );
-      tf_filter_->registerCallback( boost::bind( &MessageFilterJointStateDisplay::incomingMessage, this, _1 ));
-      // TODO(wjwwood): remove this and use tf2 interface instead
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
+  rviz::Property* category_;
+  rviz::FloatProperty* effort_property_;
+  rviz::FloatProperty* max_effort_property_;
+};
 
-      context_->getFrameManager()->registerFilterForTransformStatusCheck( tf_filter_, this );
+typedef std::set<JointInfo*> S_JointInfo;
+typedef std::vector<std::string> V_string;
 
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-    }
+class EffortVisual;
 
-  virtual ~MessageFilterJointStateDisplay()
-    {
-      unsubscribe();
-      delete tf_filter_;
-    }
+class EffortDisplay : public rviz::MessageFilterDisplay<sensor_msgs::JointState>
+{
+  Q_OBJECT
+public:
+  EffortDisplay();
+  virtual ~EffortDisplay();
 
-  virtual void reset()
-    {
-      Display::reset();
-      tf_filter_->clear();
-      messages_received_ = 0;
-    }
+  // Overrides of public virtual functions from the Display class.
+  virtual void onInitialize();
+  virtual void reset();
+
+private Q_SLOTS:
+  // Helper function to apply color and alpha to all visuals.
+  void updateColorAndAlpha();
+  void updateHistoryLength();
+  void updateRobotDescription();
+  void updateTfPrefix();
+
+  JointInfo* getJointInfo(const std::string& joint);
+  JointInfo* createJoint(const std::string& joint);
 
 protected:
-  virtual void updateTopic()
-    {
-      unsubscribe();
-      reset();
-      subscribe();
-      context_->queueRender();
-    }
+  // overrides from Display
+  virtual void onEnable();
+  virtual void onDisable();
 
-  virtual void updateQueueSize()
-    {
-      tf_filter_->setQueueSize( (uint32_t) queue_size_property_->getInt() );
-      subscribe();
-    }
+  // load
+  using MFDClass::load;
+  void load();
+  void clear();
 
-  virtual void subscribe()
-    {
-      if( !isEnabled() )
-      {
-        return;
-      }
+  // The object for urdf model
+  boost::shared_ptr<urdf::Model> robot_model_;
 
-      try
-      {
-        sub_.subscribe( update_nh_, topic_property_->getTopicStd(), queue_size_property_->getInt() );
-        setStatus( StatusProperty::Ok, "Topic", "OK" );
-      }
-      catch( ros::Exception& e )
-      {
-        setStatus( StatusProperty::Error, "Topic", QString( "Error subscribing: " ) + e.what() );
-      }
-    }
+  std::string robot_description_;
 
-  virtual void unsubscribe()
-    {
-      sub_.unsubscribe();
-    }
+private:
+  void processMessage(const sensor_msgs::JointState::ConstPtr& msg);
 
-  virtual void onEnable()
-    {
-      subscribe();
-    }
+  // Storage for the list of visuals.  It is a circular buffer where
+  // data gets popped from the front (oldest) and pushed to the back (newest)
+  boost::circular_buffer<boost::shared_ptr<EffortVisual> > visuals_;
 
-  virtual void onDisable()
-    {
-      unsubscribe();
-      reset();
-    }
+  typedef std::map<std::string, JointInfo*> M_JointInfo;
+  M_JointInfo joints_;
 
-  virtual void fixedFrameChanged()
-    {
-      tf_filter_->setTargetFrame( fixed_frame_.toStdString() );
-      reset();
-    }
+  // Property objects for user-editable properties.
+  rviz::FloatProperty *alpha_property_, *width_property_, *scale_property_;
+  rviz::IntProperty* history_length_property_;
 
-  /** @brief Incoming message callback.  Checks if the message pointer
-   * is valid, increments messages_received_, then calls
-   * processMessage(). */
-  void incomingMessage( const sensor_msgs::JointState::ConstPtr& msg )
-    {
-      if( !msg )
-      {
-        return;
-      }
-
-      ++messages_received_;
-      setStatus( StatusProperty::Ok, "Topic", QString::number( messages_received_ ) + " messages received" );
-
-      processMessage( msg );
-    }
-
-  /** @brief Implement this to process the contents of a message.
-   *
-   * This is called by incomingMessage(). */
-  virtual void processMessage( const sensor_msgs::JointState::ConstPtr& msg ) = 0;
-
-  message_filters::Subscriber<sensor_msgs::JointState> sub_;
-  tf::MessageFilterJointState* tf_filter_;
-  uint32_t messages_received_;
+  rviz::StringProperty* robot_description_property_;
+  rviz::StringProperty* tf_prefix_property_;
+  rviz::Property* joints_category_;
+  rviz::BoolProperty* all_enabled_property_;
 };
-} // rviz
+}  // namespace rviz
 
-namespace rviz
-{
-    class JointInfo: public QObject {
-        Q_OBJECT
-        public:
-        JointInfo(const std::string& name, rviz::Property* parent_category);
-        ~JointInfo();
-
-        void setEffort(double e);
-        double getEffort();
-        void setMaxEffort(double m);
-        double getMaxEffort();
-        bool getEnabled() const;
-
-        ros::Time last_update_;
-
-    public Q_SLOTS:
-        void updateVisibility();
-
-    private:
-        std::string name_;
-        double effort_, max_effort_;
-
-        rviz::Property* category_;
-        rviz::FloatProperty* effort_property_;
-        rviz::FloatProperty* max_effort_property_;
-    };
-
-    typedef std::set<JointInfo*> S_JointInfo;
-    typedef std::vector<std::string> V_string;
-
-    class EffortVisual;
-
-    class EffortDisplay: public rviz::MessageFilterJointStateDisplay
-    {
-    Q_OBJECT
-    public:
-	// Constructor.  pluginlib::ClassLoader creates instances by calling
-	// the default constructor, so make sure you have one.
-	EffortDisplay();
-	virtual ~EffortDisplay();
-
-	// Overrides of public virtual functions from the Display class.
-	virtual void onInitialize();
-	virtual void reset();
-
-    private Q_SLOTS:
-	// Helper function to apply color and alpha to all visuals.
-	void updateColorAndAlpha();
-        void updateHistoryLength();
-        void updateRobotDescription();
-        void updateTfPrefix();
-
-        JointInfo* getJointInfo( const std::string& joint);
-        JointInfo* createJoint(const std::string &joint);
-
-    protected:
-        // overrides from Display
-        virtual void onEnable();
-        virtual void onDisable();
-
-        // load
-        void load();
-        void clear();
-
-	// The object for urdf model
-	boost::shared_ptr<urdf::Model> robot_model_;
-
-        //
-        std::string robot_description_;
-
-    private:
-	void processMessage( const sensor_msgs::JointState::ConstPtr& msg );
-
-        // Storage for the list of visuals.  It is a circular buffer where
-        // data gets popped from the front (oldest) and pushed to the back (newest)
-        boost::circular_buffer<boost::shared_ptr<EffortVisual> > visuals_;
-
-        typedef std::map<std::string, JointInfo*> M_JointInfo;
-        M_JointInfo joints_;
-
-	// Property objects for user-editable properties.
-        rviz::FloatProperty *alpha_property_,* width_property_,* scale_property_;
-	rviz::IntProperty *history_length_property_;
-
-        rviz::StringProperty *robot_description_property_;
-        rviz::StringProperty *tf_prefix_property_;
-        rviz::Property *joints_category_;
-        rviz::BoolProperty *all_enabled_property_;
-    };
-} // end namespace rviz_plugin_tutorials
-
-#endif // EFFORT_DISPLAY_H
+#endif  // EFFORT_DISPLAY_H

--- a/src/rviz/default_plugin/effort_visual.cpp
+++ b/src/rviz/default_plugin/effort_visual.cpp
@@ -4,12 +4,8 @@
 
 #include <rviz/ogre_helpers/arrow.h>
 #include <rviz/ogre_helpers/billboard_line.h>
-#include <rviz/validate_floats.h>
 
 #include <ros/ros.h>
-
-#include <urdf/model.h>
-
 
 #include <utility>
 
@@ -17,168 +13,128 @@
 
 namespace rviz
 {
+EffortVisual::EffortVisual(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node)
+  : scene_manager_(scene_manager), parent_node_(parent_node)
+{
+}
 
-    EffortVisual::EffortVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, boost::shared_ptr<urdf::Model> urdf_model )
-    {
-	scene_manager_ = scene_manager;
+EffortVisual::~EffortVisual()
+{
+  // Delete the arrow to make it disappear.
+  for (auto& pair : effort_circle_)
+    delete pair.second;
 
-	// Ogre::SceneNode s form a tree, with each node storing the
-	// transform (position and orientation) of itself relative to its
-	// parent.  Ogre does the math of combining those transforms when it
-	// is time to render.
-	//
-	// Here we create a node to store the pose of the Effort's header frame
-	// relative to the RViz fixed frame.
-	frame_node_ = parent_node->createChildSceneNode();
+  for (auto& pair : effort_arrow_)
+    delete pair.second;
+}
 
-        //
-        urdf_model_ = std::move(urdf_model);
+void EffortVisual::getRainbowColor(float value, Ogre::ColourValue& color)
+{
+  value = std::min(value, 1.0f);
+  value = std::max(value, 0.0f);
 
-	// We create the arrow object within the frame node so that we can
-	// set its position and direction relative to its header frame.
-	for (std::map<std::string, urdf::JointSharedPtr >::iterator it = urdf_model_->joints_.begin(); it != urdf_model_->joints_.end(); it ++ ) {
-	    if ( it->second->type == urdf::Joint::REVOLUTE ) {
-                std::string joint_name = it->first;
-                effort_enabled_[joint_name] = true;
-            }
-        }
-    }
+  float h = value * 5.0f + 1.0f;
+  int i = floor(h);
+  float f = h - i;
+  if (!(i & 1))
+    f = 1 - f;  // if i is even
+  float n = 1 - f;
 
-    EffortVisual::~EffortVisual()
-    {
-	// Delete the arrow to make it disappear.
-	for (std::map<std::string, rviz::BillboardLine*>::iterator it = effort_circle_.begin(); it != effort_circle_.end(); it ++ ) {
-            delete (it->second);
-        }
-	for (std::map<std::string, rviz::Arrow*>::iterator it = effort_arrow_.begin(); it != effort_arrow_.end(); it ++ ) {
-            delete (it->second);
-        }
+  if (i <= 1)
+    color[0] = n, color[1] = 0, color[2] = 1;
+  else if (i == 2)
+    color[0] = 0, color[1] = n, color[2] = 1;
+  else if (i == 3)
+    color[0] = 0, color[1] = 1, color[2] = n;
+  else if (i == 4)
+    color[0] = n, color[1] = 1, color[2] = 0;
+  else if (i >= 5)
+    color[0] = 1, color[1] = n, color[2] = 0;
+}
 
-	// Destroy the frame node since we don't need it anymore.
-	scene_manager_->destroySceneNode( frame_node_ );
-    }
+void EffortVisual::setEffort(const std::string& joint_name, double effort, double max_effort)
+{
+  bool enabled = effort_enabled_.insert(std::make_pair(joint_name, true)).first->second;
 
+  // enable or disable draw
+  if (effort_circle_.find(joint_name) != effort_circle_.end() && !enabled)  // enable->disable
+  {
+    delete (effort_circle_[joint_name]);
+    delete (effort_arrow_[joint_name]);
+    effort_circle_.erase(joint_name);
+    effort_arrow_.erase(joint_name);
+  }
+  if (effort_circle_.find(joint_name) == effort_circle_.end() && enabled)  // disable -> enable
+  {
+    effort_circle_[joint_name] = new rviz::BillboardLine(scene_manager_, parent_node_);
+    effort_arrow_[joint_name] = new rviz::Arrow(scene_manager_, parent_node_);
+  }
 
-    void EffortVisual::getRainbowColor(float value, Ogre::ColourValue& color)
-    {
-	value = std::min(value, 1.0f);
-	value = std::max(value, 0.0f);
+  if (!enabled)
+    return;
 
-	float h = value * 5.0f + 1.0f;
-	int i = floor(h);
-	float f = h - i;
-	if ( !(i&1) ) f = 1 - f; // if i is even
-	float n = 1 - f;
+  double effort_value;
 
-	if      (i <= 1) color[0] = n, color[1] = 0, color[2] = 1;
-	else if (i == 2) color[0] = 0, color[1] = n, color[2] = 1;
-	else if (i == 3) color[0] = 0, color[1] = 1, color[2] = n;
-	else if (i == 4) color[0] = n, color[1] = 1, color[2] = 0;
-	else if (i >= 5) color[0] = 1, color[1] = n, color[2] = 0;
-    }
+  if (max_effort != 0.0)
+  {
+    effort_value = std::min(fabs(effort) / max_effort, 1.0) + 0.05;
+  }
+  else
+  {
+    effort_value = fabs(effort) + 0.05;
+  }
 
-    void EffortVisual::setMessage( const sensor_msgs::JointStateConstPtr& msg )
-    {
-	// for all joints...
-	int joint_num = msg->name.size();
-	for (int i = 0; i < joint_num; i++ )
-	{
-	    std::string joint_name = msg->name[i];
-	    double effort = msg->effort[i];
-		 if (!validateFloats(effort)) {
-			ROS_WARN_STREAM("Invalid effort for joint '" << joint_name << "': " << effort);
-			continue;
-		 }
-	    const urdf::Joint* joint = urdf_model_->getJoint(joint_name).get();
-	    int joint_type = joint->type;
-	    if ( joint_type == urdf::Joint::REVOLUTE )
-	    {
-                // enable or disable draw
-                if ( effort_circle_.find(joint_name) != effort_circle_.end() &&
-                     !effort_enabled_[joint_name] ) // enable->disable
-                    {
-                        delete(effort_circle_[joint_name]);
-                        delete(effort_arrow_[joint_name]);
-                        effort_circle_.erase(joint_name);
-                        effort_arrow_.erase(joint_name);
-                    }
-                if ( effort_circle_.find(joint_name) == effort_circle_.end() &&
-                     effort_enabled_[joint_name] ) // disable -> enable
-                    {
-                        effort_circle_[joint_name] = new rviz::BillboardLine( scene_manager_, frame_node_ );
-                        effort_arrow_[joint_name] = new rviz::Arrow( scene_manager_, frame_node_ );
-                    }
+  effort_arrow_[joint_name]->set(0, width_ * 2, width_ * 2 * 1.0, width_ * 2 * 2.0);
+  if (effort > 0)
+  {
+    effort_arrow_[joint_name]->setDirection(orientation_[joint_name] * Ogre::Vector3(-1, 0, 0));
+  }
+  else
+  {
+    effort_arrow_[joint_name]->setDirection(orientation_[joint_name] * Ogre::Vector3(1, 0, 0));
+  }
+  effort_arrow_[joint_name]->setPosition(
+      orientation_[joint_name] * Ogre::Vector3(0, 0.05 + effort_value * scale_ * 0.5, 0) + position_[joint_name]);
+  effort_circle_[joint_name]->clear();
+  effort_circle_[joint_name]->setLineWidth(width_);
+  for (int i = 0; i < 30; i++)
+  {
+    Ogre::Vector3 point = Ogre::Vector3((0.05 + effort_value * scale_ * 0.5) * sin(i * 2 * M_PI / 32),
+                                        (0.05 + effort_value * scale_ * 0.5) * cos(i * 2 * M_PI / 32), 0);
+    if (effort < 0)
+      point.x = -point.x;
+    effort_circle_[joint_name]->addPoint(orientation_[joint_name] * point + position_[joint_name]);
+  }
+  Ogre::ColourValue color;
+  getRainbowColor(effort_value, color);
+  effort_arrow_[joint_name]->setColor(color.r, color.g, color.b, color.a);
+  effort_circle_[joint_name]->setColor(color.r, color.g, color.b, color.a);
+}
 
-                if ( ! effort_enabled_[joint_name] ) continue;
+void EffortVisual::setFrameEnabled(const std::string& joint_name, const bool e)
+{
+  effort_enabled_[joint_name] = e;
+}
 
-		//tf::Transform offset = poseFromJoint(joint);
-		urdf::JointLimitsSharedPtr limit = joint->limits;
-		double max_effort = limit->effort, effort_value = 0.05;
+// Position and orientation are passed through to the SceneNode.
+void EffortVisual::setFramePosition(const std::string& joint_name, const Ogre::Vector3& position)
+{
+  position_[joint_name] = position;
+}
 
-		if ( max_effort != 0.0 )
-		{
-		    effort_value = std::min(fabs(effort) / max_effort, 1.0) + 0.05;
-		} else {
-                    effort_value = fabs(effort) + 0.05;
-                }
+void EffortVisual::setFrameOrientation(const std::string& joint_name, const Ogre::Quaternion& orientation)
+{
+  orientation_[joint_name] = orientation;
+}
 
-                effort_arrow_[joint_name]->set(0, width_*2, width_*2*1.0, width_*2*2.0);
-                if ( effort > 0 ) {
-                    effort_arrow_[joint_name]->setDirection(orientation_[joint_name] * Ogre::Vector3(-1,0,0));
-                } else {
-                    effort_arrow_[joint_name]->setDirection(orientation_[joint_name] * Ogre::Vector3( 1,0,0));
-                }
-                effort_arrow_[joint_name]->setPosition(orientation_[joint_name] * Ogre::Vector3(0, 0.05+effort_value*scale_*0.5, 0) + position_[joint_name]);
-                effort_circle_[joint_name]->clear();
-                effort_circle_[joint_name]->setLineWidth(width_);
-                for (int i = 0; i < 30; i++) {
-                    Ogre::Vector3 point = Ogre::Vector3((0.05+effort_value*scale_*0.5)*sin(i*2*M_PI/32), (0.05+effort_value*scale_*0.5)*cos(i*2*M_PI/32), 0);
-                    if ( effort < 0 ) point.x = -point.x;
-                    effort_circle_[joint_name]->addPoint(orientation_[joint_name] * point + position_[joint_name]);
-                }
-                Ogre::ColourValue color;
-                getRainbowColor(effort_value, color);
-                effort_arrow_[joint_name]->setColor(color.r, color.g, color.b, color.a);
-                effort_circle_[joint_name]->setColor(color.r, color.g, color.b, color.a);
-            }
-        }
-    }
+void EffortVisual::setWidth(float w)
+{
+  width_ = w;
+}
 
-    void EffortVisual::setFrameEnabled( const std::string& joint_name, const bool e )
-    {
-        effort_enabled_[joint_name] = e;
-    }
+void EffortVisual::setScale(float s)
+{
+  scale_ = s;
+}
 
-    // Position and orientation are passed through to the SceneNode.
-    void EffortVisual::setFramePosition( const Ogre::Vector3& position )
-    {
-	frame_node_->setPosition( position );
-    }
-
-    void EffortVisual::setFrameOrientation( const Ogre::Quaternion& orientation )
-    {
-	frame_node_->setOrientation( orientation );
-    }
-    // Position and orientation are passed through to the SceneNode.
-    void EffortVisual::setFramePosition( const std::string& joint_name, const Ogre::Vector3& position )
-    {
-	position_[joint_name] = position;
-    }
-
-    void EffortVisual::setFrameOrientation( const std::string& joint_name, const Ogre::Quaternion& orientation )
-    {
-	orientation_[joint_name] = orientation;
-    }
-
-    void EffortVisual::setWidth( float w )
-    {
-        width_ = w;
-    }
-
-    void EffortVisual::setScale( float s )
-    {
-        scale_ = s;
-    }
-
-} // end namespace rviz
-
+}  // end namespace rviz

--- a/src/rviz/default_plugin/effort_visual.h
+++ b/src/rviz/default_plugin/effort_visual.h
@@ -1,25 +1,16 @@
 #ifndef EFFORT_VISUAL_H
 #define EFFORT_VISUAL_H
 
-#include <sensor_msgs/JointState.h>
-
 #include <OgrePrerequisites.h>
 
-namespace urdf
+namespace rviz
 {
-    class Model;
-}
+class Arrow;
+class BillboardLine;
+}  // namespace rviz
 
 namespace rviz
 {
-    class Arrow;
-    class BillboardLine;
-}
-
-namespace rviz
-{
-
-
 // Each instance of EffortVisual represents the visualization of a single
 // sensor_msgs::Effort message.  Currently it just shows an arrow with
 // the direction and magnitude of the acceleration vector, but could
@@ -27,63 +18,42 @@ namespace rviz
 class EffortVisual
 {
 public:
-    // Constructor.  Creates the visual stuff and puts it into the
-    // scene, but in an unconfigured state.
-    EffortVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, boost::shared_ptr<urdf::Model> urdf_model );
+  // Constructor.  Creates the visual stuff and puts it into the
+  // scene, but in an unconfigured state.
+  EffortVisual(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node);
 
-    // Destructor.  Removes the visual stuff from the scene.
-    virtual ~EffortVisual();
+  // Destructor.  Removes the visual stuff from the scene.
+  virtual ~EffortVisual();
 
-    // set rainbow color
-    void getRainbowColor(float value, Ogre::ColourValue& color);
-    // Configure the visual to show the data in the message.
-    void setMessage( const sensor_msgs::JointStateConstPtr& msg );
+  // set rainbow color
+  void getRainbowColor(float value, Ogre::ColourValue& color);
+  void setEffort(const std::string& joint_name, double effort, double max_effort);
 
-    // Set the pose of the coordinate frame the message refers to.
-    // These could be done inside setMessage(), but that would require
-    // calls to FrameManager and error handling inside setMessage(),
-    // which doesn't seem as clean.  This way EffortVisual is only
-    // responsible for visualization.
-    void setFramePosition( const Ogre::Vector3& position );
-    void setFrameOrientation( const Ogre::Quaternion& orientation );
+  // set the pose of coordinates frame the each joint refers to.
+  void setFramePosition(const std::string& joint_name, const Ogre::Vector3& position);
+  void setFrameOrientation(const std::string& joint_name, const Ogre::Quaternion& orientation);
 
-    // set the pose of coordinates frame the each joint refers to.
-    void setFramePosition( const std::string& joint_name, const Ogre::Vector3& position );
-    void setFrameOrientation( const std::string& joint_name, const Ogre::Quaternion& orientation );
+  void setFrameEnabled(const std::string& joint_name, const bool e);
 
-    void setFrameEnabled( const std::string& joint_name, const bool e );
+  void setWidth(float w);
 
-    // Set the color and alpha of the visual, which are user-editable
-    // parameters and therefore don't come from the Effort message.
-    void setColor( float r, float g, float b, float a );
-
-    void setWidth( float w );
-
-    void setScale( float s );
+  void setScale(float s);
 
 private:
-    // The object implementing the effort circle
-    std::map<std::string, rviz::BillboardLine*> effort_circle_;
-    std::map<std::string, rviz::Arrow*> effort_arrow_;
-    std::map<std::string, bool> effort_enabled_;
+  // The object implementing the effort circle
+  std::map<std::string, rviz::BillboardLine*> effort_circle_;
+  std::map<std::string, rviz::Arrow*> effort_arrow_;
+  std::map<std::string, bool> effort_enabled_;
 
-    // A SceneNode whose pose is set to match the coordinate frame of
-    // the Effort message header.
-    Ogre::SceneNode* frame_node_;
+  Ogre::SceneManager* scene_manager_;
+  Ogre::SceneNode* parent_node_;
 
-    // The SceneManager, kept here only so the destructor can ask it to
-    // destroy the ``frame_node_``.
-    Ogre::SceneManager* scene_manager_;
+  std::map<std::string, Ogre::Vector3> position_;
+  std::map<std::string, Ogre::Quaternion> orientation_;
 
-    std::map<std::string, Ogre::Vector3> position_;
-    std::map<std::string, Ogre::Quaternion> orientation_;
-
-    float width_, scale_;
-
-    // The object for urdf model
-    boost::shared_ptr<urdf::Model> urdf_model_;
+  float width_, scale_;
 };
 
-} // end namespace rviz
+}  // end namespace rviz
 
-#endif // EFFORT_VISUAL_H
+#endif  // EFFORT_VISUAL_H

--- a/src/rviz/default_plugin/grid_cells_display.h
+++ b/src/rviz/default_plugin/grid_cells_display.h
@@ -31,15 +31,10 @@
 #ifndef RVIZ_GRID_CELLS_DISPLAY_H
 #define RVIZ_GRID_CELLS_DISPLAY_H
 
-#include <rviz/display.h>
+#include <rviz/message_filter_display.h>
 
 #include <nav_msgs/GridCells.h>
 #include <nav_msgs/MapMetaData.h>
-
-#ifndef Q_MOC_RUN
-#include <message_filters/subscriber.h>
-#include <tf/message_filter.h>
-#endif
 
 #include <boost/shared_ptr.hpp>
 
@@ -54,13 +49,12 @@ namespace rviz
 class ColorProperty;
 class FloatProperty;
 class PointCloud;
-class RosTopicProperty;
 
 /**
  * \class GridCellsDisplay
  * \brief Displays a nav_msgs::GridCells message
  */
-class GridCellsDisplay : public Display
+class GridCellsDisplay : public MessageFilterDisplay<nav_msgs::GridCells>
 {
 Q_OBJECT
 public:
@@ -68,36 +62,19 @@ public:
   virtual ~GridCellsDisplay();
 
   virtual void onInitialize();
-
-  // Overrides from Display
-  virtual void fixedFrameChanged();
   virtual void reset();
-
-protected:
-  // overrides from Display
-  virtual void onEnable();
-  virtual void onDisable();
 
 private Q_SLOTS:
   void updateAlpha();
-  void updateTopic();
 
 private:
-  void subscribe();
-  void unsubscribe();
-  void clear();
-  void incomingMessage( const nav_msgs::GridCells::ConstPtr& msg );
+  void processMessage( const nav_msgs::GridCells::ConstPtr& msg );
 
   PointCloud* cloud_;
 
-  message_filters::Subscriber<nav_msgs::GridCells> sub_;
-  tf::MessageFilter<nav_msgs::GridCells>* tf_filter_;
-
   ColorProperty* color_property_;
-  RosTopicProperty* topic_property_;
   FloatProperty* alpha_property_;
 
-  uint32_t messages_received_;
   uint64_t last_frame_count_;
 };
 

--- a/src/rviz/default_plugin/interactive_marker_display.cpp
+++ b/src/rviz/default_plugin/interactive_marker_display.cpp
@@ -27,8 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tf/transform_listener.h>
-
 #include <rviz/frame_manager.h>
 #include <rviz/properties/bool_property.h>
 #include <rviz/properties/ros_topic_property.h>

--- a/src/rviz/default_plugin/interactive_marker_display.h
+++ b/src/rviz/default_plugin/interactive_marker_display.h
@@ -39,7 +39,6 @@
 
 #ifndef Q_MOC_RUN
 #include <message_filters/subscriber.h>
-#include <tf/message_filter.h>
 #include <interactive_markers/interactive_marker_client.h>
 #endif
 

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
@@ -41,6 +41,7 @@
 
 #include <ros/ros.h>
 #include <interactive_markers/tools.h>
+#include <tf2_msgs/TF2Error.h>
 
 #include <rviz/frame_manager.h>
 #include <rviz/display_context.h>
@@ -315,20 +316,13 @@ void InteractiveMarker::updateReferencePose()
     }
     else
     {
+      auto tf = context_->getFrameManager()->getTF2BufferPtr();
+      tf2::CompactFrameID target_id = tf->_lookupFrameNumber(reference_frame_);
+      tf2::CompactFrameID source_id = tf->_lookupFrameNumber(fixed_frame);
       std::string error;
-      // TODO(wjwwood): remove this and use tf2 interface instead
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
+      int retval = tf ->_getLatestCommonTime(target_id, source_id, reference_time_, &error );
 
-      int retval = context_->getFrameManager()->getTFClient()->getLatestCommonTime(
-          reference_frame_, fixed_frame, reference_time_, &error );
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-      if ( retval != tf::NO_ERROR )
+      if ( retval != tf2_msgs::TF2Error::NO_ERROR )
       {
         std::ostringstream s;
         s <<"Error getting time of latest transform between " << reference_frame_

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker_control.h
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker_control.h
@@ -315,7 +315,7 @@ protected:
 
   CollObjectHandle coll_object_handle_;
 
-  /** Node representing reference frame in tf, like /map, /base_link,
+  /** Node representing reference frame in tf, like map, base_link,
    * /head, etc.  Same as the field in InteractiveMarker. */
   Ogre::SceneNode *reference_node_;
 

--- a/src/rviz/default_plugin/laser_scan_display.cpp
+++ b/src/rviz/default_plugin/laser_scan_display.cpp
@@ -69,9 +69,7 @@ void LaserScanDisplay::onInitialize()
 
 void LaserScanDisplay::processMessage( const sensor_msgs::LaserScanConstPtr& scan )
 {
-  sensor_msgs::PointCloudPtr cloud( new sensor_msgs::PointCloud );
-
-  std::string frame_id = scan->header.frame_id;
+  sensor_msgs::PointCloud2Ptr cloud( new sensor_msgs::PointCloud2 );
 
   // Compute tolerance necessary for this scan
   ros::Duration tolerance(scan->time_increment * scan->ranges.size());
@@ -83,23 +81,14 @@ void LaserScanDisplay::processMessage( const sensor_msgs::LaserScanConstPtr& sca
 
   try
   {
-    // TODO(wjwwood): remove this and use tf2 interface instead
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
+    auto tf = context_->getTF2BufferPtr();
 
-    auto tf_client = context_->getTFClient();
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-    projector_->transformLaserScanToPointCloud( fixed_frame_.toStdString(), *scan, *cloud, *tf_client,
+    projector_->transformLaserScanToPointCloud( fixed_frame_.toStdString(), *scan, *cloud, *tf,
                                                 laser_geometry::channel_option::Intensity );
   }
-  catch (tf::TransformException& e)
+  catch (tf2::TransformException& e)
   {
-    ROS_DEBUG( "LaserScan [%s]: failed to transform scan: %s.  This message should not repeat (tolerance should now be set on our tf::MessageFilter).",
+    ROS_DEBUG( "LaserScan [%s]: failed to transform scan: %s.  This message should not repeat (tolerance should now be set on our tf2::MessageFilter).",
                qPrintable( getName() ), e.what() );
     return;
   }

--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -697,7 +697,7 @@ void MapDisplay::showMap()
   frame_ = current_map_.header.frame_id;
   if (frame_.empty())
   {
-    frame_ = "/map";
+    frame_ = "map";
   }
 
   bool map_status_set = false;

--- a/src/rviz/default_plugin/marker_display.h
+++ b/src/rviz/default_plugin/marker_display.h
@@ -37,7 +37,7 @@
 #include <boost/shared_ptr.hpp>
 
 #ifndef Q_MOC_RUN
-#include <tf/message_filter.h>
+#include <tf2_ros/message_filter.h>
 #include <message_filters/subscriber.h>
 #endif
 
@@ -149,7 +149,7 @@ private:
    */
   void incomingMarker(const visualization_msgs::Marker::ConstPtr& marker);
 
-  void failedMarker(const ros::MessageEvent<visualization_msgs::Marker>& marker_evt, tf::FilterFailureReason reason);
+  void failedMarker(const ros::MessageEvent<visualization_msgs::Marker>& marker_evt, tf2_ros::FilterFailureReason reason);
 
   typedef std::map<MarkerID, MarkerBasePtr> M_IDToMarker;
   typedef std::set<MarkerBasePtr> S_MarkerBase;
@@ -162,7 +162,7 @@ private:
   boost::mutex queue_mutex_;
 
   message_filters::Subscriber<visualization_msgs::Marker> sub_;
-  tf::MessageFilter<visualization_msgs::Marker>* tf_filter_;
+  tf2_ros::MessageFilter<visualization_msgs::Marker>* tf_filter_;
 
   typedef QHash<QString, MarkerNamespace*> M_Namespace;
   M_Namespace namespaces_;

--- a/src/rviz/default_plugin/markers/arrow_marker.cpp
+++ b/src/rviz/default_plugin/markers/arrow_marker.cpp
@@ -78,7 +78,13 @@ void ArrowMarker::onNewMessage(const MarkerConstPtr&  /*old_message*/, const Mar
 
   Ogre::Vector3 pos, scale;
   Ogre::Quaternion orient;
-  transform(new_message, pos, orient, scale);
+  if (!transform(new_message, pos, orient, scale))
+  {
+    scene_node_->setVisible(false);
+    return;
+  }
+
+  scene_node_->setVisible(true);
   setPosition(pos);
   setOrientation( orient );
 

--- a/src/rviz/default_plugin/markers/line_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/line_list_marker.cpp
@@ -63,8 +63,13 @@ void LineListMarker::onNewMessage(const MarkerConstPtr&  /*old_message*/, const 
 
   Ogre::Vector3 pos, scale;
   Ogre::Quaternion orient;
-  transform(new_message, pos, orient, scale);
+  if (!transform(new_message, pos, orient, scale))
+  {
+    scene_node_->setVisible(false);
+    return;
+  }
 
+  scene_node_->setVisible(true);
   setPosition(pos);
   setOrientation(orient);
   lines_->setScale(scale);

--- a/src/rviz/default_plugin/markers/line_strip_marker.cpp
+++ b/src/rviz/default_plugin/markers/line_strip_marker.cpp
@@ -65,8 +65,13 @@ void LineStripMarker::onNewMessage(const MarkerConstPtr&  /*old_message*/, const
 
   Ogre::Vector3 pos, scale;
   Ogre::Quaternion orient;
-  transform(new_message, pos, orient, scale);
+  if (!transform(new_message, pos, orient, scale))
+  {
+    scene_node_->setVisible(false);
+    return;
+  }
 
+  scene_node_->setVisible(true);
   setPosition(pos);
   setOrientation(orient);
   lines_->setScale(scale);

--- a/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
@@ -232,7 +232,11 @@ void MeshResourceMarker::onNewMessage(const MarkerConstPtr& old_message, const M
 
   Ogre::Vector3 pos, scale;
   Ogre::Quaternion orient;
-  transform(new_message, pos, orient, scale);
+  if (!transform(new_message, pos, orient, scale))
+  {
+    scene_node_->setVisible(false);
+    return;
+  }
 
   scene_node_->setVisible(true);
   setPosition(pos);

--- a/src/rviz/default_plugin/markers/points_marker.cpp
+++ b/src/rviz/default_plugin/markers/points_marker.cpp
@@ -68,7 +68,13 @@ void PointsMarker::onNewMessage(const MarkerConstPtr&  /*old_message*/, const Ma
 
   Ogre::Vector3 pos, scale;
   Ogre::Quaternion orient;
-  transform(new_message, pos, orient, scale);
+  if (!transform(new_message, pos, orient, scale))
+  {
+    scene_node_->setVisible(false);
+    return;
+  }
+
+  scene_node_->setVisible(true);
 
   switch (new_message->type)
   {

--- a/src/rviz/default_plugin/markers/shape_marker.cpp
+++ b/src/rviz/default_plugin/markers/shape_marker.cpp
@@ -82,8 +82,12 @@ void ShapeMarker::onNewMessage( const MarkerConstPtr& old_message,
   Ogre::Vector3 pos, scale, scale_correct;
   Ogre::Quaternion orient;
   if (!transform(new_message, pos, orient, scale))
+  {
+    scene_node_->setVisible(false);
     return;
+  }
 
+  scene_node_->setVisible(true);
   setPosition(pos);
   setOrientation( orient * Ogre::Quaternion( Ogre::Degree(90), Ogre::Vector3(1,0,0) ) );
 

--- a/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
+++ b/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
@@ -69,8 +69,13 @@ void TextViewFacingMarker::onNewMessage(const MarkerConstPtr&  /*old_message*/, 
 
   Ogre::Vector3 pos, scale;
   Ogre::Quaternion orient;
-  transform(new_message, pos, orient, scale);
+  if (!transform(new_message, pos, orient, scale))
+  {
+    scene_node_->setVisible(false);
+    return;
+  }
 
+  scene_node_->setVisible(true);
   setPosition(pos);
   text_->setCharacterHeight(new_message->scale.z);
   text_->setColor(Ogre::ColourValue(new_message->color.r, new_message->color.g, new_message->color.b, new_message->color.a));

--- a/src/rviz/default_plugin/markers/triangle_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.cpp
@@ -66,6 +66,14 @@ void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const M
 {
   ROS_ASSERT(new_message->type == visualization_msgs::Marker::TRIANGLE_LIST);
 
+  Ogre::Vector3 pos, scale;
+  Ogre::Quaternion orient;
+  if (!transform(new_message, pos, orient, scale))
+  {
+    scene_node_->setVisible( false );
+    return;
+  }
+
   size_t num_points = new_message->points.size();
   if( (num_points % 3) != 0 || num_points == 0 )
   {
@@ -93,15 +101,6 @@ void TriangleListMarker::onNewMessage(const MarkerConstPtr& old_message, const M
     material_->setCullingMode(Ogre::CULL_NONE);
 
     handler_.reset( new MarkerSelectionHandler( this, MarkerID( new_message->ns, new_message->id ), context_ ));
-  }
-
-  Ogre::Vector3 pos, scale;
-  Ogre::Quaternion orient;
-  if (!transform(new_message, pos, orient, scale))
-  {    
-    ROS_DEBUG("Unable to transform marker message");
-    scene_node_->setVisible( false );
-    return;
   }
 
   setPosition(pos);

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -360,17 +360,7 @@ void TFDisplay::updateFrames()
 {
   typedef std::vector<std::string> V_string;
   V_string frames;
-  // TODO(wjwwood): remove this and use tf2 interface instead
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-  context_->getTFClient()->getFrameStrings( frames );
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
+  context_->getTF2BufferPtr()->_getFrameStrings( frames );
   std::sort(frames.begin(), frames.end());
 
   S_FrameInfo current_frames;

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -32,8 +32,6 @@
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 
-#include <tf/transform_listener.h>
-
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>
 #include <rviz/ogre_helpers/arrow.h>
@@ -478,21 +476,13 @@ Ogre::ColourValue lerpColor(const Ogre::ColourValue& start, const Ogre::ColourVa
 
 void TFDisplay::updateFrame( FrameInfo* frame )
 {
-  // TODO(wjwwood): remove this and use tf2 interface instead
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-  tf::TransformListener* tf = context_->getTFClient();
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
+  auto tf = context_->getTF2BufferPtr();
+  tf2::CompactFrameID target_id = tf->_lookupFrameNumber(fixed_frame_.toStdString());
+  tf2::CompactFrameID source_id = tf->_lookupFrameNumber(frame->name_);
 
   // Check last received time so we can grey out/fade out frames that have stopped being published
   ros::Time latest_time;
-  tf->getLatestCommonTime( fixed_frame_.toStdString(), frame->name_, latest_time, nullptr );
+  tf->_getLatestCommonTime( target_id, source_id, latest_time, nullptr );
 
   if(( latest_time != frame->last_time_to_fixed_ ) ||
      ( latest_time == ros::Time() ))
@@ -584,7 +574,7 @@ void TFDisplay::updateFrame( FrameInfo* frame )
 
   std::string old_parent = frame->parent_;
   frame->parent_.clear();
-  bool has_parent = tf->getParent( frame->name_, ros::Time(), frame->parent_ );
+  bool has_parent = tf->_getParent( frame->name_, ros::Time(), frame->parent_ );
   if( has_parent )
   {
     // If this frame has no tree property or the parent has changed,
@@ -611,30 +601,22 @@ void TFDisplay::updateFrame( FrameInfo* frame )
       }
     }
 
-    tf::StampedTransform transform;
+    geometry_msgs::TransformStamped transform;
     try {
-      // TODO(wjwwood): remove this and use tf2 interface instead
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-      auto tf_client = context_->getFrameManager()->getTFClientPtr();
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-      tf_client->lookupTransform(frame->parent_,frame->name_,ros::Time(0),transform);
+      transform = tf->lookupTransform(frame->parent_, frame->name_, ros::Time());
     }
-    catch(tf::TransformException& e)
+    catch(tf2::TransformException& e)
     {
       ROS_DEBUG( "Error transforming frame '%s' (parent of '%s') to frame '%s'",
-                 frame->parent_.c_str(), frame->name_.c_str(), qPrintable( fixed_frame_ ));
+                 frame->parent_.c_str(), frame->name_.c_str(), qPrintable( fixed_frame_ ) );
+      transform.transform.rotation.w = 1.0;
     }
 
     // get the position/orientation relative to the parent frame
-    Ogre::Vector3 relative_position( transform.getOrigin().x(), transform.getOrigin().y(), transform.getOrigin().z() );
-    Ogre::Quaternion relative_orientation( transform.getRotation().w(), transform.getRotation().x(), transform.getRotation().y(), transform.getRotation().z() );
+    const auto& translation = transform.transform.translation;
+    const auto& quat = transform.transform.rotation;
+    Ogre::Vector3 relative_position( translation.x, translation.y, translation.z );
+    Ogre::Quaternion relative_orientation( quat.w, quat.x, quat.y, quat.z );
     frame->rel_position_property_->setVector( relative_position );
     frame->rel_orientation_property_->setQuaternion( relative_orientation );
 

--- a/src/rviz/default_plugin/tools/goal_tool.cpp
+++ b/src/rviz/default_plugin/tools/goal_tool.cpp
@@ -27,9 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tf/transform_listener.h>
-
 #include <geometry_msgs/PoseStamped.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <rviz/display_context.h>
 #include <rviz/properties/string_property.h>
@@ -67,11 +66,14 @@ void GoalTool::updateTopic()
 void GoalTool::onPoseSet(double x, double y, double theta)
 {
   std::string fixed_frame = context_->getFixedFrame().toStdString();
-  tf::Quaternion quat;
+  tf2::Quaternion quat;
   quat.setRPY(0.0, 0.0, theta);
-  tf::Stamped<tf::Pose> p = tf::Stamped<tf::Pose>(tf::Pose(quat, tf::Point(x, y, 0.0)), ros::Time::now(), fixed_frame);
   geometry_msgs::PoseStamped goal;
-  tf::poseStampedTFToMsg(p, goal);
+  tf2::convert(goal.pose.orientation, quat);
+  goal.pose.position.x = x;
+  goal.pose.position.y = y;
+  goal.header.frame_id = fixed_frame;
+  goal.header.stamp = ros::Time::now();
   ROS_INFO("Setting goal: Frame:%s, Position(%.3f, %.3f, %.3f), Orientation(%.3f, %.3f, %.3f, %.3f) = Angle: %.3f\n", fixed_frame.c_str(),
       goal.pose.position.x, goal.pose.position.y, goal.pose.position.z,
       goal.pose.orientation.x, goal.pose.orientation.y, goal.pose.orientation.z, goal.pose.orientation.w, theta);

--- a/src/rviz/default_plugin/tools/initial_pose_tool.cpp
+++ b/src/rviz/default_plugin/tools/initial_pose_tool.cpp
@@ -27,9 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tf/transform_listener.h>
-
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <rviz/display_context.h>
 #include <rviz/properties/string_property.h>
@@ -80,10 +79,9 @@ void InitialPoseTool::onPoseSet(double x, double y, double theta)
   pose.pose.pose.position.x = x;
   pose.pose.pose.position.y = y;
 
-  tf::Quaternion quat;
+  tf2::Quaternion quat;
   quat.setRPY(0.0, 0.0, theta);
-  tf::quaternionTFToMsg(quat,
-                        pose.pose.pose.orientation);
+  tf2::convert(pose.pose.pose.orientation, quat);
   pose.pose.covariance[6*0+0] = std::pow(std_dev_x_->getFloat(), 2);
   pose.pose.covariance[6*1+1] = std::pow(std_dev_y_->getFloat(), 2);
   pose.pose.covariance[6*5+5] = std::pow(std_dev_theta_->getFloat(), 2);

--- a/src/rviz/display_context.h
+++ b/src/rviz/display_context.h
@@ -34,6 +34,7 @@
 
 #include <QObject>
 #include <QString>
+#include "frame_manager.h"
 
 class QKeyEvent;
 
@@ -63,7 +64,6 @@ namespace rviz
 class BitAllocator;
 class DisplayFactory;
 class DisplayGroup;
-class FrameManager;
 class RenderPanel;
 class SelectionManager;
 class ToolManager;
@@ -95,12 +95,10 @@ public:
   /** @brief Return the FrameManager instance. */
   virtual FrameManager* getFrameManager() const = 0;
 
-  /** @brief Convenience function: returns getFrameManager()->getTFClient(). */
-  [[deprecated("use getTF2BufferPtr() instead")]]
-  virtual tf::TransformListener* getTFClient() const = 0;
-
   /** @brief Convenience function: returns getFrameManager()->getTF2BufferPtr(). */
-  virtual std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() const = 0;
+  std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() const {
+    return getFrameManager()->getTF2BufferPtr();
+  }
 
   /** @brief Return the fixed frame name. */
   virtual QString getFixedFrame() const = 0;

--- a/src/rviz/frame_manager.cpp
+++ b/src/rviz/frame_manager.cpp
@@ -31,32 +31,21 @@
 #include "display.h"
 #include "properties/property.h"
 
-#include <tf/transform_listener.h>
 #include <ros/ros.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <std_msgs/Float32.h>
 
 namespace rviz
 {
 
-// TODO(wjwwood): remove this when deprecated interface is removed
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-FrameManager::FrameManager()
-: FrameManager(boost::shared_ptr<tf::TransformListener>())
-{}
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
-FrameManager::FrameManager(const boost::shared_ptr<tf::TransformListener>& tf)
+FrameManager::FrameManager(std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+                           std::shared_ptr<tf2_ros::TransformListener> tf_listener)
 {
-  if (!tf) tf_.reset(new tf::TransformListener(ros::NodeHandle(), ros::Duration(10*60), true));
-  else tf_ = tf;
+  assert(!tf_listener|| tf_buffer);  // tf_listener implies tf_buffer to defined too
+  tf_buffer_ = tf_buffer ? std::move(tf_buffer) : std::make_shared<tf2_ros::Buffer>(ros::Duration(10*60));
+  tf_listener_ = tf_listener ? std::move(tf_listener) : std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, ros::NodeHandle(), true);
 
   setSyncMode( SyncOff );
   setPause(false);
@@ -107,6 +96,7 @@ void FrameManager::setFixedFrame(const std::string& frame)
     if( fixed_frame_ != frame )
     {
       fixed_frame_ = frame;
+      fixed_frame_id_ = tf_buffer_->_lookupFrameNumber(fixed_frame_);
       cache_.clear();
       should_emit = true;
     }
@@ -180,7 +170,7 @@ bool FrameManager::adjustTime( const std::string &frame, ros::Time& time )
         ros::Time latest_time;
         std::string error_string;
         int error_code;
-        error_code = tf_->getLatestCommonTime( fixed_frame_, frame, latest_time, &error_string );
+        error_code = tf_buffer_->_getLatestCommonTime( fixed_frame_id_, tf_buffer_->_lookupFrameNumber(frame), latest_time, &error_string );
 
         if ( error_code != 0 )
         {
@@ -248,22 +238,14 @@ bool FrameManager::transform(const std::string& frame, ros::Time time, const geo
   position = Ogre::Vector3::ZERO;
   orientation = Ogre::Quaternion::IDENTITY;
 
-  // put all pose data into a tf stamped pose
-  tf::Quaternion bt_orientation(pose_msg.orientation.x, pose_msg.orientation.y, pose_msg.orientation.z, pose_msg.orientation.w);
-  tf::Vector3 bt_position(pose_msg.position.x, pose_msg.position.y, pose_msg.position.z);
+  geometry_msgs::Pose pose = pose_msg;
+  if (pose.orientation.x == 0.0 && pose.orientation.y == 0.0 && pose.orientation.z == 0.0 && pose.orientation.w == 0.0)
+    pose.orientation.w = 1.0;
 
-  if (bt_orientation.x() == 0.0 && bt_orientation.y() == 0.0 && bt_orientation.z() == 0.0 && bt_orientation.w() == 0.0)
-  {
-    bt_orientation.setW(1.0);
-  }
-
-  tf::Stamped<tf::Pose> pose_in(tf::Transform(bt_orientation,bt_position), time, frame);
-  tf::Stamped<tf::Pose> pose_out;
-
-  // convert pose into new frame
+  // convert pose into fixed_frame_
   try
   {
-    tf_->transformPose( fixed_frame_, pose_in, pose_out );
+    tf2::doTransform(pose, pose, tf_buffer_->lookupTransform(fixed_frame_, frame, time));
   }
   catch(std::runtime_error& e)
   {
@@ -271,18 +253,15 @@ bool FrameManager::transform(const std::string& frame, ros::Time time, const geo
     return false;
   }
 
-  bt_position = pose_out.getOrigin();
-  position = Ogre::Vector3(bt_position.x(), bt_position.y(), bt_position.z());
-
-  bt_orientation = pose_out.getRotation();
-  orientation = Ogre::Quaternion( bt_orientation.w(), bt_orientation.x(), bt_orientation.y(), bt_orientation.z() );
+  position = Ogre::Vector3(pose.position.x, pose.position.y, pose.position.z);
+  orientation = Ogre::Quaternion( pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z );
 
   return true;
 }
 
 bool FrameManager::frameHasProblems(const std::string& frame, ros::Time  /*time*/, std::string& error)
 {
-  if (!tf_->frameExists(frame))
+  if (!tf_buffer_->_frameExists(frame))
   {
     error = "Frame [" + frame + "] does not exist";
     if (frame == fixed_frame_)
@@ -303,7 +282,7 @@ bool FrameManager::transformHasProblems(const std::string& frame, ros::Time time
   }
 
   std::string tf_error;
-  bool transform_succeeded = tf_->canTransform(fixed_frame_, frame, time, &tf_error);
+  bool transform_succeeded = tf_buffer_->canTransform(fixed_frame_, frame, time, &tf_error);
   if (transform_succeeded)
   {
     return false;
@@ -335,31 +314,6 @@ std::string getTransformStatusName(const std::string& caller_id)
   std::stringstream ss;
   ss << "Transform [sender=" << caller_id << "]";
   return ss.str();
-}
-
-std::string
-FrameManager::discoverFailureReason(
-  const std::string& frame_id,
-  const ros::Time& stamp,
-  const std::string&  /*caller_id*/,
-  tf::FilterFailureReason reason)
-{
-  if (reason == tf::filter_failure_reasons::OutTheBack)
-  {
-    std::stringstream ss;
-    ss << "Message removed because it is too old (frame=[" << frame_id << "], stamp=[" << stamp << "])";
-    return ss.str();
-  }
-  else
-  {
-    std::string error;
-    if (transformHasProblems(frame_id, stamp, error))
-    {
-      return error;
-    }
-  }
-
-  return "Unknown reason for transform failure";
 }
 
 std::string

--- a/src/rviz/frame_manager.h
+++ b/src/rviz/frame_manager.h
@@ -35,27 +35,21 @@
 #include <QObject>
 
 #include <ros/time.h>
+#include <tf2_ros/buffer.h>
+#include <geometry_msgs/Pose.h>
 
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 
 #include <boost/thread/mutex.hpp>
 
-#include <geometry_msgs/Pose.h>
-
 #ifndef Q_MOC_RUN
-#include <tf/message_filter.h>
 #include <tf2_ros/message_filter.h>
 #endif
 
-namespace tf
-{
-class TransformListener;
-}
-
 namespace tf2_ros
 {
-class Buffer;
+class TransformListener;
 }
 
 namespace rviz
@@ -77,24 +71,9 @@ public:
     SyncApprox
   };
 
-  /// Default constructor, which will create a tf::TransformListener automatically.
-  FrameManager();
-
-  /** @brief Constructor
-   * @param tf a pointer to tf::TransformListener (should not be used anywhere else because of thread safety)
-   */
-  [[deprecated(
-    "This constructor signature will be removed in the next version. "
-    "If you still need to pass a boost::shared_ptr<tf::TransformListener>, "
-    "disable the warning explicitly. "
-    "When this constructor is removed, a new constructor with a single, "
-    "optional argument will take a std::pair<> containing a "
-    "std::shared_ptr<tf2_ros::Buffer> and a "
-    "std::shared_ptr<tf2_ros::TransformListener>. "
-    "However, that cannot occur until the use of tf::TransformListener is "
-    "removed internally."
-  )]]
-  explicit FrameManager(const boost::shared_ptr<tf::TransformListener>& tf);
+  /// Constructor, will create a TransformListener (and Buffer) automatically if not provided
+  explicit FrameManager(std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
+                        std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::shared_ptr<tf2_ros::TransformListener>());
 
   /** @brief Destructor.
    *
@@ -168,7 +147,7 @@ public:
   /** @brief Clear the internal cache. */
   void update();
 
-  /** @brief Check to see if a frame exists in the tf::TransformListener.
+  /** @brief Check to see if a frame exists in our tf buffer.
    * @param[in] frame The name of the frame to check.
    * @param[in] time Dummy parameter, not actually used.
    * @param[out] error If the frame does not exist, an error message is stored here.
@@ -182,31 +161,12 @@ public:
    * @return true if the transform is not known, false if it is. */
   bool transformHasProblems(const std::string& frame, ros::Time time, std::string& error);
 
-  /** @brief Connect a tf::MessageFilter's callbacks to success and failure handler functions in this FrameManager. 
-   * @param filter The tf::MessageFilter to connect to.
-   * @param display The Display using the filter.
-   *
-   * FrameManager has internal functions for handling success and
-   * failure of tf::MessageFilters which call Display::setStatus()
-   * based on success or failure of the filter, including appropriate
-   * error messages. */
-  template<class M>
-  [[deprecated("use a tf2_ros::MessageFilter instead")]]
-  void registerFilterForTransformStatusCheck(tf::MessageFilter<M>* filter, Display* display)
-  {
-    filter->registerCallback(boost::bind(&FrameManager::messageCallback<M>, this, _1, display));
-    filter->registerFailureCallback(boost::bind(
-      &FrameManager::failureCallback<M, tf::FilterFailureReason>, this, _1, _2, display
-    ));
-  }
-
   /** Connect success and failure callbacks to a tf2_ros::MessageFilter.
    * @param filter The tf2_ros::MessageFilter to connect to.
    * @param display The Display using the filter.
    *
-   * FrameManager has internal functions for handling success and
-   * failure of tf2_ros::MessageFilters which call Display::setStatus()
-   * based on success or failure of the filter, including appropriate
+   * FrameManager has internal functions for handling success and failure of tf2_ros::MessageFilters,
+   * which call Display::setStatus() based on success or failure of the filter, including appropriate
    * error messages. */
   template<class M>
   void registerFilterForTransformStatusCheck(tf2_ros::MessageFilter<M>* filter, Display* display)
@@ -220,30 +180,7 @@ public:
   /** @brief Return the current fixed frame name. */
   const std::string& getFixedFrame() { return fixed_frame_; }
 
-  /** @brief Return the tf::TransformListener used to receive transform data. */
-  [[deprecated("use getTF2BufferPtr() instead")]]
-  tf::TransformListener* getTFClient() { return tf_.get(); }
-
-  /** @brief Return a boost shared pointer to the tf::TransformListener used to receive transform data. */
-  [[deprecated("use getTF2BufferPtr() instead")]]
-  const boost::shared_ptr<tf::TransformListener>& getTFClientPtr() { return tf_; }
-
-  const std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() { return tf_->getTF2BufferPtr(); }
-
-  /** @brief Create a description of a transform problem.
-   * @param frame_id The name of the frame with issues.
-   * @param stamp The time for which the problem was detected.
-   * @param caller_id Dummy parameter, not used.
-   * @param reason The reason given by the tf::MessageFilter in its failure callback.
-   * @return An error message describing the problem.
-   *
-   * Once a problem has been detected with a given frame or transform,
-   * call this to get an error message describing the problem. */
-  [[deprecated("used tf2 version instead")]]
-  std::string discoverFailureReason(const std::string& frame_id,
-                                    const ros::Time& stamp,
-                                    const std::string& caller_id,
-                                    tf::FilterFailureReason reason);
+  const std::shared_ptr<tf2_ros::Buffer> getTF2BufferPtr() { return tf_buffer_; }
 
   /** Create a description of a transform problem.
    * @param frame_id The name of the frame with issues.
@@ -304,18 +241,7 @@ private:
     TfFilterFailureReasonType reason,
     Display* display)
   {
-    // TODO(wjwwood): remove this when only Tf2 is supported
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
     std::string status_text = discoverFailureReason( frame_id, stamp, caller_id, reason );
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
     messageFailedImpl(caller_id, status_text, display);
   }
 
@@ -355,8 +281,10 @@ private:
   boost::mutex cache_mutex_;
   M_Cache cache_;
 
-  boost::shared_ptr<tf::TransformListener> tf_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::string fixed_frame_;
+  tf2::CompactFrameID fixed_frame_id_;
 
   bool pause_;
 

--- a/src/rviz/helpers/tf_prefix.h
+++ b/src/rviz/helpers/tf_prefix.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, Bielefeld University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Bielefeld University nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <string>
+
+namespace rviz
+{
+
+std::string concat(const std::string& prefix, const std::string& frame)
+{
+  if (prefix.empty())
+    return frame;
+
+  std::string composite = prefix;
+  composite.append("/");
+  composite.append(frame);
+  return composite;
+}
+
+} // namespace rviz

--- a/src/rviz/properties/tf_frame_property.cpp
+++ b/src/rviz/properties/tf_frame_property.cpp
@@ -86,17 +86,7 @@ void TfFrameProperty::setFrameManager( FrameManager* frame_manager )
 void TfFrameProperty::fillFrameList()
 {
   std::vector<std::string> std_frames;
-  // TODO(wjwwood): remove this and use tf2 interface instead
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-  frame_manager_->getTFClient()->getFrameStrings( std_frames );
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
+  frame_manager_->getTF2BufferPtr()->_getFrameStrings( std_frames );
   std::sort( std_frames.begin(), std_frames.end() );
 
   clearOptions();

--- a/src/rviz/robot/tf_link_updater.cpp
+++ b/src/rviz/robot/tf_link_updater.cpp
@@ -29,8 +29,7 @@
 
 #include "tf_link_updater.h"
 #include <rviz/frame_manager.h>
-
-#include <tf/tf.h>
+#include <rviz/helpers/tf_prefix.h>
 
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
@@ -48,11 +47,7 @@ TFLinkUpdater::TFLinkUpdater(FrameManager* frame_manager, const StatusCallback& 
 bool TFLinkUpdater::getLinkTransforms(const std::string& _link_name, Ogre::Vector3& visual_position, Ogre::Quaternion& visual_orientation,
                                       Ogre::Vector3& collision_position, Ogre::Quaternion& collision_orientation) const
 {
-  std::string link_name = _link_name;
-  if (!tf_prefix_.empty())
-  {
-    link_name = tf::resolve(tf_prefix_, link_name);
-  }
+  std::string link_name = concat(tf_prefix_, _link_name);
 
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;

--- a/src/rviz/validate_quaternions.h
+++ b/src/rviz/validate_quaternions.h
@@ -33,7 +33,7 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <OgreQuaternion.h>
 #include <ros/ros.h>
-#include <tf/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.h>
 
 #include <boost/array.hpp>
 
@@ -122,7 +122,7 @@ inline bool validateQuaternions( const Ogre::Quaternion& quaternion )
   return validateQuaternions( quaternion.w, quaternion.x, quaternion.y, quaternion.z );
 }
 
-inline bool validateQuaternions( const tf::Quaternion& quaternion )
+inline bool validateQuaternions( const tf2::Quaternion& quaternion )
 {
   return validateQuaternions( quaternion.w(), quaternion.x(), quaternion.y(), quaternion.z());
 }

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -166,7 +166,7 @@ VisualizationManager::VisualizationManager(
   ip->setIcon( loadPixmap("package://rviz/icons/options.png") );
   global_options_ = ip;
 
-  fixed_frame_property_ = new TfFrameProperty( "Fixed Frame", "/map",
+  fixed_frame_property_ = new TfFrameProperty( "Fixed Frame", "map",
                                                "Frame into which all data is transformed before being displayed.",
                                                global_options_, frame_manager_, false,
                                                SLOT( updateFixedFrame() ), this );

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -51,9 +51,6 @@
 #include <boost/filesystem.hpp>
 #include <utility>
 
-
-#include <tf/transform_listener.h>
-
 #include <ros/package.h>
 #include <ros/callback_queue.h>
 
@@ -117,21 +114,11 @@ public:
   boost::mutex render_mutex_;
 };
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-VisualizationManager::VisualizationManager(RenderPanel* render_panel, WindowManagerInterface * wm)
-: VisualizationManager(render_panel, wm, boost::shared_ptr<tf::TransformListener>())
-{}
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
 VisualizationManager::VisualizationManager(
   RenderPanel* render_panel,
   WindowManagerInterface* wm,
-  const boost::shared_ptr<tf::TransformListener>& tf)
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener)
 : ogre_root_( Ogre::Root::getSingletonPtr() )
 , update_timer_(nullptr)
 , shutting_down_(false)
@@ -146,16 +133,7 @@ VisualizationManager::VisualizationManager(
   // visibility_bit_allocator_ is listed after default_visibility_bit_ (and thus initialized later be default):
   default_visibility_bit_ = visibility_bit_allocator_.allocBit();
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
-  frame_manager_ = new FrameManager(tf);
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
+  frame_manager_ = new FrameManager(std::move(tf_buffer), std::move(tf_listener));
 
   render_panel->setAutoRender(false);
 
@@ -415,51 +393,16 @@ void VisualizationManager::updateTime()
 
 void VisualizationManager::updateFrames()
 {
-  typedef std::vector<std::string> V_string;
-  V_string frames;
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  frame_manager_->getTFClient()->getFrameStrings( frames );
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
-  // Check the fixed frame to see if it's ok
-  std::string error;
-  if( frame_manager_->frameHasProblems( getFixedFrame().toStdString(), ros::Time(), error ))
+  if (!frame_manager_->getTF2BufferPtr()->_frameExists(getFixedFrame().toStdString()))
   {
-    if( frames.empty() )
-    {
-      // fixed_prop->setToWarn();
-      std::stringstream ss;
-      ss << "No tf data.  Actual error: " << error;
-      global_status_->setStatus( StatusProperty::Warn, "Fixed Frame", QString::fromStdString( ss.str() ));
-    }
-    else
-    {
-      // fixed_prop->setToError();
-      global_status_->setStatus( StatusProperty::Error, "Fixed Frame", QString::fromStdString( error ));
-    }
+    bool no_frames = frame_manager_->getTF2BufferPtr()->allFramesAsString().empty();
+    global_status_->setStatus( no_frames ? StatusProperty::Warn : StatusProperty::Error, "Fixed Frame",
+                               no_frames ? QString("No TF data") : QString("Unknown frame %1").arg(getFixedFrame()));
   }
   else
   {
-    // fixed_prop->setToOK();
     global_status_->setStatus( StatusProperty::Ok, "Fixed Frame", "OK" );
   }
-}
-
-tf::TransformListener* VisualizationManager::getTFClient() const
-{
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  return frame_manager_->getTFClient();
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
 }
 
 std::shared_ptr<tf2_ros::Buffer> VisualizationManager::getTF2BufferPtr() const
@@ -470,15 +413,7 @@ std::shared_ptr<tf2_ros::Buffer> VisualizationManager::getTF2BufferPtr() const
 void VisualizationManager::resetTime()
 {
   root_display_group_->reset();
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  frame_manager_->getTFClient()->clear();
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
+  frame_manager_->getTF2BufferPtr()->clear();
   ros_time_begin_ = ros::Time();
   wall_clock_begin_ = ros::WallTime();
 

--- a/src/rviz/visualization_manager.h
+++ b/src/rviz/visualization_manager.h
@@ -34,6 +34,7 @@
 #include <deque>
 
 #include <ros/time.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <rviz/bit_allocator.h>
 #include <rviz/config.h>
@@ -54,11 +55,6 @@ class Light;
 namespace ros
 {
 class CallbackQueueInterface;
-}
-
-namespace tf
-{
-class TransformListener;
 }
 
 namespace rviz
@@ -106,29 +102,18 @@ public:
    * \brief Constructor
    * Creates managers and sets up global properties.
    * @param render_panel a pointer to the main render panel widget of the app.
-   * @param wm a pointer to the window manager (which is really just a
-   *        VisualizationFrame, the top-level container widget of rviz).
-   * @param tf a pointer to tf::TransformListener which will be internally used by FrameManager.
+   * @param wm a pointer to the window manager
+   *        (which is really just a VisualizationFrame, the top-level container widget of rviz).
+   * @param tf_buffer an (optional) pointer to the tf2_ros::Buffer to be used by the FrameManager
+   * @param tf_listener an (optional) pointer to the tf2_ros::TransformListener to be used
+   *        This listener's tf buffer needs to be the same as the passed tf_buffer!
+   *        Both tf_buffer and tf_listener are automatically created if not provided.
    */
   explicit VisualizationManager(
     RenderPanel* render_panel,
-    WindowManagerInterface* wm = 0);
-
-  [[deprecated(
-    "This constructor signature will be removed in the next version. "
-    "If you still need to pass a boost::shared_ptr<tf::TransformListener>, "
-    "disable the warning explicitly. "
-    "When this constructor is removed, a new optional argument will added to "
-    "the other constructor and it will take a std::pair<> containing a "
-    "std::shared_ptr<tf2_ros::Buffer> and a "
-    "std::shared_ptr<tf2_ros::TransformListener>. "
-    "However, that cannot occur until the use of tf::TransformListener is "
-    "removed internally."
-  )]]
-  VisualizationManager(
-    RenderPanel* render_panel,
-    WindowManagerInterface* wm,
-    const boost::shared_ptr<tf::TransformListener>& tf);
+    WindowManagerInterface* wm = nullptr,
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::shared_ptr<tf2_ros::Buffer>(),
+    std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::shared_ptr<tf2_ros::TransformListener>());
 
   /**
    * \brief Destructor
@@ -203,12 +188,6 @@ public:
    * @sa getFixedFrame() */
   void setFixedFrame( const QString& frame );
   
-  /**
-   * @brief Convenience function: returns getFrameManager()->getTFClient().
-   */
-  [[deprecated("use getTF2BufferPtr() instead")]]
-  tf::TransformListener* getTFClient() const;
-
   /**
    * @brief Convenience function: returns getFrameManager()->getTF2BufferPtr().
    */

--- a/src/test/arrow_marker_test.py
+++ b/src/test/arrow_marker_test.py
@@ -20,7 +20,7 @@ def make_marker(marker_type, scale, r, g, b, a):
     # make a visualization marker array for the occupancy grid
     m = Marker()
     m.action = Marker.ADD
-    m.header.frame_id = '/base_link'
+    m.header.frame_id = 'base_link'
     m.header.stamp = rospy.Time.now()
     m.ns = 'marker_test_%d' % marker_type
     m.id = 0
@@ -42,7 +42,7 @@ def make_arrow_points_marker(scale, tail, tip, idnum):
     # make a visualization marker array for the occupancy grid
     m = Marker()
     m.action = Marker.ADD
-    m.header.frame_id = '/base_link'
+    m.header.frame_id = 'base_link'
     m.header.stamp = rospy.Time.now()
     m.ns = 'points_arrows'
     m.id = idnum

--- a/src/test/cloud_test.cpp
+++ b/src/test/cloud_test.cpp
@@ -1,10 +1,7 @@
-#include "ros/ros.h"
-
+#include <ros/ros.h>
 #include <limits>
 
-#include "sensor_msgs/PointCloud.h"
-
-#include <tf/transform_broadcaster.h>
+#include <sensor_msgs/PointCloud.h>
 
 int main( int argc, char** argv )
 {
@@ -18,17 +15,12 @@ int main( int argc, char** argv )
   ros::Publisher million_pub = n.advertise<sensor_msgs::PointCloud>( "million_points_cloud_test", 0 );
   ros::Publisher changing_channels_pub = n.advertise<sensor_msgs::PointCloud>( "changing_channels_test", 0 );
 
-  tf::TransformBroadcaster tf_broadcaster;
-
   ros::Duration(0.1).sleep();
 
   int i = 0;
   while (n.ok())
   {
     ros::Time tm(ros::Time::now());
-    tf::Transform t;
-    t.setIdentity();
-    //    tf_broadcaster.sendTransform(tf::Stamped<tf::Transform>(t, tm, "base", "map"));
 
     ROS_INFO("Publishing");
 

--- a/src/test/cloud_test.cpp
+++ b/src/test/cloud_test.cpp
@@ -32,7 +32,7 @@ int main( int argc, char** argv )
       if (cloud.channels.empty())
       {
         cloud.header.stamp = tm;
-        cloud.header.frame_id = "/base_link";
+        cloud.header.frame_id = "base_link";
 
         cloud.channels.resize(1);
         int32_t xcount = 100;
@@ -67,7 +67,7 @@ int main( int argc, char** argv )
     {
       sensor_msgs::PointCloud cloud;
       cloud.header.stamp = tm;
-      cloud.header.frame_id = "/base_link";
+      cloud.header.frame_id = "base_link";
 
       cloud.points.resize(5);
       cloud.channels.resize(2);
@@ -111,7 +111,7 @@ int main( int argc, char** argv )
     {
       sensor_msgs::PointCloud cloud;
       cloud.header.stamp = tm;
-      cloud.header.frame_id = "/base_link";
+      cloud.header.frame_id = "base_link";
 
       cloud.points.resize(5);
       cloud.channels.resize(3);
@@ -160,7 +160,7 @@ int main( int argc, char** argv )
     {
       sensor_msgs::PointCloud cloud;
       cloud.header.stamp = tm;
-      cloud.header.frame_id = "/base_link";
+      cloud.header.frame_id = "base_link";
 
       int num_rows = 1;
       int num_cols = 200;

--- a/src/test/image_test.cpp
+++ b/src/test/image_test.cpp
@@ -13,7 +13,7 @@ int main( int argc, char** argv )
   ros::Duration(0.1).sleep();
 
   sensor_msgs::Image red_image;
-  red_image.header.frame_id = "/base_link";
+  red_image.header.frame_id = "base_link";
   red_image.header.stamp = ros::Time::now();
   red_image.height = 100;
   red_image.width = 100;

--- a/src/test/interactive_marker_test.cpp
+++ b/src/test/interactive_marker_test.cpp
@@ -40,7 +40,7 @@ visualization_msgs::InteractiveMarker makeMarker( float r, float g, float b )
 {
   // create an interactive marker for our server
   visualization_msgs::InteractiveMarker int_marker;
-  int_marker.header.frame_id = "/base_link";
+  int_marker.header.frame_id = "base_link";
   int_marker.name = "my_marker";
   int_marker.description = "Simple 1-DOF Control";
 
@@ -118,7 +118,7 @@ visualization_msgs::InteractiveMarker makeCrazyMarker( bool linear )
 {
   // create an interactive marker for our server
   visualization_msgs::InteractiveMarker int_marker;
-  int_marker.header.frame_id = "/base_link";
+  int_marker.header.frame_id = "base_link";
   int_marker.name = "crazy_marker";
   int_marker.description = "Unusual 1-DOF Control";
 

--- a/src/test/map_test.py
+++ b/src/test/map_test.py
@@ -16,7 +16,7 @@ t = 0
 
 while not rospy.is_shutdown():
 
-    grid.header.frame_id = "/map"
+    grid.header.frame_id = "map"
     grid.header.stamp = rospy.Time.now()
     grid.info.map_load_time = rospy.Time.now()
     grid.info.resolution = 1.0

--- a/src/test/marker_array_test.py
+++ b/src/test/marker_array_test.py
@@ -19,7 +19,7 @@ MARKERS_MAX = 100
 while not rospy.is_shutdown():
 
    marker = Marker()
-   marker.header.frame_id = "/base_link"
+   marker.header.frame_id = "base_link"
    marker.type = marker.SPHERE
    marker.action = marker.ADD
    marker.scale.x = 0.2

--- a/src/test/marker_test.cpp
+++ b/src/test/marker_test.cpp
@@ -10,7 +10,7 @@
 ros::Publisher g_marker_pub;
 
 void emitRow(const std::string& type_name, uint32_t type, int32_t x_pos, float r, float g, float b,
-    const ros::Duration& lifetime, ros::Publisher& pub, bool frame_locked = true, const std::string& frame_id = std::string("/base_link"),
+    const ros::Duration& lifetime, ros::Publisher& pub, bool frame_locked = true, const std::string& frame_id = std::string("base_link"),
     float sx = 1.0, float sy = 1.0, float sz = 1.0)
 {
   static uint32_t count = 0;
@@ -71,7 +71,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
   x_pos += 3;
   emitRow("cubes", visualization_msgs::Marker::CUBE, x_pos, 0.0, 1.0, 0.0, ros::Duration(), g_marker_pub);
   x_pos += 3;
-  emitRow("cubes_frame_locked", visualization_msgs::Marker::CUBE, x_pos, 1.0, 1.0, 0.0, ros::Duration(), g_marker_pub, true, "/my_link");
+  emitRow("cubes_frame_locked", visualization_msgs::Marker::CUBE, x_pos, 1.0, 1.0, 0.0, ros::Duration(), g_marker_pub, true, "my_link");
   x_pos += 3;
   emitRow("spheres", visualization_msgs::Marker::SPHERE, x_pos, 0.0, 0.0, 1.0, ros::Duration(), g_marker_pub);
   x_pos += 3;
@@ -103,7 +103,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
     for (int i = -5; i <= 5; ++i)
     {
       visualization_msgs::Marker marker;
-      marker.header.frame_id = "/base_link";
+      marker.header.frame_id = "base_link";
       marker.header.stamp = ros::Time::now();
       marker.ns = "marker_test_arrow_by_points";
       marker.id = i;
@@ -145,7 +145,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_cube_list";
     marker.id = 0;
@@ -187,7 +187,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_cube_list_color_per";
     marker.id = 0;
@@ -236,7 +236,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_point_list_alpha_per";
     marker.id = 0;
@@ -287,7 +287,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_sphere_list";
     marker.id = 0;
@@ -336,7 +336,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_points";
     marker.id = 0;
@@ -378,7 +378,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_points_color_per";
     marker.id = 0;
@@ -428,7 +428,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
   {
     int count = 10;
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_line_list";
     marker.id = 0;
@@ -467,7 +467,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
   {
     int count = 10;
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_line_list_color_per";
     marker.id = 0;
@@ -515,7 +515,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_line_strip";
     marker.id = 0;
@@ -550,7 +550,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_line_strip_color_per";
     marker.id = 0;
@@ -594,7 +594,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_triangle_list";
     marker.id = 0;
@@ -656,7 +656,7 @@ void publishCallback(const ros::TimerEvent& /*unused*/)
 
   {
     visualization_msgs::Marker marker;
-    marker.header.frame_id = "/base_link";
+    marker.header.frame_id = "base_link";
     marker.header.stamp = ros::Time::now();
     marker.ns = "marker_test_mesh_color_change";
     marker.id = 0;

--- a/src/test/mesh_marker_test.cpp
+++ b/src/test/mesh_marker_test.cpp
@@ -9,7 +9,7 @@ void
 publishText(int& id, float x, float y, const std::string & text)
 {
   visualization_msgs::Marker marker;
-  marker.header.frame_id = "/base_link";
+  marker.header.frame_id = "base_link";
   marker.header.stamp = ros::Time::now();
   marker.ns = "mesh";
   marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
@@ -40,7 +40,7 @@ publishMesh(
   using visualization_msgs::Marker;
 
   Marker marker;
-  marker.header.frame_id = "/base_link";
+  marker.header.frame_id = "base_link";
   marker.header.stamp = ros::Time::now();
   marker.ns = "mesh";
   switch (mesh)

--- a/src/test/mesh_marker_test.cpp
+++ b/src/test/mesh_marker_test.cpp
@@ -1,10 +1,7 @@
-#include "ros/ros.h"
+#include <ros/ros.h>
 
-#include "visualization_msgs/Marker.h"
-#include "visualization_msgs/MarkerArray.h"
-
-#include <tf/transform_broadcaster.h>
-#include <tf/tf.h>
+#include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
 
 ros::Publisher g_marker_pub;
 

--- a/src/test/mock_context.h
+++ b/src/test/mock_context.h
@@ -43,7 +43,6 @@ public:
   virtual WindowManagerInterface* getWindowManager() const { return 0; }
   virtual SelectionManager* getSelectionManager() const { return 0; }
   virtual FrameManager* getFrameManager() const { return 0; }
-  virtual tf::TransformListener* getTFClient() const { return 0; }
   virtual QString getFixedFrame() const { return ""; }
   virtual uint64_t getFrameCount() const { return 0; }
   virtual DisplayFactory* getDisplayFactory() const { return display_factory_; }

--- a/src/test/posearray.py
+++ b/src/test/posearray.py
@@ -13,7 +13,7 @@ rospy.init_node('posearray')
 while not rospy.is_shutdown():
 
    ps = PoseArray()
-   ps.header.frame_id = "/base_link"
+   ps.header.frame_id = "base_link"
    ps.header.stamp = rospy.Time.now()
    
    pose = Pose()

--- a/src/test/publish_test_map.py
+++ b/src/test/publish_test_map.py
@@ -10,7 +10,7 @@ rospy.init_node('test_map')
 
 _map = OccupancyGrid()
 _map.header.stamp = rospy.get_rostime()
-_map.header.frame_id = '/map'
+_map.header.frame_id = 'map'
 _map.info.resolution = .1
 _map.info.width = 16
 _map.info.height = 16

--- a/src/test/rviz_logo_marker.cpp
+++ b/src/test/rviz_logo_marker.cpp
@@ -13,7 +13,7 @@ void makeMarker( )
 {
   // create an interactive marker for our server
   visualization_msgs::InteractiveMarker int_marker;
-  int_marker.header.frame_id = "/rviz_logo";
+  int_marker.header.frame_id = "rviz_logo";
   int_marker.name = "R";
 
   int_marker.pose.orientation.x = 0.0;

--- a/src/test/rviz_logo_marker.cpp
+++ b/src/test/rviz_logo_marker.cpp
@@ -4,8 +4,8 @@
 #include "visualization_msgs/MarkerArray.h"
 #include "interactive_markers/interactive_marker_server.h"
 
-#include <tf/tf.h>
-#include <tf/transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 interactive_markers::InteractiveMarkerServer* server;
 
@@ -26,7 +26,7 @@ void makeMarker( )
   visualization_msgs::Marker marker;
   marker.type = visualization_msgs::Marker::MESH_RESOURCE;
 
-  tf::quaternionTFToMsg( tf::Quaternion( tf::Vector3(0, 0, 1), 0.2 ), marker.pose.orientation );
+  tf2::convert(tf2::Quaternion(tf2::Vector3(0, 0, 1), 0.2), marker.pose.orientation);
 
   marker.pose.position.x = 0;
   marker.pose.position.y = -0.22;
@@ -80,22 +80,26 @@ void makeMarker( )
   server->applyChanges();
 }
 
-void publishCallback(tf::TransformBroadcaster&  /*tf_broadcaster*/, const ros::TimerEvent& /*unused*/)
+void publishCallback(const ros::TimerEvent& /*unused*/)
 {
-  static tf::TransformBroadcaster br;
-  tf::Transform transform;
-  transform.setOrigin( tf::Vector3(3, 1, 0) );
-  transform.setRotation( tf::createQuaternionFromRPY(0, 0, M_PI * 0.9) );
-  br.sendTransform(tf::StampedTransform(transform, ros::Time::now(), "base_link", "rviz_logo"));
+  static tf2_ros::TransformBroadcaster br;
+  geometry_msgs::TransformStamped transform;
+  tf2::convert(tf2::Vector3(3, 1, 0), transform.transform.translation);
+  tf2::Quaternion q;
+  q.setRPY(0, 0, M_PI * 0.9);
+  tf2::convert(q, transform.transform.rotation);
+  transform.header.frame_id = "base_link";
+  transform.header.stamp = ros::Time::now();
+  transform.child_frame_id = "rviz_logo";
+  br.sendTransform(transform);
 }
 
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "rviz_logo_marker");
   ros::NodeHandle n;
-  tf::TransformBroadcaster tf_broadcaster;
 
-  ros::Timer publish_timer = n.createTimer(ros::Duration(0.1), boost::bind(&publishCallback,tf_broadcaster,_1));
+  ros::Timer publish_timer = n.createTimer(ros::Duration(0.1), boost::bind(&publishCallback, _1));
 
   server = new interactive_markers::InteractiveMarkerServer("rviz_logo");
   makeMarker( );

--- a/src/test/send_bad_pc2.py
+++ b/src/test/send_bad_pc2.py
@@ -30,7 +30,7 @@ pfz.count = 1
 
 pc = PointCloud2()
 
-pc.header.frame_id = "/map"
+pc.header.frame_id = "map"
 pc.header.stamp = rospy.Time.now()
 
 pc.fields = [ pfx, pfy, pfz ]

--- a/src/test/send_covariance_msgs.py
+++ b/src/test/send_covariance_msgs.py
@@ -59,7 +59,7 @@ while not rospy.is_shutdown():
 
     # Define static pose with covariance
     pose_with_cov = PoseWithCovarianceStamped()
-    pose_with_cov.header.frame_id = "/base_link"
+    pose_with_cov.header.frame_id = "base_link"
     pose_with_cov.header.stamp = stamp
 
     pose_with_cov.pose.pose.position.x = 3
@@ -78,7 +78,7 @@ while not rospy.is_shutdown():
 
     # Define a dynamic pose that should move inside the deviation
     pose = PoseStamped()
-    pose.header.frame_id = "/base_link"
+    pose.header.frame_id = "base_link"
     pose.header.stamp = stamp
 
     pose.pose.position.x = pose_with_cov.pose.pose.position.x + linear_deviation*cos( 10 * angle )

--- a/src/test/send_efforts.py
+++ b/src/test/send_efforts.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from sensor_msgs.msg import JointState
+from math import pi, sin
+import rospy
+
+topic = 'joint_states'
+publisher = rospy.Publisher(topic, JointState, queue_size=1)
+rospy.init_node('send_efforts')
+
+t = 0
+msg = JointState()
+msg.name = ['panda_joint1', 'panda_joint2', 'panda_joint3', 'panda_joint4', 'panda_joint5',
+'panda_joint6', 'panda_joint7', 'panda_finger_joint1']
+N = len(msg.name)
+msg.position = [0. for i in range(N)]
+
+while not rospy.is_shutdown():
+	msg.header.stamp = rospy.Time.now()
+	msg.effort = [10. * sin(t) for i in range(N)]
+	publisher.publish(msg)
+	t = t + 0.1
+	rospy.sleep(0.1)

--- a/src/test/send_odometry.py
+++ b/src/test/send_odometry.py
@@ -13,7 +13,7 @@ y = 0
 while not rospy.is_shutdown():
 
    odo = Odometry()
-   odo.header.frame_id = "/base_link"
+   odo.header.frame_id = "base_link"
    odo.header.stamp = rospy.Time.now()
    
    odo.pose.pose.position.x = 0

--- a/src/test/send_path.py
+++ b/src/test/send_path.py
@@ -18,7 +18,7 @@ timestep = rate.sleep_dur.to_sec()
 while not rospy.is_shutdown():
 
    p = Path()
-   p.header.frame_id = "/base_link"
+   p.header.frame_id = "base_link"
    p.header.stamp = rospy.Time.now()
    
    num_points = 50

--- a/src/test/send_point.py
+++ b/src/test/send_point.py
@@ -14,7 +14,7 @@ t = 0
 while not rospy.is_shutdown():
 
    p = PointStamped()
-   p.header.frame_id = "/base_link"
+   p.header.frame_id = "base_link"
    p.header.stamp = rospy.Time.now()
    
    r = 5.0

--- a/src/test/send_polygon.py
+++ b/src/test/send_polygon.py
@@ -15,7 +15,7 @@ t = 0
 while not rospy.is_shutdown():
 
    p = PolygonStamped()
-   p.header.frame_id = "/base_link"
+   p.header.frame_id = "base_link"
    p.header.stamp = rospy.Time.now()
    
    dr = 0.5 * math.cos( t )

--- a/src/test/send_pose.py
+++ b/src/test/send_pose.py
@@ -14,7 +14,7 @@ t = 0
 while not rospy.is_shutdown():
 
    p = PoseStamped()
-   p.header.frame_id = "/base_link"
+   p.header.frame_id = "base_link"
    p.header.stamp = rospy.Time.now()
    
    r = 5.0

--- a/src/test/send_range.py
+++ b/src/test/send_range.py
@@ -14,7 +14,7 @@ dist = 3
 while not rospy.is_shutdown():
 
    r = Range()
-   r.header.frame_id = "/moon"
+   r.header.frame_id = "moon"
    r.header.stamp = rospy.Time.now()
    
    r.radiation_type = 0

--- a/src/test/send_two_clouds.py
+++ b/src/test/send_two_clouds.py
@@ -47,7 +47,7 @@ rospy.init_node('send_two_clouds')
 cloud = PointCloud()
 while not rospy.is_shutdown():
 
-    cloud.header.frame_id = "/base_link"
+    cloud.header.frame_id = "base_link"
     cloud.header.stamp = rospy.Time.now()
    
     cloud.points = [

--- a/src/test/send_wrench.py
+++ b/src/test/send_wrench.py
@@ -14,7 +14,7 @@ t = 0
 while not rospy.is_shutdown():
 
    p = WrenchStamped()
-   p.header.frame_id = "/base_link"
+   p.header.frame_id = "base_link"
    p.header.stamp = rospy.Time.now()
    
    f = 0.5 * math.sin(t);


### PR DESCRIPTION
This is the only blocker for the upcoming Noetic release (cf. #1498).
I started the migration process as follows:
- [x] Update `InteractiveMarkerDisplay` (8995e37c713d3d7efddaa5b7880c6594c831fe45)
- [x] Replace deprecated `getTFClient()` with `getTF2BufferPtr()`
  - [x] in `TfFrameProperty` (03a732fbf70c0e4c630492bc2f9d3e938f3d47ae)
  - [x] in `TfDisplay`
  - [x] in `InteractiveMarker`
  - [x] in `LaserScanDisplay`
- [x] Use (already migrated) `MessageFilterDisplay` for all remaining displays:
  - [x] `GridCellsDisplay`, which manually reimplements the logic of a `MessageFilterDisplay`
  - [x] `EffortDisplay`, which uses `MessageFilterJointState`, a custom re-imlementation of `tf::MessageFilter`
- [x] Adapt FrameManager and VisualizationManager to use `tf2_ros::Buffer`.
- [x] Remove all tf1-related, already deprecated functions.

Any help is highly appreciated, @jschleicher or @simonschmeisser?