### PR TITLE
first pass at toggling visibility

### DIFF
--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -319,11 +319,6 @@ void MarkerDisplay::processAdd(const visualization_msgs::Marker::ConstPtr& messa
     }
   }
 
-  if (!ns_it.value()->isEnabled())
-  {
-    return;
-  }
-
   bool create = true;
   MarkerBasePtr marker;
 
@@ -354,6 +349,8 @@ void MarkerDisplay::processAdd(const visualization_msgs::Marker::ConstPtr& messa
   if (marker)
   {
     marker->setMessage(message);
+
+    marker->setVisible(ns_it.value()->isEnabled());
 
     if (message->lifetime.toSec() > 0.0001f)
     {
@@ -445,6 +442,17 @@ void MarkerDisplay::setTopic(const QString& topic, const QString& /*datatype*/)
   marker_topic_property_->setString(topic);
 }
 
+void MarkerDisplay::setVisibilityForNamespace(const std::string& ns, bool visible)
+{
+  for (auto const &marker_it : markers_)
+  {
+    if (marker_it.first.first == ns)
+    {
+      marker_it.second->setVisible(visible);
+    }
+  }
+}
+
 /////////////////////////////////////////////////////////////////////////////////
 // MarkerNamespace
 
@@ -462,7 +470,11 @@ void MarkerNamespace::onEnableChanged()
 {
   if (!isEnabled())
   {
-    owner_->deleteMarkersInNamespace(getName().toStdString());
+    owner_->setVisibilityForNamespace(getName().toStdString(), false);
+  }
+  else
+  {
+    owner_->setVisibilityForNamespace(getName().toStdString(), true);
   }
 
   // Update the configuration that stores the enabled state of all markers

--- a/src/rviz/default_plugin/marker_display.h
+++ b/src/rviz/default_plugin/marker_display.h
@@ -91,6 +91,8 @@ public:
 
   void setTopic(const QString& topic, const QString& datatype) override;
 
+  void setVisibilityForNamespace(const std::string& ns, bool visible);
+
 protected:
   void deleteMarkerInternal(const MarkerID& id);
 

--- a/src/rviz/default_plugin/markers/marker_base.cpp
+++ b/src/rviz/default_plugin/markers/marker_base.cpp
@@ -141,6 +141,11 @@ const Ogre::Quaternion& MarkerBase::getOrientation() const
   return scene_node_->getOrientation();
 }
 
+void MarkerBase::setVisible(bool visible)
+{
+  scene_node_->setVisible(visible);
+}
+
 void MarkerBase::extractMaterials(Ogre::Entity* entity, S_MaterialPtr& materials)
 {
   uint32_t num_sub_entities = entity->getNumSubEntities();

--- a/src/rviz/default_plugin/markers/marker_base.h
+++ b/src/rviz/default_plugin/markers/marker_base.h
@@ -95,6 +95,8 @@ public:
     return S_MaterialPtr();
   }
 
+  void setVisible(bool visible);
+
 protected:
   bool transform(const MarkerConstPtr& message,
                  Ogre::Vector3& pos,


### PR DESCRIPTION
### Description
Change the behavior of the Marker & MarkerArray checkboxes to only toggle visibility instead of deleting the markers. I feel like this is the behavior most people expect/prefer (see #379) I can document the change on the wiki if this is merged

### Checklist

- [ ] If you are addressing rendering issues, please provide:
  - [ ] Images of both, broken and fixed renderings.
  - [ ] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [ ] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.