### PR TITLE
OgreUTFString was moved in 1.12

### DIFF
--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -50,7 +50,7 @@
 #include <OGRE/OgreHardwareBufferManager.h>
 #include <OGRE/Overlay/OgreFontManager.h>
 #include <OGRE/Overlay/OgreFont.h>
-#include <OGRE/OgreUTFString.h>
+#include <OgreUTFString.h>
 
 #include <sstream>
 


### PR DESCRIPTION
https://github.com/ros-visualization/rviz/commit/41d62f5749b05c68131b752c605191518eaf19d5 breaks compilation on ogre 1.12.x as `OgreUTFString.h` has been moved to `OGRE/Overlay/OgreUTFString.h` here https://github.com/OGRECave/ogre/commit/a9ab158f6f6f1ba87b413525d418c49a9e0528f8

later with the upcoming ogre 1.13 this header is completely gone here
https://github.com/OGRECave/ogre/commit/3d7d116b99e7dea688fbfd010487814259d6685d#diff-0776b468d71baadd36bc4b898e6b2e11ea4b3e117bdf5fbcd8eda3065f3bfb36

will need another (more involved I fear) fixup then