### PR TITLE
Maintain original mesh materials for RobotLinks

### DIFF
--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -164,6 +164,7 @@ RobotLink::RobotLink(Robot* robot,
   , trail_(nullptr)
   , axes_(nullptr)
   , material_alpha_(1.0)
+  , use_original_material(true)
   , robot_alpha_(1.0)
   , only_render_depth_(false)
   , is_selectable_(true)
@@ -404,11 +405,13 @@ void RobotLink::updateAlpha()
       {
         material->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
         material->setDepthWriteEnabled(false);
+        use_original_material = false;
       }
       else
       {
         material->setSceneBlending(Ogre::SBT_REPLACE);
         material->setDepthWriteEnabled(true);
+        use_original_material = true;
       }
     }
   }
@@ -668,6 +671,7 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
         sub->setMaterial(mat);
       }
       materials_[sub] = sub->getMaterial();
+      original_materials_[sub] = sub->getMaterial()->clone(sub->getMaterial()->getName() + "_original");
     }
   }
 }
@@ -925,9 +929,10 @@ void RobotLink::setToNormalMaterial()
   {
     M_SubEntityToMaterial::iterator it = materials_.begin();
     M_SubEntityToMaterial::iterator end = materials_.end();
-    for (; it != end; ++it)
+    M_SubEntityToMaterial::iterator it_original = original_materials_.begin();
+    for (; it != end; ++it, ++it_original)
     {
-      it->first->setMaterial(it->second);
+      it->first->setMaterial(use_original_material ? it_original->second : it->second);
     }
   }
 }

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -216,8 +216,10 @@ protected:
 private:
   typedef std::map<Ogre::SubEntity*, Ogre::MaterialPtr> M_SubEntityToMaterial;
   M_SubEntityToMaterial materials_;
+  M_SubEntityToMaterial original_materials_;
   Ogre::MaterialPtr default_material_;
   std::string default_material_name_;
+  bool use_original_material;
 
   std::vector<Ogre::Entity*>
       visual_meshes_; ///< The entities representing the visual mesh of this link (if they exist)


### PR DESCRIPTION
Currently, rviz modifies a custom material setting loaded together with a mesh model, e.g. within [`updateAlpha()`](https://github.com/ros-visualization/rviz/blob/5531206e77d8092dbdb6a50a5b1a3c23fe5e181e/src/rviz/robot/robot_link.cpp#L390-L413).
This destroys, for example, transparency within those original materials.

With this pull request, the _original_ material is stored additionally to the _active_ one, such that the original one can be restored if needed. This allows to correctly render e.g. glass:

|  old                       |  new                     |
|-------------------------|------------------------|
| ![Screenshot from 2022-01-30 17-26-22](https://user-images.githubusercontent.com/4062443/151708047-7b83ef40-c9e6-41cb-bd10-d692f72a7bb1.png) | ![Screenshot from 2022-01-30 17-15-24](https://user-images.githubusercontent.com/4062443/151708073-9d8f3cec-ca99-401a-800b-fda80bdcda5b.png) |

