### PR TITLE
Fixed the orientation of covariance view to match with the interpreta…

### DIFF
--- a/src/rviz/default_plugin/covariance_visual.cpp
+++ b/src/rviz/default_plugin/covariance_visual.cpp
@@ -350,12 +350,18 @@ void CovarianceVisual::setCovariance(const geometry_msgs::PoseWithCovariance& po
   // Map covariance to a Eigen::Matrix
   Eigen::Map<const Eigen::Matrix<double, 6, 6> > covariance(pose.covariance.data());
 
+  Eigen::Quaterniond qori(ori.w,ori.x,ori.y,ori.z);
+  Eigen::Matrix3d rotmat = qori.toRotationMatrix();
+  Eigen::Matrix6d covarianceRotated = covariance;
+  covarianceRotated.bottomRightCorner(3,3) = rotmat.transpose()*covariance.bottomRightCorner(3,3)*rotmat;
+
+
   updatePosition(covariance);
   if (!pose_2d_)
   {
-    updateOrientation(covariance, kRoll);
-    updateOrientation(covariance, kPitch);
-    updateOrientation(covariance, kYaw);
+    updateOrientation(covarianceRotated, kRoll);
+    updateOrientation(covarianceRotated, kPitch);
+    updateOrientation(covarianceRotated, kYaw);
   }
   else
   {


### PR DESCRIPTION
Fixed the orientation of covariance view to match with the interpretation of the covariance in e.g. `geometry_msgs::PoseWithCovariance` used by tf2. 
This means, that the "tangent covariance" on the tips of the axis vector visualizations will actually show the orientation uncertainties/noises in the frame of the world, not in the frame of the object/body as was the case previously. 