### PR TITLE
include Ogre headers via system path

### DIFF
--- a/src/image_view/image_view.cpp
+++ b/src/image_view/image_view.cpp
@@ -39,17 +39,17 @@
 #include "ros/ros.h"
 #include <ros/package.h>
 
-#include <OgreRoot.h>
-#include <OgreRenderWindow.h>
-#include <OgreSceneManager.h>
-#include <OgreViewport.h>
-#include <OgreRectangle2D.h>
-#include <OgreMaterial.h>
-#include <OgreMaterialManager.h>
-#include <OgreTextureUnitState.h>
-#include <OgreSharedPtr.h>
-#include <OgreTechnique.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreRectangle2D.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTextureUnitState.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgreTechnique.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include "image_view.h"
 

--- a/src/image_view/image_view.h
+++ b/src/image_view/image_view.h
@@ -35,13 +35,13 @@
 #include "ros/ros.h"
 #include <ros/package.h>
 
-#include <OgreRoot.h>
-#include <OgreSceneManager.h>
-#include <OgreViewport.h>
-#include <OgreRectangle2D.h>
-#include <OgreMaterial.h>
-#include <OgreMaterialManager.h>
-#include <OgreTextureUnitState.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreRectangle2D.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTextureUnitState.h>
 
 #include <image_transport/image_transport.h>
 #include <image_transport/subscriber_filter.h>

--- a/src/rviz/default_plugin/axes_display.cpp
+++ b/src/rviz/default_plugin/axes_display.cpp
@@ -29,8 +29,8 @@
 
 #include <boost/bind.hpp>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/camera_display.cpp
+++ b/src/rviz/default_plugin/camera_display.cpp
@@ -29,17 +29,17 @@
 
 #include <boost/bind.hpp>
 
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreRectangle2D.h>
-#include <OgreRenderSystem.h>
-#include <OgreRenderWindow.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreTextureManager.h>
-#include <OgreViewport.h>
-#include <OgreTechnique.h>
-#include <OgreCamera.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreRectangle2D.h>
+#include <OGRE/OgreRenderSystem.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreTechnique.h>
+#include <OGRE/OgreCamera.h>
 
 #include <tf2_ros/message_filter.h>
 

--- a/src/rviz/default_plugin/camera_display.h
+++ b/src/rviz/default_plugin/camera_display.h
@@ -35,9 +35,9 @@
 #include <QObject>
 
 #ifndef Q_MOC_RUN
-#include <OgreMaterial.h>
-#include <OgreRenderTargetListener.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreRenderTargetListener.h>
+#include <OGRE/OgreSharedPtr.h>
 
 #include <sensor_msgs/CameraInfo.h>
 

--- a/src/rviz/default_plugin/covariance_property.cpp
+++ b/src/rviz/default_plugin/covariance_property.cpp
@@ -36,8 +36,8 @@
 
 #include <QColor>
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/covariance_property.h
+++ b/src/rviz/default_plugin/covariance_property.h
@@ -32,7 +32,7 @@
 
 #include <QColor>
 
-#include <OgreColourValue.h>
+#include <OGRE/OgreColourValue.h>
 
 #include <rviz/properties/bool_property.h>
 

--- a/src/rviz/default_plugin/covariance_visual.cpp
+++ b/src/rviz/default_plugin/covariance_visual.cpp
@@ -32,9 +32,9 @@
 #include <rviz/ogre_helpers/shape.h>
 #include <rviz/validate_quaternions.h>
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreQuaternion.h>
 
 #include <ros/console.h>
 

--- a/src/rviz/default_plugin/covariance_visual.h
+++ b/src/rviz/default_plugin/covariance_visual.h
@@ -40,8 +40,8 @@
 
 #include <Eigen/Dense>
 
