### PR TITLE
Fix locale-dependent string-to-float conversion when loading Collada meshes

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -630,11 +630,19 @@ float getMeshUnitRescale(const std::string& resource_path)
         tinyxml2::XMLElement* unitXml = assetXml->FirstChildElement("unit");
         if (unitXml && unitXml->Attribute("meter"))
         {
+          // Convert attribute meter to a float in a locale-independent manner
+          std::string unit_scale_str(unitXml->Attribute("meter"));
+          std::istringstream stream(unit_scale_str);
+          stream.imbue(std::locale::classic());
+          float conversion_result;
+          stream >> conversion_result;
           // Failing to convert leaves unit_scale as the default.
-          if (unitXml->QueryFloatAttribute("meter", &unit_scale) != 0)
-            ROS_WARN_STREAM("getMeshUnitRescale::Failed to convert unit element meter attribute to "
-                            "determine scaling. unit element: "
+          if (stream.fail() || !stream.eof())
+            ROS_WARN_STREAM("getMeshUnitRescale::Failed to convert <unit> element 'meter' attribute to "
+                            "determine scaling. <unit> element: "
                             << unitXml->GetText());
+          else
+            unit_scale = conversion_result;
         }
       }
     }

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -638,11 +638,15 @@ float getMeshUnitRescale(const std::string& resource_path)
           stream >> conversion_result;
           // Failing to convert leaves unit_scale as the default.
           if (stream.fail() || !stream.eof())
+          {
             ROS_WARN_STREAM("getMeshUnitRescale::Failed to convert <unit> element 'meter' attribute to "
                             "determine scaling. <unit> element: "
                             << unitXml->GetText());
+          }
           else
+          {
             unit_scale = conversion_result;
+          }
         }
       }
     }


### PR DESCRIPTION
### Description

Fixes #1665.

`<unit meter="">` attribute of of Collada meshes was read in a locale-dependent manner. This PR fixes it.

### Checklist

- [x] If you are addressing rendering issues, please provide:
  - [x] Images of both, broken and fixed renderings. https://github.com/ros-visualization/rviz/issues/1665#issuecomment-976860077
  - [x] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg. https://github.com/ros-visualization/rviz/issues/1665#issuecomment-976495446
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [x] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
