### PR TITLE
Fix Windows compilation

### DIFF
--- a/src/rviz/default_plugin/screw_display.h
+++ b/src/rviz/default_plugin/screw_display.h
@@ -11,8 +11,6 @@
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/WrenchStamped.h>
 
-#include "rviz/default_plugin/rviz_default_plugin_export.h"
-
 namespace Ogre
 {
 class SceneNode;
@@ -31,7 +29,7 @@ namespace rviz
 class ScrewVisual;
 
 template <class MessageType>
-class RVIZ_DEFAULT_PLUGIN_EXPORT ScrewDisplay : public rviz::MessageFilterDisplay<MessageType>
+class ScrewDisplay : public rviz::MessageFilterDisplay<MessageType>
 {
 public:
   // Constructor.  pluginlib::ClassLoader creates instances by calling

--- a/src/rviz/default_plugin/screw_display.h
+++ b/src/rviz/default_plugin/screw_display.h
@@ -11,6 +11,8 @@
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/WrenchStamped.h>
 
+#include "rviz/default_plugin/rviz_default_plugin_export.h"
+
 namespace Ogre
 {
 class SceneNode;
@@ -29,7 +31,7 @@ namespace rviz
 class ScrewVisual;
 
 template <class MessageType>
-class RVIZ_EXPORT ScrewDisplay : public rviz::MessageFilterDisplay<MessageType>
+class RVIZ_DEFAULT_PLUGIN_EXPORT ScrewDisplay : public rviz::MessageFilterDisplay<MessageType>
 {
 public:
   // Constructor.  pluginlib::ClassLoader creates instances by calling

--- a/src/rviz/default_plugin/screw_visual.h
+++ b/src/rviz/default_plugin/screw_visual.h
@@ -4,8 +4,6 @@
 #include <geometry_msgs/Vector3.h>
 #include <OgrePrerequisites.h>
 
-#include "rviz/default_plugin/rviz_default_plugin_export.h"
-
 namespace rviz
 {
 class Arrow;
@@ -15,7 +13,7 @@ class BillboardLine;
 namespace rviz
 {
 // ScrewVisual visualizes a single screw, i.e. a wrench, twist, or acceleration
-class RVIZ_DEFAULT_PLUGIN_EXPORT ScrewVisual
+class ScrewVisual
 {
 public:
   // Constructor.  Creates the visual stuff and puts it into the scene, but in an unconfigured state.

--- a/src/rviz/default_plugin/screw_visual.h
+++ b/src/rviz/default_plugin/screw_visual.h
@@ -4,6 +4,8 @@
 #include <geometry_msgs/Vector3.h>
 #include <OgrePrerequisites.h>
 
+#include "rviz/default_plugin/rviz_default_plugin_export.h"
+
 namespace rviz
 {
 class Arrow;
@@ -13,7 +15,7 @@ class BillboardLine;
 namespace rviz
 {
 // ScrewVisual visualizes a single screw, i.e. a wrench, twist, or acceleration
-class RVIZ_EXPORT ScrewVisual
+class RVIZ_DEFAULT_PLUGIN_EXPORT ScrewVisual
 {
 public:
   // Constructor.  Creates the visual stuff and puts it into the scene, but in an unconfigured state.

--- a/src/rviz/default_plugin/wrench_visual.h
+++ b/src/rviz/default_plugin/wrench_visual.h
@@ -8,7 +8,7 @@ namespace rviz
 {
 // For API compatibility we provide the old WrenchVisual class as well
 class [[deprecated("Replace with ScrewVisual")]] WrenchVisual;
-class RVIZ_EXPORT WrenchVisual : public ScrewVisual
+class WrenchVisual : public ScrewVisual
 {
 public:
   using ScrewVisual::ScrewVisual;


### PR DESCRIPTION
The recent commit https://github.com/ros-visualization/rviz/commit/dd1779e78dbb1468fdb11968632fafd5e7a272f2 broke compilation on Windows. This PR fixes this issue.

Compiler error without this patch:
```
%SRC_DIR%\ros-noetic-rviz\src\work\src\rviz\default_plugin\screw_display.cpp(87): error C2491: 'rviz::ScrewDisplay<MessageType>::ScrewDisplay': definition of dllimport function not allowed
%SRC_DIR%\ros-noetic-rviz\src\work\src\rviz\default_plugin\screw_display.cpp(95): error C2491: 'rviz::ScrewDisplay<MessageType>::onInitialize': definition of dllimport function not allowed
%SRC_DIR%\ros-noetic-rviz\src\work\src\rviz\default_plugin\screw_display.cpp(103): error C2491: 'rviz::ScrewDisplay<MessageType>::reset': definition of dllimport function not allowed
%SRC_DIR%\ros-noetic-rviz\src\work\src\rviz\default_plugin\screw_display.cpp(125): error C2491: 'rviz::ScrewDisplay<MessageType>::updateProperties': definition of dllimport function not allowed
%SRC_DIR%\ros-noetic-rviz\src\work\src\rviz\default_plugin\screw_display.cpp(132): error C2491: 'rviz::ScrewDisplay<MessageType>::updateHistoryLength': definition of dllimport function not allowed
%SRC_DIR%\ros-noetic-rviz\src\work\src\rviz\default_plugin\screw_display.cpp(191): error C2491: 'rviz::ScrewDisplay<MessageType>::processMessagePrivate': definition of dllimport function not allowed
```

With patch compilation succeeds.