### PR TITLE
Drop proprietary COLLADA scaling

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -232,10 +232,6 @@ void buildMesh(const aiScene* scene,
     return;
 
   transform *= node->mTransformation;
-  aiMatrix3x3 rotation(transform);
-  aiMatrix3x3 inverse_transpose_rotation(rotation);
-  inverse_transpose_rotation.Inverse();
-  inverse_transpose_rotation.Transpose();
 
   for (uint32_t i = 0; i < node->mNumMeshes; i++)
   {
@@ -297,7 +293,7 @@ void buildMesh(const aiScene* scene,
 
       if (input_mesh->HasNormals())
       {
-        aiVector3D n = inverse_transpose_rotation * input_mesh->mNormals[j];
+        aiVector3D n = input_mesh->mNormals[j];
         n.Normalize();
         *vertices++ = n.x;
         *vertices++ = n.y;


### PR DESCRIPTION
As pointed out by @simonschmeisser in https://github.com/ros-visualization/rviz/pull/1684#issuecomment-977827800, `assimp` should actually provide the correct scaling factor and it actually does: The scaling is embedded in the root node's transform, which was deliberately ignored.
Fixes #1665. @simonschmeisser and @peci1, could you please review and test?