### PR TITLE
add ProgressDialog on duplicate rviz items, for issue #1612

### DIFF
--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -133,8 +133,8 @@ void DisplaysPanel::onDuplicateDisplay()
 
   QList<Display*> duplicated_displays;
 
-  QProgressDialog progressDialog("Duplicating displays...", "Cancel", 0,
-                                 displays_to_duplicate.size(), this);
+  QProgressDialog progressDialog("Duplicating displays...", "Cancel", 0, displays_to_duplicate.size(),
+                                 this);
 
   progressDialog.setWindowModality(Qt::WindowModal);
   progressDialog.show();
@@ -152,7 +152,8 @@ void DisplaysPanel::onDuplicateDisplay()
     duplicated_displays.push_back(disp);
 
     progressDialog.setValue(i);
-    if (progressDialog.wasCanceled()) {
+    if (progressDialog.wasCanceled())
+    {
         break;
     }
   }

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -157,7 +157,6 @@ void DisplaysPanel::onDuplicateDisplay()
       break;
     }
   }
-  
   progressDialog.setValue(displays_to_duplicate.size());
   // make sure the newly duplicated displays are selected.
   if (!duplicated_displays.empty())

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -154,7 +154,7 @@ void DisplaysPanel::onDuplicateDisplay()
     progressDialog.setValue(i);
     if (progressDialog.wasCanceled())
     {
-        break;
+      break;
     }
   }
   

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -33,18 +33,19 @@
 #include <QPushButton>
 #include <QInputDialog>
 #include <QApplication>
+#include <QProgressDialog>
 
 #include <boost/bind.hpp>
 
-#include <rviz/display_factory.h>
-#include <rviz/display.h>
-#include <rviz/add_display_dialog.h>
-#include <rviz/properties/property.h>
-#include <rviz/properties/property_tree_widget.h>
-#include <rviz/properties/property_tree_with_help.h>
-#include <rviz/visualization_manager.h>
+#include "rviz/display_factory.h"
+#include "rviz/display.h"
+#include "rviz/add_display_dialog.h"
+#include "rviz/properties/property.h"
+#include "rviz/properties/property_tree_widget.h"
+#include "rviz/properties/property_tree_with_help.h"
+#include "rviz/visualization_manager.h"
 
-#include <rviz/displays_panel.h>
+#include "rviz/displays_panel.h"
 
 namespace rviz
 {
@@ -132,6 +133,12 @@ void DisplaysPanel::onDuplicateDisplay()
 
   QList<Display*> duplicated_displays;
 
+  QProgressDialog progressDialog("Duplicating displays...", "Cancel", 0,
+                                 displays_to_duplicate.size(), this);
+
+  progressDialog.setWindowModality(Qt::WindowModal);
+  progressDialog.show();
+
   for (int i = 0; i < displays_to_duplicate.size(); i++)
   {
     // initialize display
@@ -143,7 +150,14 @@ void DisplaysPanel::onDuplicateDisplay()
     displays_to_duplicate[i]->save(config);
     disp->load(config);
     duplicated_displays.push_back(disp);
+
+    progressDialog.setValue(i);
+    if (progressDialog.wasCanceled()) {
+        break;
+    }
   }
+  
+  progressDialog.setValue(displays_to_duplicate.size());
   // make sure the newly duplicated displays are selected.
   if (!duplicated_displays.empty())
   {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

This PR for issue #1612 ， it create a progressdialog when dupliating rviz component so that the duplication can 
proceed completely. Users can use the cancel button at any time to cancel the operation being copied.

before add progressdialog:
![image](https://user-images.githubusercontent.com/81728978/114870161-6a0d3e80-9e2a-11eb-9be4-e5d7f283f5f1.png)

after add progressdialog:
![image](https://user-images.githubusercontent.com/81728978/114867112-f9b0ee00-9e26-11eb-8a33-c515f56f1e38.png)


### Checklist

- [x] If you are addressing rendering issues, please provide:
  - [x] Images of both, broken and fixed renderings.
  - [x] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [x] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [x] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [x] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
