### PR TITLE
Fix misc point cloud ogre helper bounds issues

### DIFF
--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -540,7 +540,6 @@ void PointCloud::addPoints(Point* points, uint32_t num_points)
     }
 
     aabb.merge(p.position);
-    bounding_radius_ = std::max(bounding_radius_, p.position.squaredLength());
 
     float x = p.position.x;
     float y = p.position.y;
@@ -571,6 +570,7 @@ void PointCloud::addPoints(Point* points, uint32_t num_points)
   op->vertexData->vertexCount = current_vertex_count - op->vertexData->vertexStart;
   rend->setBoundingBox(aabb);
   bounding_box_.merge(aabb);
+  bounding_radius_ = Ogre::Math::boundingRadiusFromAABB(bounding_box_);
   ROS_ASSERT(op->vertexData->vertexCount + op->vertexData->vertexStart <=
              rend->getBuffer()->getNumVertices());
 
@@ -620,13 +620,12 @@ void PointCloud::popPoints(uint32_t num_points)
 
   // reset bounds
   bounding_box_.setNull();
-  bounding_radius_ = 0.0f;
   for (uint32_t i = 0; i < point_count_; ++i)
   {
     Point& p = points_[i];
     bounding_box_.merge(p.position);
-    bounding_radius_ = std::max(bounding_radius_, p.position.squaredLength());
   }
+  bounding_radius_ = Ogre::Math::boundingRadiusFromAABB(bounding_box_);
 
   shrinkRenderables();
 

--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -480,6 +480,7 @@ void PointCloud::addPoints(Point* points, uint32_t num_points)
 
   Ogre::AxisAlignedBox aabb;
   aabb.setNull();
+  Ogre::Vector3 point_size_offset(width_/2.0, height_/2.0, depth_/2.0);
   uint32_t current_vertex_count = 0;
   bounding_radius_ = 0.0f;
   uint32_t vertex_size = 0;
@@ -539,7 +540,8 @@ void PointCloud::addPoints(Point* points, uint32_t num_points)
       root->convertColourValue(p.color, &color);
     }
 
-    aabb.merge(p.position);
+    aabb.merge(p.position + point_size_offset);
+    aabb.merge(p.position - point_size_offset);
 
     float x = p.position.x;
     float y = p.position.y;

--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -806,13 +806,7 @@ Ogre::Real PointCloudRenderable::getBoundingRadius() const
 
 Ogre::Real PointCloudRenderable::getSquaredViewDepth(const Ogre::Camera* cam) const
 {
-  Ogre::Vector3 vMin, vMax, vMid, vDist;
-  vMin = mBox.getMinimum();
-  vMax = mBox.getMaximum();
-  vMid = ((vMax - vMin) * 0.5) + vMin;
-  vDist = cam->getDerivedPosition() - vMid;
-
-  return vDist.squaredLength();
+  return getWorldBoundingBox().squaredDistance(cam->getDerivedPosition());
 }
 
 void PointCloudRenderable::getWorldTransforms(Ogre::Matrix4* xform) const

--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -801,7 +801,7 @@ Ogre::HardwareVertexBufferSharedPtr PointCloudRenderable::getBuffer()
 
 Ogre::Real PointCloudRenderable::getBoundingRadius() const
 {
-  return Ogre::Math::Sqrt(std::max(mBox.getMaximum().squaredLength(), mBox.getMinimum().squaredLength()));
+  return Ogre::Math::boundingRadiusFromAABB(mBox);
 }
 
 Ogre::Real PointCloudRenderable::getSquaredViewDepth(const Ogre::Camera* cam) const


### PR DESCRIPTION
There were a few circumstances where the point cloud ogre helper calculated incorrect bounds. These circumstances were mostly noticed when using the octomap_rviz_plugins to visualize octomaps where the maps would disappear when viewed from certain angles or zoom levels, or when using a non-unity alpha the different prune depths of the tree would render out-of-depth-order due to the bug in getSquaredViewDepth. Sorry I don't have any visuals right now to post with the PR as these commits were made on our branch of rviz a couple years ago and I'm just now getting a bit of time to send the fixes upstream.