### PR TITLE
[tool] load parameters before initializing

### DIFF
--- a/src/rviz/tool.cpp
+++ b/src/rviz/tool.cpp
@@ -73,6 +73,7 @@ void Tool::setName(const QString& name)
 {
   name_ = name;
   property_container_->setName(name_);
+  Q_EMIT nameChanged(this);
 }
 
 void Tool::setDescription(const QString& description)

--- a/src/rviz/tool.cpp
+++ b/src/rviz/tool.cpp
@@ -71,9 +71,14 @@ void Tool::setCursor(const QCursor& cursor)
 
 void Tool::setName(const QString& name)
 {
+  // Early return if the name did not change
+  if (name == name_)
+    return;
+
+  // Change the name and emit a signal to let slots know
   name_ = name;
   property_container_->setName(name_);
-  Q_EMIT nameChanged(this);
+  Q_EMIT nameChanged(name_);
 }
 
 void Tool::setDescription(const QString& description)

--- a/src/rviz/tool.h
+++ b/src/rviz/tool.h
@@ -192,6 +192,7 @@ public:
 
 Q_SIGNALS:
   void close();
+  void nameChanged(Tool* tool);
 
 protected:
   /** Override onInitialize to do any setup needed after the

--- a/src/rviz/tool.h
+++ b/src/rviz/tool.h
@@ -192,7 +192,7 @@ public:
 
 Q_SIGNALS:
   void close();
-  void nameChanged(Tool* tool);
+  void nameChanged(const QString& name);
 
 protected:
   /** Override onInitialize to do any setup needed after the

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1185,6 +1185,19 @@ void VisualizationFrame::addTool(Tool* tool)
   tool_to_action_map_[tool] = action;
 
   remove_tool_menu_->addAction(tool->getName());
+
+  QObject::connect(tool, &Tool::nameChanged, this, &VisualizationFrame::onToolNameChanged);
+}
+
+void VisualizationFrame::onToolNameChanged(const QString& name)
+{
+  // Early return if the tool is not present
+  auto it = tool_to_action_map_.find(qobject_cast<Tool*>(sender()));
+  if (it == tool_to_action_map_.end())
+    return;
+
+  // Change the name of the action
+  it->second->setIconText(name);
 }
 
 void VisualizationFrame::onToolbarActionTriggered(QAction* action)

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -227,6 +227,9 @@ protected Q_SLOTS:
    * the shortcut key, onToolbarActionTriggered() is called. */
   void addTool(Tool* tool);
 
+  /** @brief React to name changes of a tool, updating the name of the associated QAction */
+  void onToolNameChanged(const QString& name);
+
   /** @brief Remove the given tool from the frame's toolbar. */
   void removeTool(Tool* tool);
 


### PR DESCRIPTION
### Description

With this PR the tool parameters will be available when `onInitialize` is called. One can use this feature to solve #1138 by adding
an `rviz::StringProperty`, e.g. named `Tool Name`, and then use its value to rename the tool in `onInitialize`.