### PR TITLE
Fix memory access in case of 3-byte pixel formats

### DIFF
--- a/src/rviz/selection/selection_manager.cpp
+++ b/src/rviz/selection/selection_manager.cpp
@@ -582,17 +582,20 @@ void SelectionManager::unpackColors(const Ogre::PixelBox& box, V_CollObject& pix
 
   pixels.clear();
   pixels.reserve(w * h);
+  size_t size = Ogre::PixelUtil::getMemorySize(1, 1, 1, box.format);
 
   for (int y = 0; y < h; y++)
   {
     for (int x = 0; x < w; x++)
     {
-      uint32_t pos = (x + y * w) * 4;
-
-      uint32_t pix_val = *(uint32_t*)((uint8_t*)box.data + pos);
-      uint32_t handle = colorToHandle(box.format, pix_val);
-
-      pixels.push_back(handle);
+      if (size == 4) // In case of a 4-byte color format, we can directly process the 32-bit values
+      {
+        uint32_t pos = (x + y * w) * 4;
+        uint32_t pix_val = *(uint32_t*)((uint8_t*)box.data + pos);
+        pixels.push_back(colorToHandle(box.format, pix_val));
+      }
+      else
+        pixels.push_back(colorToHandle(const_cast<Ogre::PixelBox&>(box).getColourAt(x, y, 1)));
     }
   }
 }


### PR DESCRIPTION
This fixes an invalid memory access found in https://github.com/ros-visualization/rviz/issues/1508#issuecomment-636570064:

While the memory array allocated for Ogre::PixelBox is considering the pixel format size here:
https://github.com/ros-visualization/rviz/blob/171eb3cfd1ec69cb6ff72da3ca41a1a4caa74eef/src/rviz/selection/selection_manager.cpp#L778-L779

the unpacking routine always assumes that the pixel format is 4 bytes here:
https://github.com/ros-visualization/rviz/blob/171eb3cfd1ec69cb6ff72da3ca41a1a4caa74eef/src/rviz/selection/selection_manager.cpp#L590-L593

This is failing if the pixel format is 3 bytes only...
Unfortunately. `PixelBox::getColourAt()` transforms the bytes into float values, which we transform back subsequently to bytes... That's a lot more overhead :cry: