### PR TITLE
Updated issue template to guide users to try running RViz with C locale

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,3 +21,4 @@ Describe your issue here and explain how to reproduce it.
     paste your console output here
     ```
 * If source build, which git commit?
+* System locale: e.g. `en_US.UTF-8` (get it by running `echo "$LANG $LC_NUMERIC"` on Linux; before reporting a rendering issue, try running RViz with `LANG=C rviz` and report whether the error is reproducible even in this case)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,4 +21,5 @@ Describe your issue here and explain how to reproduce it.
     paste your console output here
     ```
 * If source build, which git commit?
-* System locale: e.g. `en_US.UTF-8` (get it by running `echo "$LANG $LC_NUMERIC"` on Linux; before reporting a rendering issue, try running RViz with `LANG=C rviz` and report whether the error is reproducible even in this case)
+* System locale, i.e. the output of `echo "$LANG $LC_NUMERIC"`:
+  Before reporting a rendering issue, try running RViz with `LANG=C rviz`!


### PR DESCRIPTION
Updated issue template to guide users to try running RViz with C locale. This could prevent (or pinpoint faster) issues like #1665.