### PR TITLE
Add configurable features for camera view panel

### DIFF
--- a/src/rviz/view_controller.cpp
+++ b/src/rviz/view_controller.cpp
@@ -62,6 +62,20 @@ ViewController::ViewController()
   near_clip_property_->setMin(0.001);
   near_clip_property_->setMax(10000);
 
+  far_clip_property_ =
+      new FloatProperty("Far Clip Distance", 100.0f,
+                        "Anything farer to the camera than this threshold will not get rendered.", this,
+                        SLOT(updateFarClipDistance()));
+  far_clip_property_->setMin(0.001);
+  far_clip_property_->setMax(100000);
+
+  fov_property_ =
+      new FloatProperty("Vertical FOV", 45.0f, "Vertical Filed Of View (FOV) of camera (degrees).", this,
+                        SLOT(updateVerticalFOV()));
+  fov_property_->setMin(1);
+  fov_property_->setMax(90);
+
+
   stereo_enable_ = new BoolProperty("Enable Stereo Rendering", true,
                                     "Render the main view in stereo if supported."
                                     "  On Linux this requires a recent version of Ogre and"
@@ -108,6 +122,8 @@ void ViewController::initialize(DisplayContext* context)
   standard_cursors_[Crosshair] = makeIconCursor("package://rviz/icons/crosshair.svg");
 
   updateNearClipDistance();
+  updateFarClipDistance();
+  updateVerticalFOV();
   updateStereoProperties();
 
   if (!RenderSystem::get()->isStereoSupported())
@@ -243,6 +259,18 @@ void ViewController::updateNearClipDistance()
 {
   float n = near_clip_property_->getFloat();
   camera_->setNearClipDistance(n);
+}
+
+void ViewController::updateFarClipDistance()
+{
+  float n = far_clip_property_->getFloat();
+  camera_->setFarClipDistance(n);
+}
+
+void ViewController::updateVerticalFOV()
+{
+  float n = fov_property_->getFloat();
+  camera_->setFOVy(Ogre::Radian(n / 180 * M_PI));
 }
 
 void ViewController::updateStereoProperties()

--- a/src/rviz/view_controller.h
+++ b/src/rviz/view_controller.h
@@ -184,6 +184,8 @@ Q_SIGNALS:
 private Q_SLOTS:
 
   void updateNearClipDistance();
+  void updateFarClipDistance();
+  void updateVerticalFOV();
   void updateStereoProperties();
   void updateInvertZAxis();
 
@@ -233,6 +235,8 @@ protected:
   QCursor cursor_;
 
   FloatProperty* near_clip_property_;
+  FloatProperty* far_clip_property_;
+  FloatProperty* fov_property_;
   BoolProperty* stereo_enable_;
   BoolProperty* stereo_eye_swap_;
   FloatProperty* stereo_eye_separation_;


### PR DESCRIPTION
### Description

Add option to modify far clip and vertical FOV of camera view, which are useful when viewing in FPS mode (e.g. frame aligned mode).

- camera view panel before changing:
![Screenshot from 2021-06-11 11-29-08](https://user-images.githubusercontent.com/3666095/121622272-ac5ca000-caa8-11eb-82ae-7776fade3764.png)

- after change:

![Screenshot from 2021-06-11 11-18-54](https://user-images.githubusercontent.com/3666095/121622294-b8e0f880-caa8-11eb-9858-ccd79eef520c.png)
