### PR TITLE
PropertyTree: set custom SelectionModel only with valid model

### DIFF
--- a/src/rviz/properties/property_tree_widget.cpp
+++ b/src/rviz/properties/property_tree_widget.cpp
@@ -103,11 +103,12 @@ void PropertyTreeWidget::setModel(PropertyTreeModel* model)
   }
   model_ = model;
   QTreeView::setModel(model_);
-  QItemSelectionModel* m = selectionModel();
-  setSelectionModel(new PropertySelectionModel(model_));
-  m->deleteLater();
   if (model_)
   {
+    QItemSelectionModel* m = selectionModel();
+    setSelectionModel(new PropertySelectionModel(model_));
+    m->deleteLater();
+
     connect(model_, SIGNAL(propertyHiddenChanged(const Property*)), this,
             SLOT(propertyHiddenChanged(const Property*)), Qt::QueuedConnection);
     connect(model_, SIGNAL(expand(const QModelIndex&)), this, SLOT(expand(const QModelIndex&)));


### PR DESCRIPTION
This seems to be a corner-case one might actually call a bug in qt5.
the `setSelectionModel(new PropertySelectionModel(nullptr))` call
complains that the SelectionModel and the PropertyTreeView use different
models, although both are set to nullptr in user code.

Qt actually sets the model of QAbstractItemView to
the dummy `QAbstractItemModelPrivate::staticEmptyModel`, but the
SelectionModel is actually initialized with `nullptr`.