### PR TITLE
PropertyWidget: Limit comboboxes to column width

### DIFF
--- a/src/rviz/properties/combo_box.cpp
+++ b/src/rviz/properties/combo_box.cpp
@@ -27,12 +27,17 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "rviz/properties/combo_box.h"
+#include <rviz/properties/combo_box.h>
+#include <QAbstractItemView>
 
 namespace rviz
 {
-ComboBox::ComboBox(QWidget* parent) : QComboBox(parent)
+// allow popup list to become larger than QCombBox itself
+void ComboBox::showPopup()
 {
+  auto view = this->view();
+  view->setMinimumWidth(view->sizeHintForColumn(0));
+  QComboBox::showPopup();
 }
 
 } // end namespace rviz

--- a/src/rviz/properties/combo_box.h
+++ b/src/rviz/properties/combo_box.h
@@ -38,7 +38,8 @@ class ComboBox : public QComboBox
   Q_OBJECT
   Q_PROPERTY(QString currentText READ currentText USER true)
 public:
-  ComboBox(QWidget* parent = nullptr);
+  using QComboBox::QComboBox;
+  void showPopup() override;
 };
 
 } // end namespace rviz

--- a/src/rviz/properties/editable_enum_property.cpp
+++ b/src/rviz/properties/editable_enum_property.cpp
@@ -61,6 +61,8 @@ QWidget* EditableEnumProperty::createEditor(QWidget* parent, const QStyleOptionV
   Q_EMIT requestOptions(this);
 
   EditableComboBox* cb = new EditableComboBox(parent);
+  // avoid larger comboxbox than column width of PropertyWidget
+  cb->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
   cb->addItems(strings_);
   cb->setEditText(getValue().toString());
   QObject::connect(cb, SIGNAL(currentIndexChanged(const QString&)), this,

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -50,7 +50,8 @@ SplitterHandle::SplitterHandle(QTreeView* parent)
 bool SplitterHandle::eventFilter(QObject* event_target, QEvent* event)
 {
   if (event_target == parent_ &&
-      (event->type() == QEvent::Resize || event->type() == QEvent::LayoutRequest))
+      (event->type() == QEvent::Resize || event->type() == QEvent::LayoutRequest ||
+       event->type() == QEvent::Show))
   {
     updateGeometry();
   }


### PR DESCRIPTION
Follow up on #1545: The original fix missed some size updates. Thus, added QEvent::Show in SplitterHandle's event filter.
Also, combobox editors, created by enum properties need to be limited in width. To show the full enum texts in the drop down, this one might be wider.