### PR TITLE
frame axes trail

### DIFF
--- a/src/rviz/default_plugin/axes_display.cpp
+++ b/src/rviz/default_plugin/axes_display.cpp
@@ -31,6 +31,7 @@
 
 #include <OGRE/OgreSceneNode.h>
 #include <OGRE/OgreSceneManager.h>
+#include <OGRE/OgreRibbonTrail.h>
 
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>

--- a/src/rviz/default_plugin/axes_display.cpp
+++ b/src/rviz/default_plugin/axes_display.cpp
@@ -45,9 +45,9 @@ namespace rviz
 {
 AxesDisplay::AxesDisplay() : Display(), axes_(nullptr), trail_(nullptr)
 {
-  frame_property_ =
-      new TfFrameProperty("Reference Frame", TfFrameProperty::FIXED_FRAME_STRING,
-                          "The TF frame these axes will use for their origin.", this, nullptr, true);
+  frame_property_ = new TfFrameProperty("Reference Frame", TfFrameProperty::FIXED_FRAME_STRING,
+                                        "The TF frame these axes will use for their origin.", this,
+                                        nullptr, true, SLOT(resetTrail()));
 
   length_property_ =
       new FloatProperty("Length", 1.0, "Length of each axis, in meters.", this, SLOT(updateShape()));
@@ -84,6 +84,22 @@ void AxesDisplay::onInitialize()
   axes_ = new Axes(scene_manager_, nullptr, length_property_->getFloat(), radius_property_->getFloat(),
                    alpha_property_->getFloat());
   axes_->getSceneNode()->setVisible(isEnabled());
+}
+
+void AxesDisplay::reset()
+{
+  Display::reset();
+  resetTrail(false);
+}
+
+void AxesDisplay::resetTrail(bool update)
+{
+  if (!trail_)
+    return;
+  if (update)
+    this->update(0.0, 0.0);
+  trail_->nodeUpdated(axes_->getSceneNode());
+  trail_->clearAllChains();
 }
 
 void AxesDisplay::onEnable()

--- a/src/rviz/default_plugin/axes_display.cpp
+++ b/src/rviz/default_plugin/axes_display.cpp
@@ -42,7 +42,7 @@
 
 namespace rviz
 {
-AxesDisplay::AxesDisplay() : Display(), axes_(nullptr)
+AxesDisplay::AxesDisplay() : Display(), axes_(nullptr), trail_(nullptr)
 {
   frame_property_ =
       new TfFrameProperty("Reference Frame", TfFrameProperty::FIXED_FRAME_STRING,
@@ -56,6 +56,10 @@ AxesDisplay::AxesDisplay() : Display(), axes_(nullptr)
       new FloatProperty("Radius", 0.1, "Radius of each axis, in meters.", this, SLOT(updateShape()));
   radius_property_->setMin(0.0001);
 
+  trail_property_ =
+      new Property("Show Trail", false, "Enable/disable a 2 meter \"ribbon\" which follows this frame.",
+                   this, SLOT(updateTrail()));
+
   alpha_property_ =
       new FloatProperty("Alpha", 1.0, "Alpha channel value of each axis.", this, SLOT(updateShape()));
   alpha_property_->setMin(0.0);
@@ -64,6 +68,11 @@ AxesDisplay::AxesDisplay() : Display(), axes_(nullptr)
 
 AxesDisplay::~AxesDisplay()
 {
+  if (trail_)
+  {
+    scene_manager_->destroyRibbonTrail(trail_);
+  }
+
   delete axes_;
 }
 
@@ -79,17 +88,50 @@ void AxesDisplay::onInitialize()
 void AxesDisplay::onEnable()
 {
   axes_->getSceneNode()->setVisible(true);
+  if (trail_)
+    trail_->setVisible(true);
 }
 
 void AxesDisplay::onDisable()
 {
   axes_->getSceneNode()->setVisible(false);
+  if (trail_)
+    trail_->setVisible(false);
 }
 
 void AxesDisplay::updateShape()
 {
   axes_->set(length_property_->getFloat(), radius_property_->getFloat(), alpha_property_->getFloat());
   context_->queueRender();
+}
+
+void AxesDisplay::updateTrail()
+{
+  if (trail_property_->getValue().toBool())
+  {
+    if (!trail_)
+    {
+      static int count = 0;
+      std::stringstream ss;
+      ss << "Trail for frame " << frame_property_->getFrame().toStdString() << count++;
+      trail_ = scene_manager_->createRibbonTrail(ss.str());
+      trail_->setMaxChainElements(100);
+      trail_->setInitialWidth(0, 0.01f);
+      trail_->setInitialColour(0, 1, 0, 0);
+      trail_->addNode(axes_->getSceneNode());
+      trail_->setTrailLength(2.0f);
+      trail_->setVisible(isEnabled());
+      axes_->getSceneNode()->getParentSceneNode()->attachObject(trail_);
+    }
+  }
+  else
+  {
+    if (trail_)
+    {
+      scene_manager_->destroyRibbonTrail(trail_);
+      trail_ = nullptr;
+    }
+  }
 }
 
 void AxesDisplay::update(float /*dt*/, float /*ros_dt*/)

--- a/src/rviz/default_plugin/axes_display.h
+++ b/src/rviz/default_plugin/axes_display.h
@@ -32,7 +32,10 @@
 
 #include <rviz/display.h>
 
-#include <OGRE/OgreRibbonTrail.h>
+namespace Ogre
+{
+class RibbonTrail;
+}
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/axes_display.h
+++ b/src/rviz/default_plugin/axes_display.h
@@ -65,14 +65,16 @@ public:
 
 protected:
   // overrides from Display
+  void reset() override;
   void onEnable() override;
   void onDisable() override;
 
 private Q_SLOTS:
   /** @brief Update the length and radius of the axes object from property values. */
   void updateShape();
-
+  /** @brief Create or Destroy trail based on boolean property */
   void updateTrail();
+  void resetTrail(bool update = true);
 
 private:
   Axes* axes_; ///< Handles actually drawing the axes

--- a/src/rviz/default_plugin/axes_display.h
+++ b/src/rviz/default_plugin/axes_display.h
@@ -32,6 +32,8 @@
 
 #include <rviz/display.h>
 
+#include <OGRE/OgreRibbonTrail.h>
+
 namespace rviz
 {
 class Axes;
@@ -67,11 +69,15 @@ private Q_SLOTS:
   /** @brief Update the length and radius of the axes object from property values. */
   void updateShape();
 
+  void updateTrail();
+
 private:
   Axes* axes_; ///< Handles actually drawing the axes
+  Ogre::RibbonTrail* trail_;
 
   FloatProperty* length_property_;
   FloatProperty* radius_property_;
+  Property* trail_property_;
   FloatProperty* alpha_property_;
   TfFrameProperty* frame_property_;
 };


### PR DESCRIPTION
### Description

Add the option to add a trail (`Ogre::RibbonTrail`) to the frame axes display. This replicates the "Show Trail" features from the `RobotModelDisplay`. This implements and fixes https://github.com/ros-visualization/rviz/issues/1627.

The ribbon trail will show the path a frame took. However, when the frame axes and ribbon trail is initialised, it will show a trail from the origin to where the frame is spawned. I am not sure if this intended behaviour that is also present in the `RobotModelDisplay` view.

Edi: I think the problem simply stems from the visualisation of the axes scene node which is rendered at the origin before the first frame pose has been received.

### Checklist

- [x] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [x] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.

![rviz_screenshot_2021_11_02-11_03_42](https://user-images.githubusercontent.com/8226248/139835708-4b1d3d86-def1-405f-b526-f2a06fe10a34.png)

![rviz_screenshot_2021_11_02-11_04_27](https://user-images.githubusercontent.com/8226248/139835710-c5dbe3a3-ba5b-4621-961f-9b54c2aac126.png)

