### PR TITLE
RobotLink: check if loading mesh failed before creating entity

### DIFF
--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -599,8 +599,10 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
 
     try
     {
-      loadMeshFromResource(model_name);
-      entity = scene_manager_->createEntity(ss.str(), model_name);
+      if (!loadMeshFromResource(model_name).isNull())
+      {
+        entity = scene_manager_->createEntity(ss.str(), model_name);
+      }
     }
     catch (Ogre::InvalidParametersException& e)
     {


### PR DESCRIPTION
fixes #1589 

As discovered by @rhaschke having a robot with an invalid mesh will still create an Ogre entity for it. When a Marker later contains the same invalid mesh it will skip some sanity checks due to the already existing entity and will throw an unhandled exception when actually trying to use the mesh.