### PR TITLE
fix getName override

### DIFF
--- a/src/rviz/ogre_helpers/movable_text.h
+++ b/src/rviz/ogre_helpers/movable_text.h
@@ -203,7 +203,7 @@ protected:
     return mAABB;
   }
 
-  const Ogre::String& getName() const override
+  const Ogre::String& getName() const
   {
     return mName;
   }


### PR DESCRIPTION
Without this patch, I get the following compile time error:

```
/home/wolfv/Programs/catkin_ws/src/rviz/src/rviz/ogre_helpers/movable_text.h:206:23: error: ‘const String& rviz::MovableText::getName() const’ marked ‘override’, but does not override
  206 |   const Ogre::String& getName() const override
      |                       ^~~~~~~
```

I am not sure about the implications -- did this change with the OGRE version?
For reference, I am using OGRE 1.10.12 and QT 5.12.5