### PR TITLE
Fixup github actions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,13 @@
 ---
-BasedOnStyle:  Google
-ColumnLimit:    105
+BasedOnStyle: Google
+ColumnLimit: 105
 MaxEmptyLinesToKeep: 2
 SortIncludes: false
 
-Standard:        Auto
-IndentWidth:     2
-TabWidth:        2
-UseTab:          Never
+Standard: Auto
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
 AccessModifierOffset: -2
 ConstructorInitializerIndentWidth: 2
 NamespaceIndentation: None
@@ -46,7 +46,7 @@ PenaltyReturnTypeOnItsOwnLine: 50
 
 SpacesBeforeTrailingComments: 1
 SpacesInParentheses: false
-SpacesInAngles:  false
+SpacesInAngles: false
 SpaceInEmptyParentheses: false
 SpacesInCStyleCastParentheses: false
 SpaceAfterCStyleCast: false
@@ -69,4 +69,3 @@ BraceWrapping:
     BeforeCatch: true
     BeforeElse: true
     IndentBraces: false
-...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,5 @@
 ---
-Checks:          '-*,
-                  llvm-namespace-comment,
+Checks:          'llvm-namespace-comment,
                   modernize-redundant-void-arg,
                   modernize-use-nullptr,
                   modernize-use-default,

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,11 +1,10 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-name: CI
+name: pre-release
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
 
 jobs:
@@ -13,26 +12,19 @@ jobs:
     strategy:
       matrix:
         distro: [melodic]
-        include:
-          - distro: melodic
-            env:
-              CLANG_TIDY: true
 
     env:
-      CXXFLAGS: "-Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-strict-aliasing -Wno-sign-compare"
-      CATKIN_LINT: true
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      ROS_DISTRO: ${{ matrix.distro }}
+      PRERELEASE: true
       BASEDIR: /home/runner/work
-      DOCKER_IMAGE: rhaschke/ici:rviz-${{ matrix.distro }}-${{ matrix.repo || 'ros' }}
-      CACHE_PREFIX: ${{ matrix.distro }}
-      # perform full clang-tidy check only on manual trigger (workflow_dispatch), PRs do check changed files, otherwise nothing
-      CLANG_TIDY_BASE_REF: ${{ github.event_name != 'workflow_dispatch' && (github.base_ref || github.ref) || '' }}
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CACHE_PREFIX: "${{ matrix.env.IMAGE }}${{ matrix.env.CCOV && '-ccov' || '' }}"
 
-    name: "${{ matrix.distro }}${{ matrix.repo && format(' • {0}', matrix.repo) || '' }}${{ matrix.env.CLANG_TIDY && (github.event_name != 'workflow_dispatch' && ' • clang-tidy (delta)' || ' • clang-tidy (all)') || '' }}"
+    if: github.event_name == 'workflow_dispatch'  # only allow manual triggering
+    name: "${{ matrix.distro }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       - name: Cache ccache
         uses: pat-s/always-upload-cache@v2.1.3
         with:
@@ -44,7 +36,6 @@ jobs:
 
       - name: industrial_ci
         uses: rhaschke/industrial_ci@master
-        env: ${{ matrix.env || env }}
 
       - name: Upload test artifacts (on failure)
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
- enable full (and slow) clang-tidy check via manual workflow triggering only
- make CLANG_TIDY non-pendantic (there are too many open issues)
- add prerelease workflow
- auto-format .clang-format
- drop caching of target_ws and docker image
  - the docker image continuously accumulates layers (comprising environment at least)
  - caching the target_ws missed to rebuild sometimes
