### PR TITLE
Fix resizeEvent for OGRE==1.10

### DIFF
--- a/src/rviz/ogre_helpers/render_widget.cpp
+++ b/src/rviz/ogre_helpers/render_widget.cpp
@@ -98,7 +98,7 @@ void RenderWidget::resizeEvent(QResizeEvent* e)
      * So here we just always force it to be even. */
     const int w = width() * pixel_ratio_;
     render_window_->resize(w + (w % 2), height() * pixel_ratio_);
-#if OGRE_VERSION < OGRE_VERSION_CHECK(1, 10, 0)
+#if OGRE_VERSION < OGRE_VERSION_CHECK(1, 12, 0)
     render_window_->windowMovedOrResized();
 #endif
   }


### PR DESCRIPTION
Several users in the RoboStack project reported that rviz scaling didn't work for high-dpi screens: https://github.com/RoboStack/ros-noetic/issues/102

We use Ogre 1.10 in RoboStack. After applying https://github.com/RoboStack/ros-noetic/commit/057e616d4d03c4dc23567dd1b82d2add4b7de2d0 it is now working fine.

Therefore, I think the selector for the Ogre version was wrong and this PR fixes it.