### PR TITLE
Update displays_panel.cpp

### DIFF
--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -135,6 +135,7 @@ void DisplaysPanel::onDuplicateDisplay()
 
   QProgressDialog progressDialog("Duplicatiing displays..", "Cancel", 0, displays_to_duplicate.size(),
                                  this);
+  
   progressDialog.setWindowModality(Qt::WindowModal);
   progressDialog.show();
   

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -135,10 +135,9 @@ void DisplaysPanel::onDuplicateDisplay()
 
   QProgressDialog progressDialog("Duplicatiing displays..", "Cancel", 0, displays_to_duplicate.size(),
                                  this);
-  
   progressDialog.setWindowModality(Qt::WindowModal);
   progressDialog.show();
-  
+  // duplicate all selected displays
   for (int i = 0; i < displays_to_duplicate.size(); i++)
   {
     // initialize display

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -130,13 +130,12 @@ void DisplaysPanel::onNewDisplay()
 void DisplaysPanel::onDuplicateDisplay()
 {
   QList<Display*> displays_to_duplicate = property_grid_->getSelectedObjects<Display>();
-
   QList<Display*> duplicated_displays;
+  QProgressDialog progress_dlg("Duplicating displays...", "Cancel", 0, displays_to_duplicate.size(),
+                               this);
+  progress_dlg.setWindowModality(Qt::WindowModal);
+  progress_dlg.show();
 
-  QProgressDialog progressDialog("Duplicatiing displays..", "Cancel", 0, displays_to_duplicate.size(),
-                                 this);
-  progressDialog.setWindowModality(Qt::WindowModal);
-  progressDialog.show();
   // duplicate all selected displays
   for (int i = 0; i < displays_to_duplicate.size(); i++)
   {
@@ -149,14 +148,11 @@ void DisplaysPanel::onDuplicateDisplay()
     displays_to_duplicate[i]->save(config);
     disp->load(config);
     duplicated_displays.push_back(disp);
-    progressDialog.setValue(i);
+    progress_dlg.setValue(i + 1);
     // push cancel to stop duplicate
-    if (progressDialog.wasCanceled())
-    {
+    if (progress_dlg.wasCanceled())
       break;
-    }
   }
-  progressDialog.setValue(displays_to_duplicate.size());
   // make sure the newly duplicated displays are selected.
   if (!duplicated_displays.empty())
   {

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -134,7 +134,7 @@ void DisplaysPanel::onDuplicateDisplay()
   QList<Display*> duplicated_displays;
 
   QProgressDialog progressDialog("Duplicatiing displays..", "Cancel", 0, displays_to_duplicate.size(),
-                                this);
+                                 this);
   progressDialog.setWindowModality(Qt::WindowModal);
   progressDialog.show();
   
@@ -149,7 +149,7 @@ void DisplaysPanel::onDuplicateDisplay()
     displays_to_duplicate[i]->save(config);
     disp->load(config);
     duplicated_displays.push_back(disp);
-    
+    // push cancel to stop duplicate
     progressDialog.setValue(i);
     if (progressDialog.wasCanceled()) 
     {

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -138,6 +138,7 @@ void DisplaysPanel::onDuplicateDisplay()
   progressDialog.setWindowModality(Qt::WindowModal);
   progressDialog.show();
   
+  
   for (int i = 0; i < displays_to_duplicate.size(); i++)
   {
     // initialize display
@@ -151,6 +152,7 @@ void DisplaysPanel::onDuplicateDisplay()
     duplicated_displays.push_back(disp);
     // push cancel to stop duplicate
     progressDialog.setValue(i);
+    
     if (progressDialog.wasCanceled()) 
     {
       break;

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -138,7 +138,6 @@ void DisplaysPanel::onDuplicateDisplay()
   progressDialog.setWindowModality(Qt::WindowModal);
   progressDialog.show();
   
-  
   for (int i = 0; i < displays_to_duplicate.size(); i++)
   {
     // initialize display
@@ -152,7 +151,6 @@ void DisplaysPanel::onDuplicateDisplay()
     duplicated_displays.push_back(disp);
     // push cancel to stop duplicate
     progressDialog.setValue(i);
-    
     if (progressDialog.wasCanceled()) 
     {
       break;

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -149,9 +149,8 @@ void DisplaysPanel::onDuplicateDisplay()
     displays_to_duplicate[i]->save(config);
     disp->load(config);
     duplicated_displays.push_back(disp);
-    // push cancel to stop duplicate
     progressDialog.setValue(i);
-    
+    // push cancel to stop duplicate
     if (progressDialog.wasCanceled())
     {
       break;

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -151,7 +151,8 @@ void DisplaysPanel::onDuplicateDisplay()
     duplicated_displays.push_back(disp);
     // push cancel to stop duplicate
     progressDialog.setValue(i);
-    if (progressDialog.wasCanceled()) 
+    
+    if (progressDialog.wasCanceled())
     {
       break;
     }

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -33,6 +33,7 @@
 #include <QPushButton>
 #include <QInputDialog>
 #include <QApplication>
+#include <QProgressDialog>
 
 #include <boost/bind.hpp>
 
@@ -132,6 +133,11 @@ void DisplaysPanel::onDuplicateDisplay()
 
   QList<Display*> duplicated_displays;
 
+  QProgressDialog progressDialog("Duplicatiing displays..", "Cancel", 0, displays_to_duplicate.size(),
+                                this);
+  progressDialog.setWindowModality(Qt::WindowModal);
+  progressDialog.show();
+  
   for (int i = 0; i < displays_to_duplicate.size(); i++)
   {
     // initialize display
@@ -143,7 +149,13 @@ void DisplaysPanel::onDuplicateDisplay()
     displays_to_duplicate[i]->save(config);
     disp->load(config);
     duplicated_displays.push_back(disp);
+    
+    progressDialog.setValue(i);
+    if (progressDialog.wasCanceled()) {
+      break;
+    }
   }
+  progressDialog.setValue(displays_to_duplicate.size());
   // make sure the newly duplicated displays are selected.
   if (!duplicated_displays.empty())
   {

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -151,7 +151,8 @@ void DisplaysPanel::onDuplicateDisplay()
     duplicated_displays.push_back(disp);
     
     progressDialog.setValue(i);
-    if (progressDialog.wasCanceled()) {
+    if (progressDialog.wasCanceled()) 
+    {
       break;
     }
   }


### PR DESCRIPTION
Add progress bar dialog box

<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

The progress bar dialog box is added to ensure that the duplication process can be completed properly and prevent other events from being responded to.

before add progressdialog：
![223](https://user-images.githubusercontent.com/81728978/115100401-f0329d80-9f6e-11eb-82e4-3da9e091946f.JPG)


affter add progressdialog interface appearance
![114260271-5c108580-9a06-11eb-9f18-7881743f8e62](https://user-images.githubusercontent.com/81728978/115100398-e90b8f80-9f6e-11eb-9c04-ff22d278ac14.png)



### Checklist

- [x] If you are addressing rendering issues, please provide:
  - [x] Images of both, broken and fixed renderings.
  - [x] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [x] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [x] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [x] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
