### PR TITLE
Enforce GLSL 1.4 on more Mesa systems (#1559)

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -184,7 +184,9 @@ void RenderSystem::detectGlVersion()
     int major = caps->getDriverVersion().major;
     int minor = caps->getDriverVersion().minor;
     gl_version_ = major * 100 + minor * 10;
-    mesa_workaround = caps->getDeviceName().find("Mesa ") != std::string::npos && gl_version_ >= 320;
+
+    std::string gl_version_string = (const char*)glGetString(GL_VERSION);
+    mesa_workaround = gl_version_string.find("Mesa 20.") != std::string::npos && gl_version_ >= 320;
   }
 
   switch (gl_version_)


### PR DESCRIPTION
Mesa-based rendering issues showed up e.g. on AMD GPU as well. The new approach should handle any Mesa 20-based system.
Fixes #1584.
