### PR TITLE
Pause asynchronous ROS updates with synchronous ones

### DIFF
--- a/src/rviz/default_plugin/depth_cloud_display.cpp
+++ b/src/rviz/default_plugin/depth_cloud_display.cpp
@@ -159,10 +159,6 @@ void DepthCloudDisplay::onInitialize()
   updateUseAutoSize();
   updateUseOcclusionCompensation();
 
-  // PointCloudCommon sets up a callback queue with a thread for each
-  // instance.  Use that for processing incoming messages.
-  threaded_nh_.setCallbackQueue(pointcloud_common_->getCallbackQueue());
-
   // Scan for available transport plugins
   scanForTransportSubscriberPlugins();
 

--- a/src/rviz/default_plugin/fluid_pressure_display.cpp
+++ b/src/rviz/default_plugin/fluid_pressure_display.cpp
@@ -52,10 +52,6 @@ FluidPressureDisplay::FluidPressureDisplay() : point_cloud_common_(new PointClou
       " Increasing this is useful if your incoming TF data is delayed significantly "
       "from your FluidPressure data, but it can greatly increase memory usage if the messages are big.",
       this, SLOT(updateQueueSize()));
-
-  // PointCloudCommon sets up a callback queue with a thread for each
-  // instance.  Use that for processing incoming messages.
-  update_nh_.setCallbackQueue(point_cloud_common_->getCallbackQueue());
 }
 
 FluidPressureDisplay::~FluidPressureDisplay()
@@ -65,6 +61,9 @@ FluidPressureDisplay::~FluidPressureDisplay()
 
 void FluidPressureDisplay::onInitialize()
 {
+  // Use the threaded queue for processing of incoming messages
+  update_nh_.setCallbackQueue(context_->getThreadedQueue());
+
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 

--- a/src/rviz/default_plugin/illuminance_display.cpp
+++ b/src/rviz/default_plugin/illuminance_display.cpp
@@ -52,10 +52,6 @@ IlluminanceDisplay::IlluminanceDisplay() : point_cloud_common_(new PointCloudCom
       " Increasing this is useful if your incoming TF data is delayed significantly "
       "from your Illuminance data, but it can greatly increase memory usage if the messages are big.",
       this, SLOT(updateQueueSize()));
-
-  // PointCloudCommon sets up a callback queue with a thread for each
-  // instance.  Use that for processing incoming messages.
-  update_nh_.setCallbackQueue(point_cloud_common_->getCallbackQueue());
 }
 
 IlluminanceDisplay::~IlluminanceDisplay()
@@ -65,6 +61,9 @@ IlluminanceDisplay::~IlluminanceDisplay()
 
 void IlluminanceDisplay::onInitialize()
 {
+  // Use the threaded queue for processing of incoming messages
+  update_nh_.setCallbackQueue(context_->getThreadedQueue());
+
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 

--- a/src/rviz/default_plugin/laser_scan_display.cpp
+++ b/src/rviz/default_plugin/laser_scan_display.cpp
@@ -54,10 +54,6 @@ LaserScanDisplay::LaserScanDisplay()
       " Increasing this is useful if your incoming TF data is delayed significantly "
       "from your LaserScan data, but it can greatly increase memory usage if the messages are big.",
       this, SLOT(updateQueueSize()));
-
-  // PointCloudCommon sets up a callback queue with a thread for each
-  // instance.  Use that for processing incoming messages.
-  update_nh_.setCallbackQueue(point_cloud_common_->getCallbackQueue());
 }
 
 LaserScanDisplay::~LaserScanDisplay()
@@ -68,6 +64,9 @@ LaserScanDisplay::~LaserScanDisplay()
 
 void LaserScanDisplay::onInitialize()
 {
+  // Use the threaded queue for processing of incoming messages
+  update_nh_.setCallbackQueue(context_->getThreadedQueue());
+
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 }

--- a/src/rviz/default_plugin/point_cloud2_display.cpp
+++ b/src/rviz/default_plugin/point_cloud2_display.cpp
@@ -52,10 +52,6 @@ PointCloud2Display::PointCloud2Display() : point_cloud_common_(new PointCloudCom
       " Increasing this is useful if your incoming TF data is delayed significantly "
       "from your PointCloud2 data, but it can greatly increase memory usage if the messages are big.",
       this, SLOT(updateQueueSize()));
-
-  // PointCloudCommon sets up a callback queue with a thread for each
-  // instance.  Use that for processing incoming messages.
-  update_nh_.setCallbackQueue(point_cloud_common_->getCallbackQueue());
 }
 
 PointCloud2Display::~PointCloud2Display()
@@ -65,6 +61,9 @@ PointCloud2Display::~PointCloud2Display()
 
 void PointCloud2Display::onInitialize()
 {
+  // Use the threaded queue for processing of incoming messages
+  update_nh_.setCallbackQueue(context_->getThreadedQueue());
+
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 }

--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -307,7 +307,6 @@ void PointCloudCommon::CloudInfo::clear()
 
 PointCloudCommon::PointCloudCommon(Display* display)
   : auto_size_(false)
-  , spinner_(1, &cbqueue_)
   , new_xyz_transformer_(false)
   , new_color_transformer_(false)
   , needs_retransform_(false)
@@ -377,18 +376,11 @@ void PointCloudCommon::initialize(DisplayContext* context, Ogre::SceneNode* scen
   updateBillboardSize();
   updateAlpha();
   updateSelectable();
-
-  spinner_.start();
 }
 
 PointCloudCommon::~PointCloudCommon()
 {
-  spinner_.stop();
-
-  if (transformer_class_loader_)
-  {
-    delete transformer_class_loader_;
-  }
+  delete transformer_class_loader_;
 }
 
 void PointCloudCommon::loadTransformers()

