### PR TITLE
Handle FindOGRE module's differing definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ catkin_package(
   LIBRARIES
     rviz
     ${OGRE_LIBRARIES}
+    ${OGRE_Overlay_LIBRARIES}
     ${rviz_ADDITIONAL_LIBRARIES}
     ${OPENGL_LIBRARIES}
   CATKIN_DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ catkin_package(
     ${EXPORT_HEADER_DIR}
     ${EIGEN3_INCLUDE_DIRS}
     ${OGRE_INCLUDE_DIRS}
+    ${OGRE_Overlay_INCLUDE_DIRS}
     ${OPENGL_INCLUDE_DIR}
   LIBRARIES
     rviz
@@ -217,6 +218,7 @@ include_directories(src ${EXPORT_HEADER_DIR})
 include_directories(SYSTEM
   ${EIGEN3_INCLUDE_DIRS}
   ${OGRE_INCLUDE_DIRS}
+  ${OGRE_Overlay_INCLUDE_DIRS}
   ${OPENGL_INCLUDE_DIR}
   ${PYTHON_INCLUDE_PATH}
   ${TinyXML2_INCLUDE_DIRS}

--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -137,6 +137,7 @@ target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${QT_LIBRARIES}
   ${OGRE_LIBRARIES}
+  ${OGRE_Overlay_LIBRARIES}
   ${OPENGL_LIBRARIES}
   ${rviz_ADDITIONAL_LIBRARIES}
   ${TinyXML2_LIBRARIES}
@@ -159,7 +160,7 @@ if(NOT WIN32)
   set_target_properties(executable PROPERTIES COMPILE_FLAGS "-std=c++11")
 endif()
 
-target_link_libraries(executable ${PROJECT_NAME} ${QT_LIBRARIES} ${OGRE_LIBRARIES})
+target_link_libraries(executable ${PROJECT_NAME} ${QT_LIBRARIES} ${OGRE_LIBRARIES} ${OGRE_Overlay_LIBRARIES})
 
 set_target_properties(executable
                       PROPERTIES OUTPUT_NAME ${PROJECT_NAME})


### PR DESCRIPTION
The FindOGRE CMake module sets separate include directory values for each component, so if OGRE is found using this mechanism, we need to list those directories as well.

For reference, here is where `FindOGRE` sets the per-component include directories: https://github.com/OGRECave/ogre/blob/7eaa819fb722838b0b981f2bc505726c5ee05348/CMake/Packages/FindOGRE.cmake#L468