### PR TITLE
More portable assimp and OGRE discovery logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ find_package(Boost REQUIRED
 find_package(urdfdom_headers REQUIRED)
 
 find_package(ASSIMP REQUIRED)
+if(NOT DEFINED ASSIMP_LIBRARIES AND TARGET assimp::assimp)
+  # ASSIMP >= 5.0 no longer defines ASSIMP_LIBRARIES
+  set(ASSIMP_LIBRARIES assimp::assimp)
+endif()
 include_directories(${ASSIMP_INCLUDE_DIRS})
 
 # OGRE doesn't come with correctly installed cmake files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,55 +32,59 @@ if(NOT DEFINED ASSIMP_LIBRARIES AND TARGET assimp::assimp)
 endif()
 include_directories(${ASSIMP_INCLUDE_DIRS})
 
-# OGRE doesn't come with correctly installed cmake files.
-# We need both, OGRE and OGRE-Overlay. Look for both simulatenously and use prefix X_
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(X OGRE OGRE-Overlay)
+find_package(OGRE QUIET COMPONENTS Overlay)
+if(NOT OGRE_FOUND)
+  # OGRE doesn't come with correctly installed cmake files on Linux. Use pkg-config instead.
+  # We need both, OGRE and OGRE-Overlay. Look for both simulatenously and use prefix X_
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(X REQUIRED OGRE OGRE-Overlay)
 
-# TODO: adapt version for Noetic release
-# Disable deprecation warnings for OGRE >= 1.10
-if(NOT X_OGRE_VERSION VERSION_LESS "1.10.0" AND NOT MSVC)
-  add_compile_options(-Wno-deprecated-declarations)
+  # Set OGRE_* variables as cmake-based find_package would do
+  set(OGRE_VERSION ${X_OGRE_VERSION})
+  set(OGRE_INCLUDE_DIRS ${X_INCLUDE_DIRS})
+  message(STATUS "OGRE_INCLUDE_DIRS=${OGRE_INCLUDE_DIRS}")
+
+  # Find absolute path of OGRE libraries.
+  # This is stored in the cache to save time on cmake re-run.
+  # Using absolute paths is necessary if pkg-config finds Ogre in a different
+  # location than the default.  This can happen when Ogre is built from source,
+  # or when 2 versions of Ogre are installed.  Using absolute paths ensures that
+  # components that link against Ogre (rviz and any packages depending on rviz)
+  # all find the same Ogre shared library.
+  if(NOT DEFINED OGRE_LIBRARIES)
+    set(_OGRE_LIBRARIES)
+    foreach(_lib ${X_LIBRARIES})
+      set(_lib_tag "OGRE_RVIZ_${_lib}")
+
+      find_library(${_lib_tag}
+              NAMES ${_lib}
+              HINTS ${X_LIBRARY_DIRS}
+              PATHS ${X_LIBRARY_DIRS}
+      )
+
+      list(APPEND _OGRE_LIBRARIES ${${_lib_tag}})
+    endforeach(_lib)
+
+    set(OGRE_LIBRARIES ${_OGRE_LIBRARIES} CACHE STRING "Absolute paths to OGRE libs")
+  endif(NOT DEFINED OGRE_LIBRARIES)
+  message(STATUS "OGRE_LIBRARIES=${OGRE_LIBRARIES}")
+
+  ## Fetch OGRE_PLUGIN_DIR variable from pkg-config
+  if(NOT DEFINED OGRE_PLUGIN_DIR)
+    execute_process(COMMAND
+      ${PKG_CONFIG_EXECUTABLE} --variable=plugindir OGRE
+      OUTPUT_VARIABLE OGRE_PLUGIN_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+  endif(NOT DEFINED OGRE_PLUGIN_DIR)
+  message(STATUS "OGRE_PLUGIN_DIR=${OGRE_PLUGIN_DIR}")
 endif()
 
-# find absolute path of ogre libraries.
-# This is stored in the cache to save time on cmake re-run.
-# Using absolute paths is necessary if pkg-config finds Ogre in a different
-# location than the default.  This can happen when Ogre is built from source,
-# or when 2 versions of Ogre are installed.  Using absolute paths ensures that
-# components that link against Ogre (rviz and any packages depending on rviz)
-# all find the same Ogre shared library.
-if(NOT DEFINED OGRE_LIBRARIES)
-  set(_OGRE_LIBRARIES)
-  foreach(_lib ${X_LIBRARIES})
-    set(_lib_tag "OGRE_RVIZ_${_lib}")
-
-    find_library(${_lib_tag}
-            NAMES ${_lib}
-            HINTS ${X_LIBRARY_DIRS}
-            PATHS ${X_LIBRARY_DIRS}
-    )
-
-    list(APPEND _OGRE_LIBRARIES ${${_lib_tag}})
-  endforeach(_lib)
-
-  set(OGRE_LIBRARIES ${_OGRE_LIBRARIES} CACHE STRING "Absolute paths to OGRE libs")
-endif(NOT DEFINED OGRE_LIBRARIES)
-message(STATUS "OGRE_LIBRARIES=${OGRE_LIBRARIES}")
-
-# Define OGRE_INCLUDE_DIRS as find_package would do
-set(OGRE_INCLUDE_DIRS ${X_INCLUDE_DIRS})
-message(STATUS "OGRE_INCLUDE_DIRS=${OGRE_INCLUDE_DIRS}")
-
-## Find OGRE Plugin path (not necessarily platform-independent, I guess)
-if(NOT DEFINED OGRE_PLUGIN_PATH)
-  execute_process(COMMAND
-    ${PKG_CONFIG_EXECUTABLE} --variable=plugindir OGRE
-    OUTPUT_VARIABLE OGRE_PLUGIN_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-endif(NOT DEFINED OGRE_PLUGIN_PATH)
-message(STATUS "OGRE_PLUGIN_PATH=${OGRE_PLUGIN_PATH}")
+# TODO: adapt version after upgrade to newer OGRE release
+# Disable deprecation warnings for OGRE >= 1.10
+if(NOT OGRE_VERSION VERSION_LESS "1.10.0" AND NOT MSVC)
+  add_compile_options(-Wno-deprecated-declarations)
+endif()
 
 if(APPLE)
   FIND_LIBRARY(Cocoa_LIBRARIES Cocoa)

--- a/src/rviz/env_config.cpp.in
+++ b/src/rviz/env_config.cpp.in
@@ -49,7 +49,7 @@ std::string get_ogre_plugin_path()
 {
   // The return string here is replaced at compile time by
   // CMakeLists.txt in this directory.
-  return "@OGRE_PLUGIN_PATH@";
+  return "@OGRE_PLUGIN_DIR@";
 }
 
 }


### PR DESCRIPTION
* assimp >= 5.0 no longer defines `ASSIMP_LIBRARIES`. A backward-compatible logic is added to link against assimp.
* Use cmake config files to locate OGRE by default and fallback to pkg-config if needed.