### PR TITLE
[melodic] Compatibility fix for OGRE 1.10.4 and up.

### DIFF
--- a/src/rviz/ogre_helpers/movable_text.h
+++ b/src/rviz/ogre_helpers/movable_text.h
@@ -203,7 +203,11 @@ protected:
     return mAABB;
   }
 
+#if ((OGRE_VERSION_MAJOR >= 1 && OGRE_VERSION_MINOR >= 10 && OGRE_VERSION_PATCH >= 4) || OGRE_VERSION_MAJOR >= 2)
+  const Ogre::String& getName() const
+#else
   const Ogre::String& getName() const override
+#endif
   {
     return mName;
   }

--- a/src/rviz/ogre_helpers/movable_text.h
+++ b/src/rviz/ogre_helpers/movable_text.h
@@ -47,7 +47,7 @@
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreSharedPtr.h>
-
+#include <rviz/ogre_helpers/version_check.h>
 
 namespace Ogre
 {
@@ -203,7 +203,7 @@ protected:
     return mAABB;
   }
 
-#if ((OGRE_VERSION_MAJOR >= 1 && OGRE_VERSION_MINOR >= 10 && OGRE_VERSION_PATCH >= 4) || OGRE_VERSION_MAJOR >= 2)
+#if OGRE_VERSION >= OGRE_VERSION_CHECK(1,10,4)
   const Ogre::String& getName() const
 #else
   const Ogre::String& getName() const override


### PR DESCRIPTION
A recent [lint](https://github.com/ros-visualization/rviz/pull/1502) fix causes a build break when building RViz with OGRE v1.10.4 and up.

This pull request is attempting to make the RViz to be compatible with  OGRE 1.10.4 and up again. And here is some context:

Since OGRE v1.10.4, the signature of [`OgreMovableObject::getName`](https://github.com/OGRECave/ogre/blob/v1.10.4/OgreMain/include/OgreMovableObject.h#L204) is no longer a virtual function. To accommodate that, conditionally declare the matched signature of `getName()` for `rviz::MovableText`.
