### PR TITLE
Fix OSX crash

### DIFF
--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -72,6 +72,7 @@ ImageDisplay::ImageDisplay() : ImageDisplayBase(), texture_()
                       this, SLOT(updateNormalizeOptions()));
 
   got_float_image_ = false;
+  has_run_once_ = false;
 }
 
 void ImageDisplay::onInitialize()
@@ -114,12 +115,13 @@ void ImageDisplay::onInitialize()
     screen_rect_->setBoundingBox(aabInf);
     setMaterial(*screen_rect_, material_);
     img_scene_node_->attachObject(screen_rect_);
+    img_scene_node_->setVisible(false);
   }
 
   render_panel_ = new RenderPanel();
+  render_panel_->getRenderWindow()->addListener(this);
   render_panel_->getRenderWindow()->setAutoUpdated(false);
   render_panel_->getRenderWindow()->setActive(false);
-
   render_panel_->resize(640, 480);
   render_panel_->initialize(img_scene_manager_, context_);
 
@@ -136,10 +138,30 @@ ImageDisplay::~ImageDisplay()
 {
   if (initialized())
   {
+    render_panel_->getRenderWindow()->removeListener(this);
+
     delete render_panel_;
     delete screen_rect_;
     removeAndDestroyChildNode(img_scene_node_->getParentSceneNode(), img_scene_node_);
   }
+}
+
+void ImageDisplay::preRenderTargetUpdate(const Ogre::RenderTargetEvent& /*evt*/)
+{
+  if(has_run_once_)
+  {
+    img_scene_node_->setVisible(true);
+  }
+  else
+  {
+    has_run_once_ = true;
+    img_scene_node_->setVisible(false);
+  }
+}
+
+void ImageDisplay::postRenderTargetUpdate(const Ogre::RenderTargetEvent& /*evt*/)
+{
+  img_scene_node_->setVisible(false);
 }
 
 void ImageDisplay::onEnable()

--- a/src/rviz/default_plugin/image_display.h
+++ b/src/rviz/default_plugin/image_display.h
@@ -59,7 +59,7 @@ namespace rviz
  * \class ImageDisplay
  *
  */
-class ImageDisplay : public ImageDisplayBase
+class ImageDisplay : public ImageDisplayBase, public Ogre::RenderTargetListener
 {
   Q_OBJECT
 public:
@@ -70,6 +70,10 @@ public:
   void onInitialize() override;
   void update(float wall_dt, float ros_dt) override;
   void reset() override;
+
+  // Overrides from Ogre::RenderTargetListener
+  void preRenderTargetUpdate(const Ogre::RenderTargetEvent& evt) override;
+  void postRenderTargetUpdate(const Ogre::RenderTargetEvent& evt) override;
 
 public Q_SLOTS:
   virtual void updateNormalizeOptions();
@@ -98,6 +102,8 @@ private:
   FloatProperty* max_property_;
   IntProperty* median_buffer_size_property_;
   bool got_float_image_;
+
+  bool has_run_once_;
 };
 
 } // namespace rviz

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -423,7 +423,7 @@ Ogre::RenderWindow* RenderSystem::makeRenderWindow(WindowIDType window_id,
         // Created a non-stereo window.  Discard it and try again (below)
         // without the stereo parameter.
         ogre_root_->detachRenderTarget(window);
-        window->destroy();
+        ogre_root_->destroyRenderTarget(window);
         window = nullptr;
         stream << "x";
         is_stereo = false;
@@ -480,6 +480,7 @@ Ogre::RenderWindow* RenderSystem::tryMakeRenderWindow(const std::string& name,
       if (x_baddrawable_error)
       {
         ogre_root_->detachRenderTarget(window);
+        ogre_root_->destroyRenderTarget(window);
         window = nullptr;
         x_baddrawable_error = false;
       }

--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -35,6 +35,7 @@
 
 #include <OgreSceneManager.h>
 #include <OgreCamera.h>
+#include <OgreRenderWindow.h>
 
 #include <rviz/display.h>
 #include <rviz/view_controller.h>
@@ -98,6 +99,12 @@ void RenderPanel::leaveEvent(QEvent* /*event*/)
   {
     context_->setStatus("");
   }
+}
+
+void RenderPanel::resizeEvent(QResizeEvent * event)
+{
+  QWidget::resizeEvent(event);
+  render_window_->windowMovedOrResized();
 }
 
 void RenderPanel::onRenderWindowMouseEvents(QMouseEvent* event)

--- a/src/rviz/render_panel.h
+++ b/src/rviz/render_panel.h
@@ -118,6 +118,8 @@ protected:
   /// Called when any mouse event happens inside the render window
   void onRenderWindowMouseEvents(QMouseEvent* event);
 
+  void resizeEvent(QResizeEvent * event) override;
+
   // QWidget mouse events all get sent to onRenderWindowMouseEvents().
   // QMouseEvent.type() distinguishes them later.
   void mouseMoveEvent(QMouseEvent* event) override


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

- Fixes crash on OSX when adding an Image display, see https://github.com/ros-visualization/rviz/issues/1531
- Code partly taken from https://github.com/ros2/rviz/pull/319
- Rviz still crashes when adding a second Camera display for whatever reason, I hope the maintainers can help me in pointing me towards the potential reason of that crash.