### PR TITLE
Fix jittering of movable robot links when fixed frame != robot's frame (e.g. base_link)

### DIFF
--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -227,7 +227,7 @@ void RobotModelDisplay::update(float wall_dt, float /*ros_dt*/)
   float rate = update_rate_property_->getFloat();
   bool update = rate < 0.0001f || time_since_last_transform_ >= rate;
 
-  if (has_new_transforms_ || update)
+  if (robot_->getRootLink() && (has_new_transforms_ || update))
   {
     Ogre::Vector3 position;
     Ogre::Quaternion orientation;

--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -229,6 +229,25 @@ void RobotModelDisplay::update(float wall_dt, float /*ros_dt*/)
 
   if (has_new_transforms_ || update)
   {
+    Ogre::Vector3 position;
+    Ogre::Quaternion orientation;
+    if (context_->getFrameManager()->getTransform(robot_->getRootLink()->getName(), ros::Time(),
+                                                  position, orientation))
+    {
+      robot_->setPosition(position);
+      robot_->setOrientation(orientation);
+      linkUpdaterStatusFunction(StatusProperty::Ok, robot_->getRootLink()->getName(), "Transform OK",
+                                this);
+    }
+    else
+    {
+      std::stringstream ss;
+      ss << "No transform from [" << robot_->getRootLink()->getName() << "] to ["
+         << fixed_frame_.toStdString() << "]";
+      linkUpdaterStatusFunction(StatusProperty::Error, robot_->getRootLink()->getName(), ss.str(), this);
+    }
+
+
     robot_->update(TFLinkUpdater(context_->getFrameManager(),
                                  boost::bind(linkUpdaterStatusFunction, _1, _2, _3, this),
                                  tf_prefix_property_->getStdString()));

--- a/src/rviz/robot/link_updater.h
+++ b/src/rviz/robot/link_updater.h
@@ -40,7 +40,8 @@ namespace rviz
 class LinkUpdater
 {
 public:
-  virtual bool getLinkTransforms(const std::string& link_name,
+  virtual bool getLinkTransforms(const std::string& parent_link_name,
+                                 const std::string& link_name,
                                  Ogre::Vector3& visual_position,
                                  Ogre::Quaternion& visual_orientation,
                                  Ogre::Vector3& collision_position,

--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -66,6 +66,8 @@ Robot::Robot(Ogre::SceneNode* root_node,
   , robot_loaded_(false)
   , inChangedEnableAllLinks(false)
   , name_(name)
+  , root_link_(nullptr)
+  , alpha_(1.f)
 {
   root_visual_node_ = root_node->createChildSceneNode();
   root_collision_node_ = root_node->createChildSceneNode();

--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -218,11 +218,14 @@ void Robot::clear()
 
 RobotLink* Robot::LinkFactory::createLink(Robot* robot,
                                           const urdf::LinkConstSharedPtr& link,
+                                          Ogre::SceneNode* parent_visual_node,
+                                          Ogre::SceneNode* parent_collision_node,
                                           const std::string& parent_joint_name,
                                           bool visual,
                                           bool collision)
 {
-  return new RobotLink(robot, link, parent_joint_name, visual, collision);
+  return new RobotLink(robot, link, parent_visual_node, parent_collision_node, parent_joint_name, visual,
+                       collision);
 }
 
 RobotJoint* Robot::LinkFactory::createJoint(Robot* robot, const urdf::JointConstSharedPtr& joint)
@@ -244,12 +247,16 @@ void Robot::load(const urdf::ModelInterface& urdf, bool visual, bool collision)
   // Create properties for each link.
   // Properties are not added to display until changedLinkTreeStyle() is called (below).
   {
-    typedef std::map<std::string, urdf::LinkSharedPtr> M_NameToUrdfLink;
-    M_NameToUrdfLink::const_iterator link_it = urdf.links_.begin();
-    M_NameToUrdfLink::const_iterator link_end = urdf.links_.end();
-    for (; link_it != link_end; ++link_it)
+    // traverse URDF tree in depth first order and copy tree structure for links' scene nodes
+    std::vector<std::tuple<urdf::LinkConstSharedPtr, Ogre::SceneNode*, Ogre::SceneNode*>> link_stack_;
+    link_stack_.emplace_back(urdf.getRoot(), root_visual_node_, root_collision_node_);
+    while (!link_stack_.empty())
     {
-      const urdf::LinkConstSharedPtr& urdf_link = link_it->second;
+      urdf::LinkConstSharedPtr urdf_link = std::get<0>(link_stack_.back());
+      Ogre::SceneNode* parent_visual_node = std::get<1>(link_stack_.back());
+      Ogre::SceneNode* parent_collision_node = std::get<2>(link_stack_.back());
+      link_stack_.pop_back();
+
       std::string parent_joint_name;
 
       if (urdf_link != urdf.getRoot() && urdf_link->parent_joint)
@@ -257,7 +264,9 @@ void Robot::load(const urdf::ModelInterface& urdf, bool visual, bool collision)
         parent_joint_name = urdf_link->parent_joint->name;
       }
 
-      RobotLink* link = link_factory_->createLink(this, urdf_link, parent_joint_name, visual, collision);
+      RobotLink* link =
+          link_factory_->createLink(this, urdf_link, parent_visual_node, parent_collision_node,
+                                    parent_joint_name, visual, collision);
 
       if (urdf_link == urdf.getRoot())
       {
@@ -267,6 +276,9 @@ void Robot::load(const urdf::ModelInterface& urdf, bool visual, bool collision)
       links_[urdf_link->name] = link;
 
       link->setRobotAlpha(alpha_);
+
+      for (const auto& c : urdf_link->child_links)
+        link_stack_.emplace_back(c, link->getVisualTreeNode(), link->getCollisionTreeNode());
     }
   }
 
@@ -709,8 +721,8 @@ void Robot::update(const LinkUpdater& updater)
 
     Ogre::Vector3 visual_position, collision_position;
     Ogre::Quaternion visual_orientation, collision_orientation;
-    if (updater.getLinkTransforms(link->getName(), visual_position, visual_orientation,
-                                  collision_position, collision_orientation))
+    if (updater.getLinkTransforms(link->getParentLinkName(), link->getName(), visual_position,
+                                  visual_orientation, collision_position, collision_orientation))
     {
       // Check if visual_orientation, visual_position, collision_orientation, and collision_position are
       // NaN.

--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -199,6 +199,8 @@ public:
 
     virtual RobotLink* createLink(Robot* robot,
                                   const urdf::LinkConstSharedPtr& link,
+                                  Ogre::SceneNode* parent_visual_node,
+                                  Ogre::SceneNode* parent_collision_node,
                                   const std::string& parent_joint_name,
                                   bool visual,
                                   bool collision);

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -82,6 +82,8 @@ class RobotLink : public QObject
 public:
   RobotLink(Robot* robot,
             const urdf::LinkConstSharedPtr& link,
+            Ogre::SceneNode* parent_visual_node,
+            Ogre::SceneNode* parent_collision_node,
             const std::string& parent_joint_name,
             bool visual,
             bool collision);
@@ -98,6 +100,10 @@ public:
   const std::string& getName() const
   {
     return name_;
+  }
+  const std::string& getParentLinkName() const
+  {
+    return parent_link_name_;
   }
   const std::string& getParentJointName() const
   {
@@ -118,6 +124,14 @@ public:
   Ogre::SceneNode* getCollisionNode() const
   {
     return collision_node_;
+  }
+  Ogre::SceneNode* getVisualTreeNode() const
+  {
+    return visual_tree_node_;
+  }
+  Ogre::SceneNode* getCollisionTreeNode() const
+  {
+    return collision_tree_node_;
   }
   Robot* getRobot() const
   {
@@ -200,6 +214,7 @@ protected:
   DisplayContext* context_;
 
   std::string name_; ///< Name of this link
+  std::string parent_link_name_;
   std::string parent_joint_name_;
   std::vector<std::string> child_joint_names_;
 
@@ -226,6 +241,8 @@ private:
 
   Ogre::SceneNode* visual_node_;    ///< The scene node the visual meshes are attached to
   Ogre::SceneNode* collision_node_; ///< The scene node the collision meshes are attached to
+  Ogre::SceneNode* visual_tree_node_;    ///< The scene node above visual_node is attached to
+  Ogre::SceneNode* collision_tree_node_; ///< The scene node above collision_node is attached to
 
   Ogre::RibbonTrail* trail_;
 

--- a/src/rviz/robot/tf_link_updater.h
+++ b/src/rviz/robot/tf_link_updater.h
@@ -52,7 +52,8 @@ public:
   TFLinkUpdater(FrameManager* frame_manager,
                 const StatusCallback& status_cb = StatusCallback(),
                 const std::string& tf_prefix = std::string());
-  bool getLinkTransforms(const std::string& link_name,
+  bool getLinkTransforms(const std::string& parent_link_name,
+                         const std::string& link_name,
                          Ogre::Vector3& visual_position,
                          Ogre::Quaternion& visual_orientation,
                          Ogre::Vector3& collision_position,


### PR DESCRIPTION
The following video shows the problem. The movable wheels are lagging behind the chassis of the vehicle:

https://user-images.githubusercontent.com/4062443/147698934-da740899-9e75-4ee1-b1e7-6cb854eec6a2.mp4

The reason for this is an increased latency of `odom -> base_link -> front_left_wheel` compared to e.g. `odom -> base_link`. Let's say the former has latency A, because of the transform from `base_link` to `odom`. The latter has latency A + B because it needs also the transform `front_left_wheel` to `base_link` with latency B. Therefore the wheel's scene node is updated later than the one of the chassis. Currently, all scene nodes are arranged in a flat structure in `odom` frame. Therefore each scene node's transform represents position and orientation of its mesh at the same time. When there is only a small latency, the movable links are jittering w.r.t. each other. The problem gets worse the more a child link is nested and therefore the longer a TF chain is.

The solution is to structure the scene nodes analog to the TF tree. So the position and orientation of all (movable) child links are updated when `base_link` (or some other parent link) moves. So the TF chains are decoupled and a particular link can be updated as soon the respective local transform is available. So it is not necessary to wait for the whole TF chain. This results in a much smoother appearance. In the example above the wheels' position is already updated when `odom -> base_link` transform is available. The rotation of the wheels is updated independently when the TF from `base_link -> front_left_wheel` is available.

The result looks like this:

https://user-images.githubusercontent.com/4062443/147698955-050ab398-79df-4413-9c5b-1e0b1c4e31df.mp4


