### PR TITLE
Enable Mesa workaround also on Mesa 21

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -186,7 +186,8 @@ void RenderSystem::detectGlVersion()
     gl_version_ = major * 100 + minor * 10;
 
     std::string gl_version_string = (const char*)glGetString(GL_VERSION);
-    mesa_workaround = gl_version_string.find("Mesa 20.") != std::string::npos && gl_version_ >= 320;
+    // The "Mesa 2" string is intended to match "Mesa 20.", "Mesa 21." and so on
+    mesa_workaround = gl_version_string.find("Mesa 2") != std::string::npos && gl_version_ >= 320;
   }
 
   switch (gl_version_)


### PR DESCRIPTION
### Description

This enables the Mesa workaround for Mesa 21.x, too (and all future Mesa 2?.x versions).

My system reports:

```
GL_RENDERER   = AMD RENOIR (DRM 3.40.0, 5.10.24-051024-generic, LLVM 11.0.1)
GL_VERSION    = 4.6 (Compatibility Profile) Mesa 21.0.0 - kisak-mesa PPA
GL_VENDOR     = AMD
```

The fix merged in #1588 is limited to Mesa 20.x only, but the problems it works around are present in 21.x, too.

### Checklist

- [ ] If you are addressing rendering issues, please provide:
  - [ ] Images of both, broken and fixed renderings.
  - [ ] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [ ] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
