### PR TITLE
RobotLink: check if loading mesh failed before creating entity  V2

### DIFF
--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -99,6 +99,8 @@ void RobotModelDisplay::onInitialize()
 {
   robot_ = new Robot(scene_node_, context_, "Robot: " + getName().toStdString(), this);
 
+  connect(robot_, &Robot::linkMeshLoadingFailed, this, &RobotModelDisplay::onLinkMeshLoadingFailed);
+
   updateVisualVisible();
   updateCollisionVisible();
   updateAlpha();
@@ -114,6 +116,11 @@ void RobotModelDisplay::updateRobotDescription()
 {
   if (isEnabled())
     load();
+}
+
+void RobotModelDisplay::onLinkMeshLoadingFailed(const QString& linkName, const QString& details)
+{
+  setStatus(StatusLevel::Error, linkName, details);
 }
 
 void RobotModelDisplay::updateVisualVisible()

--- a/src/rviz/default_plugin/robot_model_display.h
+++ b/src/rviz/default_plugin/robot_model_display.h
@@ -81,6 +81,7 @@ private Q_SLOTS:
   void updateTfPrefix();
   void updateAlpha();
   void updateRobotDescription();
+  void onLinkMeshLoadingFailed(const QString& linkName, const QString& details);
 
 protected:
   /** @brief Loads a URDF from the ros-param named by our

--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -222,7 +222,10 @@ RobotLink* Robot::LinkFactory::createLink(Robot* robot,
                                           bool visual,
                                           bool collision)
 {
-  return new RobotLink(robot, link, parent_joint_name, visual, collision);
+  RobotLink* l = new RobotLink(robot, link, parent_joint_name);
+  connect(l, &RobotLink::meshLoadingFailed, robot, &Robot::linkMeshLoadingFailed);
+  l->init(link, visual, collision);
+  return l;
 }
 
 RobotJoint* Robot::LinkFactory::createJoint(Robot* robot, const urdf::JointConstSharedPtr& joint)

--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -242,6 +242,8 @@ public:
 
   // set joint checkboxes and All Links Enabled checkbox based on current link enables.
   void calculateJointCheckboxes();
+Q_SIGNALS:
+  void linkMeshLoadingFailed(const QString& linkName, const QString& details);
 
 private Q_SLOTS:
   void changedLinkTreeStyle();

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -602,7 +602,7 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
     {
       if (loadMeshFromResource(model_name).isNull())
       {
-        Q_EMIT meshLoadingFailed(QString(name_.c_str()),
+        Q_EMIT meshLoadingFailed(QString(name_.c_str()) + " - mesh",
                                  QString("Failed loading mesh '%1'").arg(model_name.c_str()));
         return;
       }
@@ -612,17 +612,18 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
     {
       ROS_ERROR("Could not convert mesh resource '%s' for link '%s'. It might be an empty mesh: %s",
                 model_name.c_str(), link->name.c_str(), e.what());
-      Q_EMIT meshLoadingFailed(QString(name_.c_str()), QString("Could not convert mesh resource '%1'. "
-                                                               "It might be an empty mesh: %2")
-                                                           .arg(model_name.c_str())
-                                                           .arg(e.what()));
+      Q_EMIT meshLoadingFailed(QString(name_.c_str()) + " - mesh",
+                               QString("Could not convert mesh resource '%1'. "
+                                       "It might be an empty mesh: %2")
+                                   .arg(model_name.c_str())
+                                   .arg(e.what()));
     }
     catch (Ogre::Exception& e)
     {
       ROS_ERROR("Could not load model '%s' for link '%s': %s", model_name.c_str(), link->name.c_str(),
                 e.what());
       Q_EMIT meshLoadingFailed(
-          QString(name_.c_str()),
+          QString(name_.c_str()) + " - mesh",
           QString("Could not load model '%1': %2").arg(model_name.c_str()).arg(e.what()));
     }
     break;

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -599,8 +599,10 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
 
     try
     {
-      loadMeshFromResource(model_name);
-      entity = scene_manager_->createEntity(ss.str(), model_name);
+      if (!loadMeshFromResource(model_name).isNull())
+      {
+        entity = scene_manager_->createEntity(ss.str(), model_name);
+      }
     }
     catch (Ogre::InvalidParametersException& e)
     {

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -85,11 +85,7 @@ class RobotLink : public QObject
 {
   Q_OBJECT
 public:
-  RobotLink(Robot* robot,
-            const urdf::LinkConstSharedPtr& link,
-            const std::string& parent_joint_name,
-            bool visual,
-            bool collision);
+  RobotLink(Robot* robot, const urdf::LinkConstSharedPtr& link, const std::string& parent_joint_name);
   ~RobotLink() override;
 
   virtual void setRobotAlpha(float a);
@@ -167,6 +163,11 @@ public:
 
   // expand all sub properties
   void expandDetails(bool expand);
+
+  void init(const urdf::LinkConstSharedPtr& link, bool visual, bool collision);
+
+Q_SIGNALS:
+  void meshLoadingFailed(const QString& name, const QString& details);
 
 public Q_SLOTS:
   /** @brief Update the visibility of the link elements: visual mesh, collision mesh, trail, and axes.


### PR DESCRIPTION
alternative to #1596 which also fixes #1589 

I had to split the `RobotLink` constructor in order to be able to connect to the signal before the mesh loading happens

now unfortunately MoveIt's `RobotStateDisplay` does not extend upon `RobotModelDisplay` so that will need to be extended in a follow up