### PR TITLE
set radius first for points displayed by PointStamped display

### DIFF
--- a/src/rviz/default_plugin/point_display.cpp
+++ b/src/rviz/default_plugin/point_display.cpp
@@ -106,14 +106,14 @@ void PointStampedDisplay::processMessage(const geometry_msgs::PointStamped::Cons
 
 
   // Now set or update the contents of the chosen visual.
+  float radius = radius_property_->getFloat();
+  visual->setRadius(radius); // has to be set before setting message
   visual->setMessage(msg);
   visual->setFramePosition(position);
   visual->setFrameOrientation(orientation);
   float alpha = alpha_property_->getFloat();
-  float radius = radius_property_->getFloat();
   Ogre::ColourValue color = color_property_->getOgreColor();
   visual->setColor(color.r, color.g, color.b, alpha);
-  visual->setRadius(radius);
 
 
   // And send it to the end of the circular buffer


### PR DESCRIPTION
This PR fixes the following problem:
Currently the PointStamped display does not show added points as long as the circular buffer is filled once fully. This problem is most of the times not noticed if the history size is quite short or the topic is updated very fast. But if you have a topic with a slow rate and a long history it can take some time to fill the buffer. 

The solution is to set the radius before calling the `setMessage` function of `PointStampedVisual` as this function uses the radius to set the size of the underlying `Shape`.
