### PR TITLE
Avoid tf race conditions during update cycle of all displays and cameras

### DIFF
--- a/src/rviz/frame_manager.cpp
+++ b/src/rviz/frame_manager.cpp
@@ -47,7 +47,7 @@ FrameManager::FrameManager(std::shared_ptr<tf2_ros::Buffer> tf_buffer,
       tf_buffer ? std::move(tf_buffer) : std::make_shared<tf2_ros::Buffer>(ros::Duration(10 * 60));
   tf_listener_ = tf_listener ?
                      std::move(tf_listener) :
-                     std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, ros::NodeHandle(), true);
+                     std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, ros::NodeHandle(), false);
 
   setSyncMode(SyncOff);
   setPause(false);


### PR DESCRIPTION
During update cycle of displays and views (cameras) the tf buffer should not be updated. This can be achieved by disabling the separate thread for tf listener.

Otherwise it is possible that displays or cameras, which are updated at a later point in time within the cycle, use a more recent transform. This leads to undesired jittering of visuals. This affects displays, which use the latest available transform with ros::Time(). And all views/cameras as they always use the latest available transform.

The videos below show a axes display and a robot model display, which should be fixed to each other.

Here is a video before:

https://user-images.githubusercontent.com/4062443/147690430-288f3d9b-01f8-449b-a432-5b233fd1b273.mp4

and after:

https://user-images.githubusercontent.com/4062443/147690459-ccfa7919-43ac-4692-8fb6-71ce563680b9.mp4

This disables the timeout feature in canTransform or lookupTransform of the tf buffer. But it is not used anywhere in Rviz. I also think that it is not used in any display plugin since these function are blocking then, which is not really desired in update() or in message callback. Furthermore, I don't think that there is too much overhead when the TF messages are processed in main thread.