### PR TITLE
Extending API for rqt_rviz

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -829,6 +829,7 @@ void VisualizationFrame::setDisplayConfigFile(const std::string& path)
     title = fs::path(path).BOOST_FILENAME_STRING() + "[*] - RViz";
   }
   setWindowTitle(QString::fromStdString(title));
+  Q_EMIT displayConfigFileChanged(QString::fromStdString(path));
 }
 
 bool VisualizationFrame::saveDisplayConfig(const QString& path)

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -489,6 +489,7 @@ void VisualizationFrame::initMenus()
 
   QAction* file_menu_quit_action =
       file_menu_->addAction("&Quit", this, SLOT(close()), QKeySequence("Ctrl+Q"));
+  file_menu_quit_action->setObjectName("actQuit");
   this->addAction(file_menu_quit_action);
 
   view_menu_ = menuBar()->addMenu("&Panels");

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -196,6 +196,9 @@ Q_SIGNALS:
   /** @brief Emitted when the interface enters or leaves full screen mode. */
   void fullScreenChange(bool hidden);
 
+  /** @brief Emitted when the config file has changed */
+  void displayConfigFileChanged(const QString& fullpath);
+
 protected Q_SLOTS:
   void onOpen();
   void onSave();


### PR DESCRIPTION
This adds a new signal `VisualizationFrame::displayConfigFileChanged` and defines a name for the quit action to allow fixing some issues in [`rqt_rviz`](https://github.com/ros-visualization/rqt_rviz).