--- a/src/rviz/default_plugin/point_cloud_common.h
+++ b/src/rviz/default_plugin/point_cloud_common.h
@@ -42,9 +42,6 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 
-#include <ros/spinner.h>
-#include <ros/callback_queue.h>
-
 #include <message_filters/time_sequencer.h>
 
 #include <pluginlib/class_loader.hpp>
@@ -130,11 +127,6 @@ public:
   void addMessage(const sensor_msgs::PointCloudConstPtr& cloud);
   void addMessage(const sensor_msgs::PointCloud2ConstPtr& cloud);
 
-  ros::CallbackQueueInterface* getCallbackQueue()
-  {
-    return &cbqueue_;
-  }
-
   Display* getDisplay()
   {
     return display_;
@@ -186,9 +178,6 @@ private:
   float getSelectionBoxSize();
   void setPropertiesHidden(const QList<Property*>& props, bool hide);
   void fillTransformerOptions(EnumProperty* prop, uint32_t mask);
-
-  ros::AsyncSpinner spinner_;
-  ros::CallbackQueue cbqueue_;
 
   D_CloudInfo cloud_infos_;
 

--- a/src/rviz/default_plugin/point_cloud_display.cpp
+++ b/src/rviz/default_plugin/point_cloud_display.cpp
@@ -50,10 +50,6 @@ PointCloudDisplay::PointCloudDisplay() : point_cloud_common_(new PointCloudCommo
       " Increasing this is useful if your incoming TF data is delayed significantly "
       "from your PointCloud data, but it can greatly increase memory usage if the messages are big.",
       this, SLOT(updateQueueSize()));
-
-  // PointCloudCommon sets up a callback queue with a thread for each
-  // instance.  Use that for processing incoming messages.
-  update_nh_.setCallbackQueue(point_cloud_common_->getCallbackQueue());
 }
 
 PointCloudDisplay::~PointCloudDisplay()
@@ -63,6 +59,9 @@ PointCloudDisplay::~PointCloudDisplay()
 
 void PointCloudDisplay::onInitialize()
 {
+  // Use the threaded queue for processing of incoming messages
+  update_nh_.setCallbackQueue(context_->getThreadedQueue());
+
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 }

--- a/src/rviz/default_plugin/relative_humidity_display.cpp
+++ b/src/rviz/default_plugin/relative_humidity_display.cpp
@@ -53,10 +53,6 @@ RelativeHumidityDisplay::RelativeHumidityDisplay() : point_cloud_common_(new Poi
                       "from your RelativeHumidity data, but it can greatly increase memory usage if the "
                       "messages are big.",
                       this, SLOT(updateQueueSize()));
-
-  // PointCloudCommon sets up a callback queue with a thread for each
-  // instance.  Use that for processing incoming messages.
-  update_nh_.setCallbackQueue(point_cloud_common_->getCallbackQueue());
 }
 
 RelativeHumidityDisplay::~RelativeHumidityDisplay()
@@ -66,6 +62,9 @@ RelativeHumidityDisplay::~RelativeHumidityDisplay()
 
 void RelativeHumidityDisplay::onInitialize()
 {
+  // Use the threaded queue for processing of incoming messages
+  update_nh_.setCallbackQueue(context_->getThreadedQueue());
+
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 

--- a/src/rviz/default_plugin/temperature_display.cpp
+++ b/src/rviz/default_plugin/temperature_display.cpp
@@ -52,10 +52,6 @@ TemperatureDisplay::TemperatureDisplay() : point_cloud_common_(new PointCloudCom
       " Increasing this is useful if your incoming TF data is delayed significantly "
       "from your Temperature data, but it can greatly increase memory usage if the messages are big.",
       this, SLOT(updateQueueSize()));
-
-  // PointCloudCommon sets up a callback queue with a thread for each
-  // instance.  Use that for processing incoming messages.
-  update_nh_.setCallbackQueue(point_cloud_common_->getCallbackQueue());
 }
 
 TemperatureDisplay::~TemperatureDisplay()
@@ -65,6 +61,9 @@ TemperatureDisplay::~TemperatureDisplay()
 
 void TemperatureDisplay::onInitialize()
 {
+  // Use the threaded queue for processing of incoming messages
+  update_nh_.setCallbackQueue(context_->getThreadedQueue());
+
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -133,6 +133,7 @@ void DisplaysPanel::onDuplicateDisplay()
   QList<Display*> duplicated_displays;
   QProgressDialog progress_dlg("Duplicating displays...", "Cancel", 0, displays_to_duplicate.size(),
                                this);
+  vis_manager_->stopUpdate();
   progress_dlg.setWindowModality(Qt::WindowModal);
   progress_dlg.show();
   QApplication::processEvents(); // explicitly progress events for update


### PR DESCRIPTION
VisualizationManager uses `[start|stop]Update()` to pause ROS updates during dialog box interaction (#631).
However, asynchronous updates via `threaded_queue_` were still performed, leading to a memory leak (#1621),
because messages were partially processed by the thread (i.e. kept in memory), but not finally processed
(and cleaned up) by the synchronous `Display::update()` call.
Pausing threaded processing too resolves that issue.

Fixes #1621. Fixes #868.
@simonschmeisser: Do you see any issue pausing asynchronous message processing too while displaying dialogs?