### PR TITLE
Fix compilation with OGRE 1.12

### DIFF
--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -50,7 +50,11 @@
 #include <OGRE/OgreHardwareBufferManager.h>
 #include <OGRE/Overlay/OgreFontManager.h>
 #include <OGRE/Overlay/OgreFont.h>
+#if OGRE_VERSION < 0x010c00
 #include <OGRE/OgreUTFString.h>
+#else
+#include <OGRE/Overlay/OgreUTFString.h>
+#endif
 
 #include <sstream>
 


### PR DESCRIPTION
The `OgreUTFString.h` header has been moved to `Overlay` for OGRE 1.12.