### PR TITLE
Fix usage of QProgressDialog / LoadingDialog

### DIFF
--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -135,6 +135,7 @@ void DisplaysPanel::onDuplicateDisplay()
                                this);
   progress_dlg.setWindowModality(Qt::WindowModal);
   progress_dlg.show();
+  QApplication::processEvents(); // explicitly progress events for update
 
   // duplicate all selected displays
   for (int i = 0; i < displays_to_duplicate.size(); i++)
@@ -149,6 +150,7 @@ void DisplaysPanel::onDuplicateDisplay()
     disp->load(config);
     duplicated_displays.push_back(disp);
     progress_dlg.setValue(i + 1);
+    QApplication::processEvents(); // explicitly progress events for update
     // push cancel to stop duplicate
     if (progress_dlg.wasCanceled())
       break;

--- a/src/rviz/loading_dialog.cpp
+++ b/src/rviz/loading_dialog.cpp
@@ -48,9 +48,7 @@ LoadingDialog::LoadingDialog(QWidget* parent) : QDialog(parent)
 void LoadingDialog::showMessage(const QString& message)
 {
   label_->setText(message);
-  QApplication::processEvents();
-  QWidget::repaint();
-  QApplication::flush();
+  QApplication::processEvents(); // explicitly process events for update
 }
 
 } // end namespace rviz

--- a/src/rviz/loading_dialog.cpp
+++ b/src/rviz/loading_dialog.cpp
@@ -37,10 +37,12 @@ namespace rviz
 {
 LoadingDialog::LoadingDialog(QWidget* parent) : QDialog(parent)
 {
-  setModal(true);
+  setWindowModality(Qt::WindowModal);
+  setWindowTitle("Loading Config");
 
-  label_ = new QLabel;
-  QVBoxLayout* layout = new QVBoxLayout;
+  label_ = new QLabel(this);
+  label_->setMinimumWidth(100);
+  QVBoxLayout* layout = new QVBoxLayout(this);
   layout->addWidget(label_);
   setLayout(layout);
 }

--- a/src/rviz/ogre_helpers/render_widget.cpp
+++ b/src/rviz/ogre_helpers/render_widget.cpp
@@ -74,12 +74,6 @@ RenderWidget::RenderWidget(RenderSystem* render_system, QWidget* parent)
 #else
   rviz::RenderSystem::WindowIDType win_id = this->winId();
 #endif
-  QApplication::flush();
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  QApplication::syncX();
-#else
-  QApplication::sync();
-#endif
 
   render_window_ = render_system_->makeRenderWindow(win_id, width(), height(), pixelRatio());
 }

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -772,6 +772,7 @@ bool VisualizationFrame::loadDisplayConfigHelper(const std::string& full_path)
     dialog.reset(new LoadingDialog(this));
     dialog->show();
     connect(this, SIGNAL(statusUpdate(const QString&)), dialog.get(), SLOT(showMessage(const QString&)));
+    app_->processEvents(); // make the window correctly appear although running a long-term function
   }
 
   YamlConfigReader reader;


### PR DESCRIPTION
Both dialogs didn't correctly update their content during the long-running functions they were used in.
Resolves https://github.com/ros-visualization/rviz/issues/1612#issuecomment-820416989.