### PR TITLE
Remove unused LineEditWithButton::simulateReturnPressed()

### DIFF
--- a/src/rviz/properties/line_edit_with_button.cpp
+++ b/src/rviz/properties/line_edit_with_button.cpp
@@ -71,19 +71,4 @@ void LineEditWithButton::resizeEvent(QResizeEvent* event)
   button_->setGeometry(width() - button_width - padding, padding, button_width, button_height);
 }
 
-void LineEditWithButton::simulateReturnPressed()
-{
-  // I couldn't find a way to directly tell the editor that I was
-  // done with it here.  "Q_EMIT returnPressed()", "Q_EMIT
-  // editingFinished()" etc did nothing.  So instead, here I
-  // simulate the user pressing and releasing the "Return" key,
-  // which does indeed make it act like I want: when you select a
-  // topic from the dialog and the dialog closes, the property's
-  // Setter is called and this editor closes.
-  QKeyEvent* event = new QKeyEvent(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier);
-  QApplication::postEvent(this, event);
-  event = new QKeyEvent(QEvent::KeyRelease, Qt::Key_Return, Qt::NoModifier);
-  QApplication::postEvent(this, event);
-}
-
 } // end namespace rviz

--- a/src/rviz/properties/line_edit_with_button.h
+++ b/src/rviz/properties/line_edit_with_button.h
@@ -54,11 +54,6 @@ public:
 protected:
   void resizeEvent(QResizeEvent* event) override;
 
-  /** @brief Send key events to mimic the "return" key being pressed and
-   * released.  Useful ending an edit session and sending the data on
-   * out. */
-  void simulateReturnPressed();
-
 protected Q_SLOTS:
   /** @brief Override this to do something when the button is clicked. */
   virtual void onButtonClick()


### PR DESCRIPTION
This function isn't used across the source of rviz. Usage was removed in f194580fb148830aad69fdaa77a3294319371603 back in 2012.