### PR TITLE
Add skeleton import functionality to mesh_loader

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -704,7 +704,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path)
       {
         return Ogre::MeshPtr();
       }
-      loadSkeletonFromResource(resource_path);  // load skeleton to the resource manager
+      loadSkeletonFromResource(resource_path); // load skeleton to the resource manager
 
       Ogre::MeshSerializer ser;
       Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -28,11 +28,15 @@
  */
 
 #include "mesh_loader.h"
+#include <OGRE/OgrePrerequisites.h>
 #include <resource_retriever/retriever.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 
+#include <OGRE/OgreSkeleton.h>
+#include <OGRE/OgreSkeletonManager.h>
+#include <OGRE/OgreSkeletonSerializer.h>
 #include <OGRE/OgreMeshManager.h>
 #include <OGRE/OgreTextureManager.h>
 #include <OGRE/OgreMaterialManager.h>
@@ -56,6 +60,7 @@
 #include <assimp/postprocess.h>
 #include <assimp/IOStream.hpp>
 #include <assimp/IOSystem.hpp>
+#include <boost/filesystem/operations.hpp>
 
 namespace fs = boost::filesystem;
 
@@ -699,6 +704,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path)
       {
         return Ogre::MeshPtr();
       }
+      Ogre::SkeletonPtr skeleton = loadSkeletonFromResource(resource_path);
 
       Ogre::MeshSerializer ser;
       Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));
@@ -727,6 +733,48 @@ Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path)
   }
 
   return Ogre::MeshPtr();
+}
+
+Ogre::SkeletonPtr loadSkeletonFromResource(const std::string& resource_path)
+{
+  std::string skeleton_resource_path = resource_path.substr(0, resource_path.length() - 4);
+  skeleton_resource_path.append("skeleton");
+
+  if (Ogre::SkeletonManager::getSingleton().resourceExists(skeleton_resource_path))
+  {
+    return Ogre::SkeletonManager::getSingleton().getByName(skeleton_resource_path);
+  }
+  else
+  {
+    resource_retriever::Retriever retriever;
+    resource_retriever::MemoryResource res;
+    try
+    {
+      res = retriever.get(skeleton_resource_path);
+    }
+    catch (resource_retriever::Exception& e)
+    {
+      ROS_ERROR("%s", e.what());
+      return Ogre::SkeletonPtr();
+    }
+
+    if (res.size == 0)
+    {
+      return Ogre::SkeletonPtr();
+    }
+
+    fs::path skeleton_path(skeleton_resource_path);
+
+    Ogre::SkeletonSerializer ser;
+    Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));
+    Ogre::SkeletonPtr skeleton = Ogre::SkeletonManager::getSingleton().create(
+        skeleton_path.filename().c_str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, true);
+    ser.importSkeleton(stream, skeleton.get());
+
+    return skeleton;
+  }
+
+  return Ogre::SkeletonPtr();
 }
 
 } // namespace rviz

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -704,7 +704,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path)
       {
         return Ogre::MeshPtr();
       }
-      Ogre::SkeletonPtr skeleton = loadSkeletonFromResource(resource_path);
+      loadSkeletonFromResource(resource_path);  // load skeleton to the resource manager
 
       Ogre::MeshSerializer ser;
       Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));

--- a/src/rviz/mesh_loader.h
+++ b/src/rviz/mesh_loader.h
@@ -31,11 +31,12 @@
 #define RVIZ_MESH_LOADER_H
 
 #include <OGRE/OgreMesh.h>
+#include <OGRE/OgreSkeleton.h>
 
 namespace rviz
 {
 Ogre::MeshPtr loadMeshFromResource(const std::string& resource_path);
-
+Ogre::SkeletonPtr loadSkeletonFromResource(const std::string& resource_path);
 } // namespace rviz
 
 #endif // RVIZ_MESH_LOADER_H


### PR DESCRIPTION


### Description

This adds the functionality of importing an animated mesh to RViz using the same resource_retriever as in mesh_loader. 

Due to the way Ogre3D loads skeleton meshes a developer can automatically import an animated mesh using the same loadMeshFromResource method already present, but with the added functionality of assigning animation states.
The method is mostly the same as loadMeshFromResource but with changes to load the .skeleton file as well into the default resource group. 

Happy to accept any constructive critiques or suggestions on how to make it better!

### Checklist

- [ ] If you are addressing rendering issues, please provide:
  - [ ] Images of both, broken and fixed renderings.
  - [ ] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [ ] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [Will do if accepted! ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
