### PR TITLE
Fix memory leaks in dialog handling

### DIFF
--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -109,12 +109,12 @@ void DisplaysPanel::onNewDisplay()
   QStringList empty;
 
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  AddDisplayDialog* dialog = new AddDisplayDialog(vis_manager_->getDisplayFactory(), "Display", empty,
-                                                  empty, &lookup_name, &display_name, &topic, &datatype);
+  AddDisplayDialog dialog(vis_manager_->getDisplayFactory(), "Display", empty, empty, &lookup_name,
+                          &display_name, &topic, &datatype);
   QApplication::restoreOverrideCursor();
 
   vis_manager_->stopUpdate();
-  if (dialog->exec() == QDialog::Accepted)
+  if (dialog.exec() == QDialog::Accepted)
   {
     Display* disp = vis_manager_->createDisplay(lookup_name, display_name, true);
     if (!topic.isEmpty() && !datatype.isEmpty())
@@ -124,7 +124,6 @@ void DisplaysPanel::onNewDisplay()
   }
   vis_manager_->startUpdate();
   activateWindow(); // Force keyboard focus back on main window.
-  delete dialog;
 }
 
 void DisplaysPanel::onDuplicateDisplay()

--- a/src/rviz/properties/color_editor.cpp
+++ b/src/rviz/properties/color_editor.cpp
@@ -104,14 +104,14 @@ void ColorEditor::onButtonClick()
   ColorProperty* prop = property_;
   QColor original_color = prop->getColor();
 
-  QColorDialog* dialog = new QColorDialog(color_, parentWidget());
+  QColorDialog dialog(color_, parentWidget());
 
-  connect(dialog, SIGNAL(currentColorChanged(const QColor&)), property_, SLOT(setColor(const QColor&)));
+  connect(&dialog, SIGNAL(currentColorChanged(const QColor&)), property_, SLOT(setColor(const QColor&)));
 
   // Without this connection the PropertyTreeWidget does not update
   // the color info "live" when it changes in the dialog and the 3D
   // view.
-  connect(dialog, SIGNAL(currentColorChanged(const QColor&)), parentWidget(), SLOT(update()));
+  connect(&dialog, SIGNAL(currentColorChanged(const QColor&)), parentWidget(), SLOT(update()));
 
   // On the TWM window manager under linux, and on OSX, this
   // ColorEditor object is destroyed when (or soon after) the dialog
@@ -123,7 +123,7 @@ void ColorEditor::onButtonClick()
   // deleteLater() will take effect and "this" will be destroyed.
   // Therefore, everything we do in this function after dialog->exec()
   // should only use variables on the stack, not member variables.
-  if (dialog->exec() != QDialog::Accepted)
+  if (dialog.exec() != QDialog::Accepted)
   {
     prop->setColor(original_color);
   }

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <fstream>
+#include <memory>
 
 #include <QAction>
 #include <QShortcut>
@@ -632,9 +633,9 @@ void VisualizationFrame::onDockPanelVisibilityChange(bool visible)
 void VisualizationFrame::openPreferencesDialog()
 {
   Preferences temp_preferences(*preferences_);
-  PreferencesDialog* dialog = new PreferencesDialog(panel_factory_, &temp_preferences, this);
+  PreferencesDialog dialog(panel_factory_, &temp_preferences, this);
   manager_->stopUpdate();
-  if (dialog->exec() == QDialog::Accepted)
+  if (dialog.exec() == QDialog::Accepted)
   {
     // Apply preferences.
     preferences_ = boost::make_shared<Preferences>(temp_preferences);
@@ -765,12 +766,12 @@ bool VisualizationFrame::loadDisplayConfigHelper(const std::string& full_path)
   setWindowModified(false);
   loading_ = true;
 
-  LoadingDialog* dialog = nullptr;
+  std::unique_ptr<LoadingDialog> dialog;
   if (initialized_)
   {
-    dialog = new LoadingDialog(this);
+    dialog.reset(new LoadingDialog(this));
     dialog->show();
-    connect(this, SIGNAL(statusUpdate(const QString&)), dialog, SLOT(showMessage(const QString&)));
+    connect(this, SIGNAL(statusUpdate(const QString&)), dialog.get(), SLOT(showMessage(const QString&)));
   }
 
   YamlConfigReader reader;
@@ -786,8 +787,6 @@ bool VisualizationFrame::loadDisplayConfigHelper(const std::string& full_path)
   setDisplayConfigFile(full_path);
 
   last_config_dir_ = fs::path(full_path).parent_path().BOOST_FILE_STRING();
-
-  delete dialog;
 
   post_load_timer_->start(1000);
 

--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -177,8 +177,8 @@ bool VisualizerApp::init(int argc, char** argv)
 
     if (!ros::master::check())
     {
-      WaitForMasterDialog* dialog = new WaitForMasterDialog;
-      if (dialog->exec() != QDialog::Accepted)
+      WaitForMasterDialog dialog;
+      if (dialog.exec() != QDialog::Accepted)
       {
         return false;
       }

--- a/src/test/new_display_dialog_test.cpp
+++ b/src/test/new_display_dialog_test.cpp
@@ -49,9 +49,9 @@ int main(int argc, char** argv)
   current_names << "Chub"
                 << "Town";
   QStringList empty;
-  rviz::NewObjectDialog* dialog = new rviz::NewObjectDialog(factory, QString("Display"), current_names,
-                                                            empty, &lookup_name, &display_name, nullptr);
-  if (dialog->exec() == QDialog::Accepted)
+  rviz::NewObjectDialog dialog(factory, QString("Display"), current_names, empty, &lookup_name,
+                               &display_name, nullptr);
+  if (dialog.exec() == QDialog::Accepted)
   {
     printf("lookup_name='%s', display_name='%s'\n", lookup_name.toStdString().c_str(),
            display_name.toStdString().c_str());


### PR DESCRIPTION
Create dialog objects on stack where possible. Otherwise use unique_ptr.
Fixes #1601.