-#include <OgreVector3.h>
-#include <OgreColourValue.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreColourValue.h>
 
 namespace Ogre
 {

--- a/src/rviz/default_plugin/depth_cloud_display.cpp
+++ b/src/rviz/default_plugin/depth_cloud_display.cpp
@@ -46,8 +46,8 @@
 #include <boost/foreach.hpp>
 #include <boost/shared_ptr.hpp>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <image_transport/camera_common.h>
 #include <image_transport/subscriber_plugin.h>

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -1,5 +1,5 @@
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 #include <QTimer>
 
 #include <rviz/visualization_manager.h>

--- a/src/rviz/default_plugin/effort_visual.cpp
+++ b/src/rviz/default_plugin/effort_visual.cpp
@@ -1,6 +1,6 @@
-#include <OgreVector3.h>
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/ogre_helpers/arrow.h>
 #include <rviz/ogre_helpers/billboard_line.h>

--- a/src/rviz/default_plugin/effort_visual.h
+++ b/src/rviz/default_plugin/effort_visual.h
@@ -1,7 +1,7 @@
 #ifndef EFFORT_VISUAL_H
 #define EFFORT_VISUAL_H
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/fluid_pressure_display.cpp
+++ b/src/rviz/default_plugin/fluid_pressure_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/grid_cells_display.cpp
+++ b/src/rviz/default_plugin/grid_cells_display.cpp
@@ -28,10 +28,10 @@
  */
 
 #include <boost/bind.hpp>
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreManualObject.h>
-#include <OgreBillboardSet.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreBillboardSet.h>
 
 #include <rviz/frame_manager.h>
 #include <rviz/ogre_helpers/arrow.h>

--- a/src/rviz/default_plugin/grid_display.cpp
+++ b/src/rviz/default_plugin/grid_display.cpp
@@ -31,8 +31,8 @@
 
 #include <boost/bind.hpp>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/illuminance_display.cpp
+++ b/src/rviz/default_plugin/illuminance_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -29,18 +29,18 @@
 
 #include <boost/bind.hpp>
 
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreRectangle2D.h>
-#include <OgreRenderSystem.h>
-#include <OgreRenderWindow.h>
-#include <OgreRoot.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreTextureManager.h>
-#include <OgreViewport.h>
-#include <OgreTechnique.h>
-#include <OgreCamera.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreRectangle2D.h>
+#include <OGRE/OgreRenderSystem.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreTechnique.h>
+#include <OGRE/OgreCamera.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/image_display.h
+++ b/src/rviz/default_plugin/image_display.h
@@ -33,9 +33,9 @@
 #ifndef Q_MOC_RUN // See: https://bugreports.qt-project.org/browse/QTBUG-22829
 #include <QObject>
 
-#include <OgreMaterial.h>
-#include <OgreRenderTargetListener.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreRenderTargetListener.h>
+#include <OGRE/OgreSharedPtr.h>
 
 #include "rviz/image/image_display_base.h"
 #include "rviz/image/ros_image_texture.h"

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
@@ -31,13 +31,13 @@
 
 #include <QMenu>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreMaterialManager.h>
-#include <OgreResourceGroupManager.h>
-#include <OgreSubEntity.h>
-#include <OgreMath.h>
-#include <OgreRenderWindow.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreResourceGroupManager.h>
+#include <OGRE/OgreSubEntity.h>
+#include <OGRE/OgreMath.h>
+#include <OGRE/OgreRenderWindow.h>
 
 #include <ros/ros.h>
 #include <interactive_markers/tools.h>

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.h
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.h
@@ -36,8 +36,8 @@
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
 #endif
 
 #include <visualization_msgs/InteractiveMarker.h>

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker_control.cpp
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker_control.cpp
@@ -27,16 +27,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreViewport.h>
-#include <OgreCamera.h>
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgrePass.h>
-#include <OgreMaterial.h>
-#include <OgreEntity.h>
-#include <OgreSubEntity.h>
-#include <OgreSharedPtr.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgrePass.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreSubEntity.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgreTechnique.h>
 
 #include <rviz/display_context.h>
 #include <rviz/selection/selection_manager.h>

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker_control.h
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker_control.h
@@ -35,10 +35,10 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
-#include <OgreRay.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreSceneManager.h>
 #endif
 
 #include <QCursor>

--- a/src/rviz/default_plugin/laser_scan_display.cpp
+++ b/src/rviz/default_plugin/laser_scan_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -29,13 +29,13 @@
 
 #include <boost/bind.hpp>
 
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreTextureManager.h>
-#include <OgreTechnique.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreTechnique.h>
+#include <OGRE/OgreSharedPtr.h>
 
 #include <ros/ros.h>
 

--- a/src/rviz/default_plugin/map_display.h
+++ b/src/rviz/default_plugin/map_display.h
@@ -33,10 +33,10 @@
 #ifndef Q_MOC_RUN
 #include <boost/thread/thread.hpp>
 
-#include <OgreTexture.h>
-#include <OgreMaterial.h>
-#include <OgreVector3.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreTexture.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreSharedPtr.h>
 #endif
 
 #include <nav_msgs/MapMetaData.h>

--- a/src/rviz/default_plugin/markers/arrow_marker.cpp
+++ b/src/rviz/default_plugin/markers/arrow_marker.cpp
@@ -27,11 +27,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreEntity.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreEntity.h>
 
 #include <rviz/default_plugin/marker_display.h>
 #include <rviz/default_plugin/markers/marker_selection_handler.h>

--- a/src/rviz/default_plugin/markers/line_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/line_list_marker.cpp
@@ -34,9 +34,9 @@
 
 #include <rviz/ogre_helpers/billboard_line.h>
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreSceneNode.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/markers/line_strip_marker.cpp
+++ b/src/rviz/default_plugin/markers/line_strip_marker.cpp
@@ -36,9 +36,9 @@
 
 #include <rviz/ogre_helpers/billboard_line.h>
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreSceneNode.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/markers/marker_base.cpp
+++ b/src/rviz/default_plugin/markers/marker_base.cpp
@@ -34,11 +34,11 @@
 #include "marker_selection_handler.h"
 #include <rviz/frame_manager.h>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreEntity.h>
-#include <OgreSubEntity.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreSubEntity.h>
+#include <OGRE/OgreSharedPtr.h>
 
 
 #include <utility>

--- a/src/rviz/default_plugin/markers/marker_base.h
+++ b/src/rviz/default_plugin/markers/marker_base.h
@@ -39,7 +39,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/markers/marker_selection_handler.cpp
+++ b/src/rviz/default_plugin/markers/marker_selection_handler.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreQuaternion.h>
-#include <OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreVector3.h>
 
 #include <rviz/default_plugin/interactive_markers/interactive_marker_control.h>
 #include <rviz/default_plugin/marker_display.h>

--- a/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.cpp
@@ -36,14 +36,14 @@
 #include <rviz/display_context.h>
 #include <rviz/mesh_loader.h>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreEntity.h>
-#include <OgreSubEntity.h>
-#include <OgreMaterialManager.h>
-#include <OgreTextureManager.h>
-#include <OgreSharedPtr.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreSubEntity.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgreTechnique.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/markers/mesh_resource_marker.h
+++ b/src/rviz/default_plugin/markers/mesh_resource_marker.h
@@ -32,7 +32,7 @@
 
 #include "marker_base.h"
 
-#include <OgreMaterial.h>
+#include <OGRE/OgreMaterial.h>
 
 #include <vector>
 

--- a/src/rviz/default_plugin/markers/points_marker.cpp
+++ b/src/rviz/default_plugin/markers/points_marker.cpp
@@ -35,10 +35,10 @@
 
 #include <rviz/ogre_helpers/point_cloud.h>
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/markers/shape_marker.cpp
+++ b/src/rviz/default_plugin/markers/shape_marker.cpp
@@ -36,8 +36,8 @@
 
 #include <rviz/ogre_helpers/shape.h>
 
-#include <OgreSceneNode.h>
-#include <OgreMatrix3.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreMatrix3.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
+++ b/src/rviz/default_plugin/markers/text_view_facing_marker.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <ros/assert.h>
 

--- a/src/rviz/default_plugin/markers/triangle_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.cpp
@@ -37,12 +37,12 @@
 #include <rviz/display_context.h>
 #include <rviz/mesh_loader.h>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreTextureManager.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreTechnique.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/markers/triangle_list_marker.h
+++ b/src/rviz/default_plugin/markers/triangle_list_marker.h
@@ -30,8 +30,8 @@
 #ifndef RVIZ_TRIANGLE_LIST_MARKER_H
 #define RVIZ_TRIANGLE_LIST_MARKER_H
 
-#include <OgreMaterial.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreSharedPtr.h>
 
 #include <rviz/default_plugin/markers/marker_base.h>
 

--- a/src/rviz/default_plugin/odometry_display.cpp
+++ b/src/rviz/default_plugin/odometry_display.cpp
@@ -36,8 +36,8 @@
 #include <rviz/validate_floats.h>
 #include <rviz/validate_quaternions.h>
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include "odometry_display.h"
 #include "covariance_property.h"

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -29,11 +29,11 @@
 
 #include <boost/bind.hpp>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreManualObject.h>
-#include <OgreBillboardSet.h>
-#include <OgreMatrix4.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreBillboardSet.h>
+#include <OGRE/OgreMatrix4.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/point_cloud2_display.cpp
+++ b/src/rviz/default_plugin/point_cloud2_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -29,9 +29,9 @@
 
 #include <QColor>
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreWireBoundingBox.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreWireBoundingBox.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/point_cloud_display.cpp
+++ b/src/rviz/default_plugin/point_cloud_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/point_cloud_transformer.h
+++ b/src/rviz/default_plugin/point_cloud_transformer.h
@@ -35,8 +35,8 @@
 #include <ros/message_forward.h>
 
 #ifndef Q_MOC_RUN
-#include <OgreVector3.h>
-#include <OgreColourValue.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreColourValue.h>
 
 #include <rviz/ogre_helpers/point_cloud.h>
 #endif

--- a/src/rviz/default_plugin/point_cloud_transformers.cpp
+++ b/src/rviz/default_plugin/point_cloud_transformers.cpp
@@ -27,9 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreColourValue.h>
-#include <OgreMatrix4.h>
-#include <OgreVector3.h>
+#include <OGRE/OgreColourValue.h>
+#include <OGRE/OgreMatrix4.h>
+#include <OGRE/OgreVector3.h>
 
 #include <rviz/properties/bool_property.h>
 #include <rviz/properties/color_property.h>

--- a/src/rviz/default_plugin/point_display.cpp
+++ b/src/rviz/default_plugin/point_display.cpp
@@ -1,5 +1,5 @@
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/visualization_manager.h>
 #include <rviz/properties/color_property.h>

--- a/src/rviz/default_plugin/point_visual.cpp
+++ b/src/rviz/default_plugin/point_visual.cpp
@@ -1,6 +1,6 @@
-#include <OgreVector3.h>
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/ogre_helpers/shape.h>
 

--- a/src/rviz/default_plugin/point_visual.h
+++ b/src/rviz/default_plugin/point_visual.h
@@ -3,7 +3,7 @@
 
 #include <geometry_msgs/PointStamped.h>
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/polygon_display.cpp
+++ b/src/rviz/default_plugin/polygon_display.cpp
@@ -27,10 +27,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreManualObject.h>
-#include <OgreBillboardSet.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreBillboardSet.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/pose_array_display.cpp
+++ b/src/rviz/default_plugin/pose_array_display.cpp
@@ -27,9 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreManualObject.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/pose_display.cpp
+++ b/src/rviz/default_plugin/pose_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreEntity.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/pose_with_covariance_display.cpp
+++ b/src/rviz/default_plugin/pose_with_covariance_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreEntity.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/range_display.cpp
+++ b/src/rviz/default_plugin/range_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/relative_humidity_display.cpp
+++ b/src/rviz/default_plugin/relative_humidity_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 #include <QTimer>
 
 #include <urdf/model.h>

--- a/src/rviz/default_plugin/robot_model_display.h
+++ b/src/rviz/default_plugin/robot_model_display.h
@@ -32,7 +32,7 @@
 
 #include <rviz/display.h>
 
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
 
 #include <map>
 

--- a/src/rviz/default_plugin/screw_display.cpp
+++ b/src/rviz/default_plugin/screw_display.cpp
@@ -1,5 +1,5 @@
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/visualization_manager.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/screw_visual.cpp
+++ b/src/rviz/default_plugin/screw_visual.cpp
@@ -1,6 +1,6 @@
-#include <OgreVector3.h>
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/ogre_helpers/arrow.h>
 #include <rviz/ogre_helpers/billboard_line.h>

--- a/src/rviz/default_plugin/screw_visual.h
+++ b/src/rviz/default_plugin/screw_visual.h
@@ -2,7 +2,7 @@
 #define SCREW_VISUAL_H
 
 #include <geometry_msgs/Vector3.h>
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/temperature_display.cpp
+++ b/src/rviz/default_plugin/temperature_display.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -29,8 +29,8 @@
 
 #include <boost/bind.hpp>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -33,8 +33,8 @@
 #include <map>
 #include <set>
 
-#include <OgreQuaternion.h>
-#include <OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreVector3.h>
 
 #include <rviz/selection/forwards.h>
 

--- a/src/rviz/default_plugin/tools/focus_tool.cpp
+++ b/src/rviz/default_plugin/tools/focus_tool.cpp
@@ -27,10 +27,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreRay.h>
-#include <OgreVector3.h>
-#include <OgreViewport.h>
-#include <OgreCamera.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreCamera.h>
 
 #include <rviz/viewport_mouse_event.h>
 #include <rviz/load_resource.h>

--- a/src/rviz/default_plugin/tools/interaction_tool.cpp
+++ b/src/rviz/default_plugin/tools/interaction_tool.cpp
@@ -27,11 +27,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreCamera.h>
-#include <OgrePlane.h>
-#include <OgreRay.h>
-#include <OgreSceneNode.h>
-#include <OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgrePlane.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreViewport.h>
 
 #include <rviz/render_panel.h>
 #include <rviz/selection/selection_handler.h>

--- a/src/rviz/default_plugin/tools/measure_tool.cpp
+++ b/src/rviz/default_plugin/tools/measure_tool.cpp
@@ -41,7 +41,7 @@
 #include <rviz/selection/selection_manager.h>
 #include <rviz/load_resource.h>
 
-#include <OgreSceneNode.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include <sstream>
 

--- a/src/rviz/default_plugin/tools/measure_tool.h
+++ b/src/rviz/default_plugin/tools/measure_tool.h
@@ -38,7 +38,7 @@
 
 #include <rviz/tool.h>
 
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/tools/point_tool.cpp
+++ b/src/rviz/default_plugin/tools/point_tool.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreRay.h>
-#include <OgreVector3.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgreVector3.h>
 
 #include <rviz/viewport_mouse_event.h>
 #include <rviz/load_resource.h>

--- a/src/rviz/default_plugin/tools/pose_tool.cpp
+++ b/src/rviz/default_plugin/tools/pose_tool.cpp
@@ -27,10 +27,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgrePlane.h>
-#include <OgreRay.h>
-#include <OgreSceneNode.h>
-#include <OgreViewport.h>
+#include <OGRE/OgrePlane.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreViewport.h>
 
 #include <rviz/geometry.h>
 #include <rviz/ogre_helpers/arrow.h>

--- a/src/rviz/default_plugin/tools/pose_tool.h
+++ b/src/rviz/default_plugin/tools/pose_tool.h
@@ -30,7 +30,7 @@
 #ifndef RVIZ_POSE_TOOL_H
 #define RVIZ_POSE_TOOL_H
 
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
 
 #include <QCursor>
 

--- a/src/rviz/default_plugin/tools/selection_tool.cpp
+++ b/src/rviz/default_plugin/tools/selection_tool.cpp
@@ -29,16 +29,16 @@
 
 #include <QKeyEvent>
 
-#include <OgreRay.h>
-#include <OgreSceneManager.h>
-#include <OgreCamera.h>
-#include <OgreMovableObject.h>
-#include <OgreRectangle2D.h>
-#include <OgreSceneNode.h>
-#include <OgreViewport.h>
-#include <OgreMaterialManager.h>
-#include <OgreTexture.h>
-#include <OgreTextureManager.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreMovableObject.h>
+#include <OGRE/OgreRectangle2D.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTexture.h>
+#include <OGRE/OgreTextureManager.h>
 
 #include <ros/time.h>
 

--- a/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.cpp
@@ -27,12 +27,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreCamera.h>
-#include <OgreQuaternion.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreViewport.h>
 
 #include <rviz/display_context.h>
 #include <rviz/ogre_helpers/orthographic.h>

--- a/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.h
@@ -32,7 +32,7 @@
 
 #include <rviz/frame_position_tracking_view_controller.h>
 
-#include <OgreQuaternion.h>
+#include <OGRE/OgreQuaternion.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/view_controllers/fps_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/fps_view_controller.cpp
@@ -35,9 +35,9 @@
 #include <rviz/properties/bool_property.h>
 #include <rviz/properties/vector_property.h>
 
-#include <OgreViewport.h>
-#include <OgreCamera.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneNode.h>
 #include <Eigen/Geometry>
 #include <QSignalBlocker>
 

--- a/src/rviz/default_plugin/view_controllers/frame_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/frame_view_controller.cpp
@@ -35,9 +35,9 @@
 #include <rviz/properties/bool_property.h>
 #include <rviz/properties/vector_property.h>
 
-#include <OgreViewport.h>
-#include <OgreCamera.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneNode.h>
 #include <Eigen/Geometry>
 #include <QSignalBlocker>
 

--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
@@ -29,12 +29,12 @@
 
 #include <stdint.h>
 
-#include <OgreCamera.h>
-#include <OgreQuaternion.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreViewport.h>
 
 #include <rviz/display_context.h>
 #include <rviz/geometry.h>

--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.h
@@ -30,7 +30,7 @@
 #ifndef RVIZ_ORBIT_VIEW_CONTROLLER_H
 #define RVIZ_ORBIT_VIEW_CONTROLLER_H
 
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
 
 #include <QCursor>
 

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
@@ -31,14 +31,14 @@
 
 #include <ros/ros.h>
 
-#include <OgreCamera.h>
-#include <OgrePlane.h>
-#include <OgreQuaternion.h>
-#include <OgreRay.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreViewport.h>
-#include <OgreMath.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgrePlane.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreMath.h>
 
 #include <rviz/display_context.h>
 #include <rviz/ogre_helpers/shape.h>

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
@@ -32,7 +32,7 @@
 
 #include <rviz/default_plugin/view_controllers/orbit_view_controller.h>
 
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
 
 namespace Ogre
 {

--- a/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.cpp
@@ -31,13 +31,13 @@
 
 #include <ros/ros.h>
 
-#include <OgreCamera.h>
-#include <OgrePlane.h>
-#include <OgreQuaternion.h>
-#include <OgreRay.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgrePlane.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreViewport.h>
 
 #include <rviz/display_context.h>
 #include <rviz/ogre_helpers/shape.h>

--- a/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.h
@@ -32,7 +32,7 @@
 
 #include <rviz/default_plugin/view_controllers/orbit_view_controller.h>
 
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
 
 namespace Ogre
 {

--- a/src/rviz/display.cpp
+++ b/src/rviz/display.cpp
@@ -36,8 +36,8 @@
 #include <QMetaObject>
 #include <QWidget>
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include <rviz/display_context.h>
 #include <rviz/ogre_helpers/apply_visibility_bits.h>

--- a/src/rviz/frame_manager.h
+++ b/src/rviz/frame_manager.h
@@ -38,8 +38,8 @@
 #include <tf2_ros/buffer.h>
 #include <geometry_msgs/Pose.h>
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
 
 #include <boost/thread/mutex.hpp>
 

--- a/src/rviz/frame_position_tracking_view_controller.cpp
+++ b/src/rviz/frame_position_tracking_view_controller.cpp
@@ -27,9 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreCamera.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/frame_position_tracking_view_controller.h
+++ b/src/rviz/frame_position_tracking_view_controller.h
@@ -30,8 +30,8 @@
 #ifndef RVIZ_FRAME_POSITION_TRACKING_VIEW_CONTROLLER_H
 #define RVIZ_FRAME_POSITION_TRACKING_VIEW_CONTROLLER_H
 
-#include <OgreQuaternion.h>
-#include <OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreVector3.h>
 
 #include <rviz/view_controller.h>
 #include <rviz/rviz_export.h>

--- a/src/rviz/geometry.cpp
+++ b/src/rviz/geometry.cpp
@@ -27,11 +27,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreRay.h>
-#include <OgrePlane.h>
-#include <OgreCamera.h>
-#include <OgreSceneNode.h>
-#include <OgreViewport.h>
+#include <OGRE/OgreRay.h>
+#include <OGRE/OgrePlane.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreViewport.h>
 
 #include "geometry.h"
 

--- a/src/rviz/geometry.h
+++ b/src/rviz/geometry.h
@@ -30,7 +30,7 @@
 #ifndef GEOMETRY_H
 #define GEOMETRY_H
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/image/ros_image_texture.cpp
+++ b/src/rviz/image/ros_image_texture.cpp
@@ -35,7 +35,7 @@
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/foreach.hpp>
 
-#include <OgreTextureManager.h>
+#include <OGRE/OgreTextureManager.h>
 
 #include <sensor_msgs/image_encodings.h>
 

--- a/src/rviz/image/ros_image_texture.h
+++ b/src/rviz/image/ros_image_texture.h
@@ -32,9 +32,9 @@
 
 #include <sensor_msgs/Image.h>
 
-#include <OgreTexture.h>
-#include <OgreImage.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreTexture.h>
+#include <OGRE/OgreImage.h>
+#include <OGRE/OgreSharedPtr.h>
 
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -33,19 +33,19 @@
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include <OgreMeshManager.h>
-#include <OgreTextureManager.h>
-#include <OgreMaterialManager.h>
-#include <OgreTexture.h>
-#include <OgrePass.h>
-#include <OgreTechnique.h>
-#include <OgreMaterial.h>
-#include <OgreTextureUnitState.h>
-#include <OgreMeshSerializer.h>
-#include <OgreSubMesh.h>
-#include <OgreHardwareBufferManager.h>
-#include <OgreSharedPtr.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreMeshManager.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTexture.h>
+#include <OGRE/OgrePass.h>
+#include <OGRE/OgreTechnique.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreTextureUnitState.h>
+#include <OGRE/OgreMeshSerializer.h>
+#include <OGRE/OgreSubMesh.h>
+#include <OGRE/OgreHardwareBufferManager.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgreTechnique.h>
 
 #include <tinyxml2.h>
 

--- a/src/rviz/mesh_loader.h
+++ b/src/rviz/mesh_loader.h
@@ -30,7 +30,7 @@
 #ifndef RVIZ_MESH_LOADER_H
 #define RVIZ_MESH_LOADER_H
 
-#include <OgreMesh.h>
+#include <OGRE/OgreMesh.h>
 
 namespace rviz
 {

--- a/src/rviz/msg_conversions.h
+++ b/src/rviz/msg_conversions.h
@@ -29,8 +29,8 @@
 #ifndef MSG_CONVERSIONS_H
 #define MSG_CONVERSIONS_H
 
-#include "OgreVector3.h"
-#include "OgreQuaternion.h"
+#include "OGRE/OgreVector3.h"
+#include "OGRE/OgreQuaternion.h"
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/Vector3.h>

--- a/src/rviz/ogre_helpers/apply_visibility_bits.cpp
+++ b/src/rviz/ogre_helpers/apply_visibility_bits.cpp
@@ -29,8 +29,8 @@
 
 #include <stdint.h>
 
-#include <OgreMovableObject.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreMovableObject.h>
+#include <OGRE/OgreSceneNode.h>
 
 namespace rviz
 {

--- a/src/rviz/ogre_helpers/arrow.cpp
+++ b/src/rviz/ogre_helpers/arrow.cpp
@@ -30,10 +30,10 @@
 #include "arrow.h"
 #include "shape.h"
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
 
 #include <sstream>
 

--- a/src/rviz/ogre_helpers/arrow.h
+++ b/src/rviz/ogre_helpers/arrow.h
@@ -32,7 +32,7 @@
 #ifndef OGRE_TOOLS_ARROW_H
 #define OGRE_TOOLS_ARROW_H
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/axes.cpp
+++ b/src/rviz/ogre_helpers/axes.cpp
@@ -30,10 +30,10 @@
 #include "axes.h"
 #include "shape.h"
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
 
 #include <sstream>
 

--- a/src/rviz/ogre_helpers/axes.h
+++ b/src/rviz/ogre_helpers/axes.h
@@ -38,8 +38,8 @@
 
 #include <vector>
 
-#include <OgrePrerequisites.h>
-#include <OgreColourValue.h>
+#include <OGRE/OgrePrerequisites.h>
+#include <OGRE/OgreColourValue.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -29,13 +29,13 @@
 
 #include "billboard_line.h"
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreBillboardChain.h>
-#include <OgreMaterialManager.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreBillboardChain.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTechnique.h>
 
 #include <sstream>
 

--- a/src/rviz/ogre_helpers/billboard_line.h
+++ b/src/rviz/ogre_helpers/billboard_line.h
@@ -35,10 +35,10 @@
 #include <stdint.h>
 
 #include <vector>
-#include <OgreVector3.h>
-#include <OgreColourValue.h>
-#include <OgreMaterial.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreColourValue.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreSharedPtr.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/camera_base.cpp
+++ b/src/rviz/ogre_helpers/camera_base.cpp
@@ -29,11 +29,11 @@
 
 #include "camera_base.h"
 
-#include <OgreCamera.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
 
 #include <stdint.h>
 #include <sstream>

--- a/src/rviz/ogre_helpers/camera_base.h
+++ b/src/rviz/ogre_helpers/camera_base.h
@@ -30,8 +30,8 @@
 #ifndef OGRE_TOOLS_CAMERA_BASE_H_
 #define OGRE_TOOLS_CAMERA_BASE_H_
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/compatibility.h
+++ b/src/rviz/ogre_helpers/compatibility.h
@@ -32,13 +32,13 @@
 #define OGRE_HELPERS_COMPATIBILITY_H
 
 #include <rviz/ogre_helpers/version_check.h>
-#include <OgreSimpleRenderable.h>
+#include <OGRE/OgreSimpleRenderable.h>
 
 #if OGRE_VERSION < OGRE_VERSION_CHECK(1, 10, 0)
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneManager.h>
 #else
-#include <OgreMaterialManager.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreSceneNode.h>
 #endif
 
 #include <string>

--- a/src/rviz/ogre_helpers/grid.cpp
+++ b/src/rviz/ogre_helpers/grid.cpp
@@ -30,13 +30,13 @@
 #include "grid.h"
 #include "billboard_line.h"
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTechnique.h>
 
 #include <sstream>
 

--- a/src/rviz/ogre_helpers/grid.h
+++ b/src/rviz/ogre_helpers/grid.h
@@ -34,9 +34,9 @@
 
 #include <vector>
 
-#include <OgreColourValue.h>
-#include <OgreMaterial.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreColourValue.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreSharedPtr.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/initialization.cpp
+++ b/src/rviz/ogre_helpers/initialization.cpp
@@ -1,7 +1,7 @@
 #include "initialization.h"
 
-#include <OgreRoot.h>
-#include <OgreRenderSystem.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreRenderSystem.h>
 
 #include <exception>
 #include <stdexcept>

--- a/src/rviz/ogre_helpers/line.cpp
+++ b/src/rviz/ogre_helpers/line.cpp
@@ -31,11 +31,11 @@
 
 #include <sstream>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTechnique.h>
 
 namespace rviz
 {

--- a/src/rviz/ogre_helpers/line.h
+++ b/src/rviz/ogre_helpers/line.h
@@ -32,10 +32,10 @@
 
 #include "object.h"
 
-#include <OgreSceneNode.h>
-#include <OgreMaterial.h>
-#include <OgreSharedPtr.h>
-#include <OgrePrerequisites.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/mesh_shape.cpp
+++ b/src/rviz/ogre_helpers/mesh_shape.cpp
@@ -29,13 +29,13 @@
 
 #include "mesh_shape.h"
 
-#include <OgreMesh.h>
-#include <OgreMeshManager.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreEntity.h>
-#include <OgreMaterialManager.h>
-#include <OgreManualObject.h>
+#include <OGRE/OgreMesh.h>
+#include <OGRE/OgreMeshManager.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreManualObject.h>
 
 #include <ros/console.h>
 #include <boost/lexical_cast.hpp>

--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -41,16 +41,16 @@
 
 #include "movable_text.h"
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreRoot.h>
-#include <OgreCamera.h>
-#include <OgreSceneNode.h>
-#include <OgreMaterialManager.h>
-#include <OgreHardwareBufferManager.h>
-#include <OgreFontManager.h>
-#include <OgreFont.h>
-#include <OgreUTFString.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreHardwareBufferManager.h>
+#include <OGRE/OgreFontManager.h>
+#include <OGRE/OgreFont.h>
+#include <OGRE/OgreUTFString.h>
 
 #include <sstream>
 

--- a/src/rviz/ogre_helpers/movable_text.h
+++ b/src/rviz/ogre_helpers/movable_text.h
@@ -43,9 +43,9 @@
 #define OGRE_TOOLS_MOVABLE_TEXT_H
 
 #include <rviz/ogre_helpers/version_check.h>
-#include <OgrePrerequisites.h>
-#include <OgreMovableObject.h>
-#include <OgreRenderable.h>
+#include <OGRE/OgrePrerequisites.h>
+#include <OGRE/OgreMovableObject.h>
+#include <OGRE/OgreRenderable.h>
 #include <rviz/ogre_helpers/version_check.h>
 
 namespace Ogre

--- a/src/rviz/ogre_helpers/object.h
+++ b/src/rviz/ogre_helpers/object.h
@@ -31,7 +31,7 @@
 #define OGRE_TOOLS_OBJECT_H
 
 #include <rviz/rviz_export.h>
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/ogre_logging.cpp
+++ b/src/rviz/ogre_helpers/ogre_logging.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreLogManager.h>
-#include <OgreLog.h>
+#include <OGRE/OgreLogManager.h>
+#include <OGRE/OgreLog.h>
 
 #include <ros/ros.h>
 

--- a/src/rviz/ogre_helpers/ogre_render_queue_clearer.cpp
+++ b/src/rviz/ogre_helpers/ogre_render_queue_clearer.cpp
@@ -29,8 +29,8 @@
 
 #include "ogre_render_queue_clearer.h"
 
-#include <OgreRoot.h>
-#include <OgrePass.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgrePass.h>
 
 namespace rviz
 {

--- a/src/rviz/ogre_helpers/ogre_render_queue_clearer.h
+++ b/src/rviz/ogre_helpers/ogre_render_queue_clearer.h
@@ -30,7 +30,7 @@
 #ifndef OGRERENDERQUEUECLEARER_H_
 #define OGRERENDERQUEUECLEARER_H_
 
-#include <OgreFrameListener.h>
+#include <OGRE/OgreFrameListener.h>
 
 namespace rviz
 {

--- a/src/rviz/ogre_helpers/orbit_camera.cpp
+++ b/src/rviz/ogre_helpers/orbit_camera.cpp
@@ -30,12 +30,12 @@
 #include "orbit_camera.h"
 #include "shape.h"
 
-#include <OgreCamera.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreViewport.h>
 
 #include <cmath>
 #include <stdint.h>

--- a/src/rviz/ogre_helpers/orbit_camera.h
+++ b/src/rviz/ogre_helpers/orbit_camera.h
@@ -31,7 +31,7 @@
 #define OGRE_TOOLS_ORBIT_CAMERA_H_
 
 #include "camera_base.h"
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/orthographic.cpp
+++ b/src/rviz/ogre_helpers/orthographic.cpp
@@ -29,7 +29,7 @@
 
 #include "orthographic.h"
 
-#include <OgreMatrix4.h>
+#include <OGRE/OgreMatrix4.h>
 
 namespace rviz
 {

--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -31,19 +31,19 @@
 #include <ros/assert.h>
 #include <qglobal.h>
 
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreBillboardSet.h>
-#include <OgreBillboard.h>
-#include <OgreTexture.h>
-#include <OgreTextureManager.h>
-#include <OgreSharedPtr.h>
-#include <OgreTechnique.h>
-#include <OgreCamera.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreBillboardSet.h>
+#include <OGRE/OgreBillboard.h>
+#include <OGRE/OgreTexture.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgreTechnique.h>
+#include <OGRE/OgreCamera.h>
 
 #include <sstream>
 

--- a/src/rviz/ogre_helpers/point_cloud.h
+++ b/src/rviz/ogre_helpers/point_cloud.h
@@ -30,16 +30,16 @@
 #ifndef OGRE_TOOLS_OGRE_POINT_CLOUD_H
 #define OGRE_TOOLS_OGRE_POINT_CLOUD_H
 
-#include <OgreSimpleRenderable.h>
-#include <OgreMovableObject.h>
-#include <OgreString.h>
-#include <OgreAxisAlignedBox.h>
-#include <OgreVector3.h>
-#include <OgreMaterial.h>
-#include <OgreColourValue.h>
-#include <OgreRoot.h>
-#include <OgreHardwareBufferManager.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreSimpleRenderable.h>
+#include <OGRE/OgreMovableObject.h>
+#include <OGRE/OgreString.h>
+#include <OGRE/OgreAxisAlignedBox.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreColourValue.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreHardwareBufferManager.h>
+#include <OGRE/OgreSharedPtr.h>
 
 #include <stdint.h>
 

--- a/src/rviz/ogre_helpers/qt_ogre_render_window.cpp
+++ b/src/rviz/ogre_helpers/qt_ogre_render_window.cpp
@@ -31,13 +31,13 @@
 #include "render_system.h"
 #include <rviz/ogre_helpers/version_check.h>
 
-#include <OgreRoot.h>
-#include <OgreViewport.h>
-#include <OgreCamera.h>
-#include <OgreRenderWindow.h>
-#include <OgreStringConverter.h>
-#include <OgreGpuProgramManager.h>
-#include <OgreRenderTargetListener.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreStringConverter.h>
+#include <OGRE/OgreGpuProgramManager.h>
+#include <OGRE/OgreRenderTargetListener.h>
 
 #include <ros/console.h>
 #include <ros/assert.h>

--- a/src/rviz/ogre_helpers/qt_ogre_render_window.h
+++ b/src/rviz/ogre_helpers/qt_ogre_render_window.h
@@ -33,8 +33,8 @@
 
 #include "render_widget.h"
 
-#include <OgreColourValue.h>
-#include <OgreRenderTargetListener.h>
+#include <OGRE/OgreColourValue.h>
+#include <OGRE/OgreRenderTargetListener.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -51,9 +51,9 @@
 #include <ros/console.h>
 
 #include <rviz/ogre_helpers/version_check.h>
-#include <OgreRenderWindow.h>
-#include <OgreSceneManager.h>
-#include <OgreOverlaySystem.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreOverlaySystem.h>
 
 #include <rviz/env_config.h>
 #include <rviz/ogre_helpers/ogre_logging.h>

--- a/src/rviz/ogre_helpers/render_system.h
+++ b/src/rviz/ogre_helpers/render_system.h
@@ -29,7 +29,7 @@
 #ifndef RENDER_SYSTEM_H
 #define RENDER_SYSTEM_H
 
-#include <OgreRoot.h>
+#include <OGRE/OgreRoot.h>
 #include <stdint.h>
 
 #include <rviz/rviz_export.h>

--- a/src/rviz/ogre_helpers/render_widget.cpp
+++ b/src/rviz/ogre_helpers/render_widget.cpp
@@ -31,7 +31,7 @@
 #include <rviz/ogre_helpers/render_system.h>
 #include <rviz/ogre_helpers/version_check.h>
 
-#include <OgreRenderWindow.h>
+#include <OGRE/OgreRenderWindow.h>
 
 #include <QtGlobal>
 #include <QApplication>

--- a/src/rviz/ogre_helpers/shape.cpp
+++ b/src/rviz/ogre_helpers/shape.cpp
@@ -31,14 +31,14 @@
 #include <ros/assert.h>
 
 #include <rviz/ogre_helpers/version_check.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreEntity.h>
-#include <OgreMaterialManager.h>
-#include <OgreTextureManager.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreTechnique.h>
 #include <stdint.h>
 
 namespace rviz

--- a/src/rviz/ogre_helpers/shape.h
+++ b/src/rviz/ogre_helpers/shape.h
@@ -32,9 +32,9 @@
 
 #include "object.h"
 
-#include <OgreMaterial.h>
-#include <OgreVector3.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreSharedPtr.h>
 
 namespace Ogre
 {

--- a/src/rviz/properties/parse_color.h
+++ b/src/rviz/properties/parse_color.h
@@ -32,7 +32,7 @@
 #include <QColor>
 #include <QString>
 
-#include <OgreColourValue.h>
+#include <OGRE/OgreColourValue.h>
 
 namespace rviz
 {

--- a/src/rviz/properties/quaternion_property.h
+++ b/src/rviz/properties/quaternion_property.h
@@ -29,7 +29,7 @@
 #ifndef QUATERNION_PROPERTY_H
 #define QUATERNION_PROPERTY_H
 
-#include <OgreQuaternion.h>
+#include <OGRE/OgreQuaternion.h>
 
 #include <rviz/properties/property.h>
 

--- a/src/rviz/properties/vector_property.h
+++ b/src/rviz/properties/vector_property.h
@@ -29,7 +29,7 @@
 #ifndef VECTOR_PROPERTY_H
 #define VECTOR_PROPERTY_H
 
-#include <OgreVector3.h>
+#include <OGRE/OgreVector3.h>
 
 #include <rviz/properties/property.h>
 #include <rviz/rviz_export.h>

--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -33,8 +33,8 @@
 #include <utility>
 
 
-#include <OgreSceneManager.h>
-#include <OgreCamera.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreCamera.h>
 
 #include <rviz/display.h>
 #include <rviz/view_controller.h>

--- a/src/rviz/render_panel.h
+++ b/src/rviz/render_panel.h
@@ -33,7 +33,7 @@
 #include "ogre_helpers/qt_ogre_render_window.h"
 
 #ifndef Q_MOC_RUN
-#include <OgreSceneManager.h>
+#include <OGRE/OgreSceneManager.h>
 
 #include <boost/thread/mutex.hpp>
 #endif

--- a/src/rviz/robot/link_updater.h
+++ b/src/rviz/robot/link_updater.h
@@ -33,7 +33,7 @@
 #include <string>
 #include <rviz/properties/status_property.h>
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace rviz
 {

--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -41,12 +41,12 @@
 
 #include <urdf_model/model.h>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreEntity.h>
-#include <OgreMaterialManager.h>
-#include <OgreMaterial.h>
-#include <OgreResourceGroupManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreResourceGroupManager.h>
 
 #include <ros/console.h>
 #include <ros/assert.h>

--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -35,13 +35,13 @@
 #include <string>
 #include <map>
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreAny.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreAny.h>
 
 #include <urdf/model.h> // can be replaced later by urdf_model/types.h
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace Ogre
 {

--- a/src/rviz/robot/robot_joint.cpp
+++ b/src/rviz/robot/robot_joint.cpp
@@ -31,7 +31,7 @@
 #include <rviz/robot/robot_link.h>
 #include <rviz/robot/robot.h>
 
-#include <OgreSceneNode.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include <rviz/properties/float_property.h>
 #include <rviz/properties/vector_property.h>

--- a/src/rviz/robot/robot_joint.h
+++ b/src/rviz/robot/robot_joint.h
@@ -36,10 +36,10 @@
 #include <QObject>
 
 #ifndef Q_MOC_RUN
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreAny.h>
-#include <OgreMaterial.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreAny.h>
+#include <OGRE/OgreMaterial.h>
 #endif
 
 #include <urdf/model.h>
@@ -48,7 +48,7 @@
 #include <rviz/ogre_helpers/object.h>
 #include <rviz/selection/forwards.h>
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace Ogre
 {

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -29,16 +29,16 @@
 
 #include <boost/filesystem.hpp>
 
-#include <OgreEntity.h>
-#include <OgreMaterial.h>
-#include <OgreMaterialManager.h>
-#include <OgreRibbonTrail.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreSubEntity.h>
-#include <OgreTextureManager.h>
-#include <OgreSharedPtr.h>
-#include <OgreTechnique.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreRibbonTrail.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSubEntity.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgreTechnique.h>
 
 #include <ros/console.h>
 

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -36,11 +36,11 @@
 #include <QObject>
 
 #ifndef Q_MOC_RUN
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreAny.h>
-#include <OgreMaterial.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
+#include <OGRE/OgreAny.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreSharedPtr.h>
 #endif
 
 #include <urdf/model.h> // can be replaced later by urdf_model/types.h
@@ -49,7 +49,7 @@
 #include <rviz/ogre_helpers/object.h>
 #include <rviz/selection/forwards.h>
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 namespace Ogre
 {

--- a/src/rviz/robot/tf_link_updater.cpp
+++ b/src/rviz/robot/tf_link_updater.cpp
@@ -31,8 +31,8 @@
 #include <rviz/frame_manager.h>
 #include <rviz/helpers/tf_prefix.h>
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
 
 namespace rviz
 {

--- a/src/rviz/selection/forwards.h
+++ b/src/rviz/selection/forwards.h
@@ -34,8 +34,8 @@
 #include <set>
 #include <map>
 #include <boost/unordered_map.hpp>
-#include <OgrePixelFormat.h>
-#include <OgreColourValue.h>
+#include <OGRE/OgrePixelFormat.h>
+#include <OGRE/OgreColourValue.h>
 
 #include <ros/console.h>
 

--- a/src/rviz/selection/selection_handler.cpp
+++ b/src/rviz/selection/selection_handler.cpp
@@ -34,12 +34,12 @@
 
 #include <ros/assert.h>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-#include <OgreManualObject.h>
-#include <OgreWireBoundingBox.h>
-#include <OgreEntity.h>
-#include <OgreSubEntity.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreWireBoundingBox.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreSubEntity.h>
 
 #include <rviz/selection/selection_manager.h>
 #include <rviz/ogre_helpers/compatibility.h>

--- a/src/rviz/selection/selection_handler.h
+++ b/src/rviz/selection/selection_handler.h
@@ -37,7 +37,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
 
-#include <OgreMovableObject.h>
+#include <OGRE/OgreMovableObject.h>
 #endif
 
 #include <rviz/selection/forwards.h>

--- a/src/rviz/selection/selection_manager.cpp
+++ b/src/rviz/selection/selection_manager.cpp
@@ -31,23 +31,23 @@
 
 #include <QTimer>
 
-#include <OgreCamera.h>
-#include <OgreEntity.h>
-#include <OgreHardwarePixelBuffer.h>
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
-#include <OgreRenderSystem.h>
-#include <OgreRenderTexture.h>
-#include <OgreRoot.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreSubEntity.h>
-#include <OgreTextureManager.h>
-#include <OgreViewport.h>
-#include <OgreWireBoundingBox.h>
-#include <OgreSharedPtr.h>
-#include <OgreTechnique.h>
-#include <OgreRectangle2D.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreHardwarePixelBuffer.h>
+#include <OGRE/OgreManualObject.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreRenderSystem.h>
+#include <OGRE/OgreRenderTexture.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreSubEntity.h>
+#include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreWireBoundingBox.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgreTechnique.h>
+#include <OGRE/OgreRectangle2D.h>
 
 #include <sensor_msgs/image_encodings.h>
 #include <sensor_msgs/Image.h>

--- a/src/rviz/selection/selection_manager.h
+++ b/src/rviz/selection/selection_manager.h
@@ -43,12 +43,12 @@
 #include <boost/unordered_map.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 
-#include <OgreTexture.h>
-#include <OgreMaterial.h>
-#include <OgreMaterialManager.h>
-#include <OgreMovableObject.h>
-#include <OgreRenderQueueListener.h>
-#include <OgreSharedPtr.h>
+#include <OGRE/OgreTexture.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreMovableObject.h>
+#include <OGRE/OgreRenderQueueListener.h>
+#include <OGRE/OgreSharedPtr.h>
 #endif
 
 #include <vector>

--- a/src/rviz/validate_floats.h
+++ b/src/rviz/validate_floats.h
@@ -38,8 +38,8 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Twist.h>
 #include <std_msgs/ColorRGBA.h>
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreVector3.h>
+#include <OGRE/OgreQuaternion.h>
 
 #include <boost/array.hpp>
 

--- a/src/rviz/validate_quaternions.h
+++ b/src/rviz/validate_quaternions.h
@@ -31,7 +31,7 @@
 #define RVIZ_VALIDATE_QUATERNIONS_H
 
 #include <geometry_msgs/PoseStamped.h>
-#include <OgreQuaternion.h>
+#include <OGRE/OgreQuaternion.h>
 #include <ros/ros.h>
 #include <tf2/LinearMath/Quaternion.h>
 

--- a/src/rviz/view_controller.cpp
+++ b/src/rviz/view_controller.cpp
@@ -31,9 +31,9 @@
 #include <QFont>
 #include <QKeyEvent>
 
-#include <OgreCamera.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/view_controller.h
+++ b/src/rviz/view_controller.h
@@ -36,7 +36,7 @@
 #include <utility>
 
 
-#include <OgrePrerequisites.h>
+#include <OGRE/OgrePrerequisites.h>
 
 #include <rviz/properties/property.h>
 #include <rviz/rviz_export.h>

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -60,8 +60,8 @@
 #include <ros/package.h>
 #include <ros/init.h>
 
-#include <OgreRenderWindow.h>
-#include <OgreMeshManager.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreMeshManager.h>
 
 #include <rviz/ogre_helpers/initialization.h>
 

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -37,16 +37,16 @@
 
 #include <boost/bind.hpp>
 
-#include <OgreRoot.h>
-#include <OgreSceneManager.h>
-#include <OgreSceneNode.h>
-#include <OgreLight.h>
-#include <OgreViewport.h>
-#include <OgreMaterialManager.h>
-#include <OgreMaterial.h>
-#include <OgreRenderWindow.h>
-#include <OgreSharedPtr.h>
-#include <OgreCamera.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreLight.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreMaterial.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreSharedPtr.h>
+#include <OGRE/OgreCamera.h>
 
 #include <boost/filesystem.hpp>
 #include <utility>

--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -33,9 +33,9 @@
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 
-#include <OgreMaterialManager.h>
-#include <OgreGpuProgramManager.h>
-#include <OgreHighLevelGpuProgramManager.h>
+#include <OGRE/OgreMaterialManager.h>
+#include <OGRE/OgreGpuProgramManager.h>
+#include <OGRE/OgreHighLevelGpuProgramManager.h>
 #include <std_srvs/Empty.h>
 
 #ifdef Q_OS_MAC

--- a/src/test/render_points_test.cpp
+++ b/src/test/render_points_test.cpp
@@ -34,8 +34,8 @@
 #include <QApplication>
 #include <QVBoxLayout>
 
-#include <OgreCamera.h>
-#include <OgreSceneNode.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreSceneNode.h>
 
 using namespace rviz;
 

--- a/src/test/render_points_test.h
+++ b/src/test/render_points_test.h
@@ -44,10 +44,10 @@
 #include <rviz/ogre_helpers/billboard_line.h>
 #include <rviz/ogre_helpers/render_system.h>
 
-#include <OgreRoot.h>
-#include <OgreSceneManager.h>
-#include <OgreViewport.h>
-#include <OgreLight.h>
+#include <OGRE/OgreRoot.h>
+#include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreViewport.h>
+#include <OGRE/OgreLight.h>
 
 #include <ros/time.h>
 #endif

--- a/src/test/two_render_widgets.cpp
+++ b/src/test/two_render_widgets.cpp
@@ -35,11 +35,11 @@
 #include <QVBoxLayout>
 #include <QPushButton>
 
-#include <OgreCamera.h>
-#include <OgreEntity.h>
-#include <OgreRenderWindow.h>
-#include <OgreSceneNode.h>
-#include <OgreViewport.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreEntity.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreSceneNode.h>
+#include <OGRE/OgreViewport.h>
 
 using namespace rviz;
 


### PR DESCRIPTION
... to silence warnings about upstream files.

According to the pkgconfig and the cmake files of Ogre, /usr/include
is an include folder for the project and thus <OGRE/Ogre...> is a valid include path.

The following illustrates the behavior with one of various warnings:
<<<
❯ cat bar.cpp
❯ clang++ -Werror -Wall -Wextra -pedantic -std=c++14 -c bar.cpp -I/usr/include/OGRE
In file included from bar.cpp:1:
In file included from /usr/include/OGRE/OgrePixelFormat.h:31:
In file included from /usr/include/OGRE/OgrePrerequisites.h:326:
In file included from /usr/include/OGRE/OgreMemoryAllocatorConfig.h:188:
/usr/include/OGRE/OgreMemorySTLAllocator.h:130:4: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
                        register size_type sz = count*sizeof( T );
                        ^~~~~~~~~
1 error generated.
❯ cat foo.cpp
❯ clang++ -Werror -Wall -Wextra -pedantic -std=c++14 -c foo.cpp
❯
<<<

RViz surpresses these warnings with `include_directories(SYSTEM ${OGRE_INCLUDE_DIRS})`
but passes the plain OGRE_INCLUDE_DIRS variable on in catkin_package(INCLUDE_DIRS ...).
There is no way to specify a SYSTEM include there.
Consequently all downstream projects including rviz headers will see OGRE's warnings
and have no easy way to avoid them because the correct OGRE include path is only one entry in
${rviz_INCLUDE_DIRS} (or more likely ${catkin_INCLUDE_DIRS}).

Came up in https://github.com/ros-planning/moveit_task_constructor/pull/273#issuecomment-853887647