### PR TITLE
Fix GLSL 1.50 for Mesa

### DIFF
--- a/ogre_media/materials/glsl120/smooth_square.frag
+++ b/ogre_media/materials/glsl120/smooth_square.frag
@@ -14,12 +14,12 @@ void main()
                 smoothstep(-0.48, -0.45, ax) * (1.0 - smoothstep(0.45, 0.48, ax));
 
   float inv_blend = 1.0 - blend;
-  vec3 col = blend * gl_Color.xyz + (sign(0.5 - length(vec3(gl_Color.xyz))) * vec3(0.2, 0.2, 0.2) + gl_Color.xyz) * inv_blend;
+  vec3 col = blend * gl_Color.rgb + (sign(0.5 - length(vec3(gl_Color.rgb))) * vec3(0.2, 0.2, 0.2) + gl_Color.rgb) * inv_blend;
 
   //alternative version: make color at edge darker
-  //vec3 col = (0.5 + 0.5*blend) * gl_Color.xyz;
+  //vec3 col = (0.5 + 0.5*blend) * gl_Color.rgb;
 
-  col = col + col * highlight.xyz;
+  col = col + col * highlight.rgb;
 
-  gl_FragColor = vec4(col.r, col.g, col.b, alpha * gl_Color.a );
+  gl_FragColor = vec4(col.rgb, alpha * gl_Color.a);
 }

--- a/ogre_media/materials/glsl120/smooth_square.frag
+++ b/ogre_media/materials/glsl120/smooth_square.frag
@@ -7,17 +7,20 @@ uniform float alpha;
 
 void main()
 {
+  const float inner = 0.48;
   float ax = gl_TexCoord[0].x-0.5;
   float ay = gl_TexCoord[0].y-0.5;
 
-  float blend = smoothstep(-0.48, -0.45, ay) * (1.0 - smoothstep(0.45, 0.48, ay)) *
-                smoothstep(-0.48, -0.45, ax) * (1.0 - smoothstep(0.45, 0.48, ax));
+  // blending factor, varying between 0.0 (at the border) and 1.0 (at the center of the square)
+  float blend = smoothstep(-0.5, -inner, ay) * (1.0 - smoothstep(inner, 0.5, ay)) *
+                smoothstep(-0.5, -inner, ax) * (1.0 - smoothstep(inner, 0.5, ax));
 
+#if 1 // high contrast edge (dark edge on light surface / light edge on dark surface)
   float inv_blend = 1.0 - blend;
   vec3 col = blend * gl_Color.rgb + (sign(0.5 - length(vec3(gl_Color.rgb))) * vec3(0.2, 0.2, 0.2) + gl_Color.rgb) * inv_blend;
-
-  //alternative version: make color at edge darker
-  //vec3 col = (0.5 + 0.5*blend) * gl_Color.rgb;
+#else // alternatively: make color at edge darker
+  vec3 col = (0.5 + 0.5*blend) * gl_Color.rgb;
+#endif
 
   col = col + col * highlight.rgb;
 

--- a/ogre_media/materials/glsl150/box.geom
+++ b/ogre_media/materials/glsl150/box.geom
@@ -24,7 +24,8 @@ in VertexData {
 } vdata[];
 
 
-out vec4 gl_TexCoord[];
+out vec4 color;
+out vec2 TexCoord;
 
 layout(points) in;
 layout(triangle_strip, max_vertices=24) out;
@@ -43,12 +44,12 @@ void emitVertex( int side, vec4 x, vec4 y, vec4 z, vec3 tex, vec4 size_factor )
   vec4 pos_rel = tex.x*x + tex.y*y + tex.z*z;
   vec4 pos = gl_in[0].gl_Position + vec4( pos_rel * size_factor );
   gl_Position = worldviewproj_matrix * pos;
-  gl_TexCoord[0] = vec4( tex.x*0.5+0.5, tex.y*0.5+0.5, 0.0, 0.0 );
+  TexCoord = vec2(tex.x*0.5+0.5, tex.y*0.5+0.5);
 
 #ifdef WITH_LIGHTING
-    gl_FrontColor = vec4( vdata[0].color.rgb * lightness[side], vdata[0].color.a );
+    color = vec4( vdata[0].color.rgb * lightness[side], vdata[0].color.a );
 #else
-    gl_FrontColor = vdata[0].color;
+    color = vdata[0].color;
 #endif
 
 #ifdef WITH_DEPTH

--- a/ogre_media/materials/glsl150/box.geom
+++ b/ogre_media/materials/glsl150/box.geom
@@ -52,9 +52,9 @@ void emitVertex( int side, vec4 x, vec4 y, vec4 z, vec3 tex )
   gl_TexCoord[0] = vec4( tex.x*0.5+0.5, tex.y*0.5+0.5, 0.0, 0.0 );
 
 #ifdef WITH_LIGHTING
-    gl_FrontColor = vec4( gl_in[0].gl_FrontColor.xyz * lightness[side], gl_in[0].gl_FrontColor.a );
+    gl_FrontColor = vec4( gl_in[0].gl_FrontColor.rgb * lightness[side], gl_in[0].gl_FrontColor.a );
 #else
-    gl_FrontColor = vec4( gl_in[0].gl_FrontColor.xyz, gl_in[0].gl_FrontColor.a );
+    gl_FrontColor = vec4( gl_in[0].gl_FrontColor.rgb, gl_in[0].gl_FrontColor.a );
 #endif
 
 #ifdef WITH_DEPTH
@@ -69,11 +69,9 @@ void main()
 {
   for( int side=0; side<3; side++ )
   {
-    int side2 = (side+1)%3;
-    int side3 = (side+2)%3;
     vec4 x=axes[ side ];
-    vec4 y=axes[ side2 ];
-    vec4 z=axes[ side3 ];
+    vec4 y=axes[ (side+1)%3 ];
+    vec4 z=axes[ (side+2)%3 ];
 
     // face for +z
     emitVertex( side, x, y, z, vec3(-1, -1, +1) );

--- a/ogre_media/materials/glsl150/box.geom
+++ b/ogre_media/materials/glsl150/box.geom
@@ -38,15 +38,10 @@ const vec4 axes[3] = vec4[] (
 const float lightness[6] = float[] (
     0.9, 0.5, 0.6, 0.6, 1.0, 0.4 );
 
-
-void emitVertex( int side, vec4 x, vec4 y, vec4 z, vec3 tex )
+void emitVertex( int side, vec4 x, vec4 y, vec4 z, vec3 tex, vec4 size_factor )
 {
-  // if auto_size == 1, then size_factor == size*gl_Vertex.z
-  // if auto_size == 0, then size_factor == size
-  vec4 size_factor = (1-auto_size.x+(auto_size.x*gl_in[0].gl_Position.z))*size;
-
   vec4 pos_rel = tex.x*x + tex.y*y + tex.z*z;
-  vec4 pos = gl_in[0].gl_Position + vec4( pos_rel * size_factor * 0.5 );
+  vec4 pos = gl_in[0].gl_Position + vec4( pos_rel * size_factor );
   gl_Position = worldviewproj_matrix * pos;
   gl_TexCoord[0] = vec4( tex.x*0.5+0.5, tex.y*0.5+0.5, 0.0, 0.0 );
 
@@ -66,6 +61,10 @@ void emitVertex( int side, vec4 x, vec4 y, vec4 z, vec3 tex )
 
 void main()
 {
+  // if auto_size == 1, then size_factor == size*gl_Vertex.z
+  // if auto_size == 0, then size_factor == size
+  vec4 size_factor = (0.5*(1-auto_size.x+(auto_size.x*gl_in[0].gl_Position.z)))*size;
+
   for( int side=0; side<3; side++ )
   {
     vec4 x=axes[ side ];
@@ -73,17 +72,17 @@ void main()
     vec4 z=axes[ (side+2)%3 ];
 
     // face for +z
-    emitVertex( side, x, y, z, vec3(-1, -1, +1) );
-    emitVertex( side, x, y, z, vec3(+1, -1, +1) );
-    emitVertex( side, x, y, z, vec3(-1, +1, +1) );
-    emitVertex( side, x, y, z, vec3(+1, +1, +1) );
+    emitVertex( side, x, y, z, vec3(-1, -1, +1), size_factor );
+    emitVertex( side, x, y, z, vec3(+1, -1, +1), size_factor );
+    emitVertex( side, x, y, z, vec3(-1, +1, +1), size_factor );
+    emitVertex( side, x, y, z, vec3(+1, +1, +1), size_factor );
     EndPrimitive();
 
     // face for -z
-    emitVertex( side+3, x, y, z, vec3(-1, -1, -1) );
-    emitVertex( side+3, x, y, z, vec3(-1, +1, -1) );
-    emitVertex( side+3, x, y, z, vec3(+1, -1, -1) );
-    emitVertex( side+3, x, y, z, vec3(+1, +1, -1) );
+    emitVertex( side+3, x, y, z, vec3(-1, -1, -1), size_factor );
+    emitVertex( side+3, x, y, z, vec3(-1, +1, -1), size_factor );
+    emitVertex( side+3, x, y, z, vec3(+1, -1, -1), size_factor );
+    emitVertex( side+3, x, y, z, vec3(+1, +1, -1), size_factor );
     EndPrimitive();
   }
 }

--- a/ogre_media/materials/glsl150/box.geom
+++ b/ogre_media/materials/glsl150/box.geom
@@ -19,10 +19,9 @@ uniform mat4 worldviewproj_matrix;
 uniform vec4 size;
 uniform vec4 auto_size;
 
-in gl_PerVertex {
-	vec4 gl_Position;
-	vec4 gl_FrontColor;
-} gl_in[];
+in VertexData {
+	vec4 color;
+} vdata[];
 
 
 out vec4 gl_TexCoord[];
@@ -52,9 +51,9 @@ void emitVertex( int side, vec4 x, vec4 y, vec4 z, vec3 tex )
   gl_TexCoord[0] = vec4( tex.x*0.5+0.5, tex.y*0.5+0.5, 0.0, 0.0 );
 
 #ifdef WITH_LIGHTING
-    gl_FrontColor = vec4( gl_in[0].gl_FrontColor.rgb * lightness[side], gl_in[0].gl_FrontColor.a );
+    gl_FrontColor = vec4( vdata[0].color.rgb * lightness[side], vdata[0].color.a );
 #else
-    gl_FrontColor = vec4( gl_in[0].gl_FrontColor.rgb, gl_in[0].gl_FrontColor.a );
+    gl_FrontColor = vdata[0].color;
 #endif
 
 #ifdef WITH_DEPTH

--- a/ogre_media/materials/glsl150/glsl150.program
+++ b/ogre_media/materials/glsl150/glsl150.program
@@ -78,3 +78,13 @@ vertex_program rviz/glsl150/pass_pos_color.vert glsl
 {
   source pass_pos_color.vert
 }
+
+fragment_program rviz/glsl150/smooth_square.frag glsl
+{
+  source smooth_square.frag
+  default_params
+  {
+    param_named_auto highlight custom 5
+    param_named_auto alpha custom 1
+  }
+}

--- a/ogre_media/materials/glsl150/pass_pos_color.vert
+++ b/ogre_media/materials/glsl150/pass_pos_color.vert
@@ -1,14 +1,12 @@
 #version 150 compatibility
 
-// this merely passes over position and color,
-// as needed by box.geom
+// this merely passes over position and color as needed by box.geom
 
-out gl_PerVertex {
-	vec4 gl_Position;
-	vec4 gl_FrontColor;
-};
+out VertexData {
+    vec4 color;
+} vdata;
 
 void main() {
     gl_Position = gl_Vertex;
-    gl_FrontColor = gl_Color;
+    vdata.color = gl_Color;
 }

--- a/ogre_media/materials/glsl150/smooth_square.frag
+++ b/ogre_media/materials/glsl150/smooth_square.frag
@@ -1,0 +1,33 @@
+#version 150
+
+// rasterizes a smooth square with ax,ay in [-0.5..0.5]
+
+uniform vec4 highlight;
+uniform float alpha;
+
+in vec4 color;
+in vec2 TexCoord;
+
+out vec4 FragColor;
+
+void main()
+{
+  const float inner = 0.48;
+  float ax = TexCoord.x-0.5;
+  float ay = TexCoord.y-0.5;
+
+  // blending factor, varying between 0.0 (at the border) and 1.0 (at the center of the square)
+  float blend = smoothstep(-0.5, -inner, ay) * (1.0 - smoothstep(inner, 0.5, ay)) *
+                smoothstep(-0.5, -inner, ax) * (1.0 - smoothstep(inner, 0.5, ax));
+
+#if 1 // high contrast edge (dark edge on light surface / light edge on dark surface)
+  float inv_blend = 1.0 - blend;
+  vec3 col = blend * color.rgb + (sign(0.5 - length(vec3(color.rgb))) * vec3(0.2, 0.2, 0.2) + color.rgb) * inv_blend;
+#else // alternatively: make color at edge darker
+  vec3 col = (0.5 + 0.5*blend) * color.rgb;
+#endif
+
+  col = col + col * highlight.rgb;
+
+  FragColor = vec4(col.rgb, alpha * color.a);
+}

--- a/ogre_media/materials/scripts150/point_cloud_box.material
+++ b/ogre_media/materials/scripts150/point_cloud_box.material
@@ -1,6 +1,6 @@
 material rviz/PointCloudBox
 {
-  /* This material should only be used with glsl < 1.50 */
+  /* This material should only be used with glsl >= 1.50 */
 
   // the 'gp' techniques need one input vertex per box
   // and use geometry shaders to create the geometry
@@ -11,7 +11,7 @@ material rviz/PointCloudBox
     {
       vertex_program_ref   rviz/glsl150/pass_pos_color.vert {}
       geometry_program_ref rviz/glsl150/box.geom(with_lighting) {}
-      fragment_program_ref rviz/glsl120/smooth_square.frag {}
+      fragment_program_ref rviz/glsl150/smooth_square.frag {}
     }
   }
 

--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -173,7 +173,6 @@ void RenderSystem::loadOgrePlugins()
 
 void RenderSystem::detectGlVersion()
 {
-  bool mesa_workaround = false;
   if (force_gl_version_)
   {
     gl_version_ = force_gl_version_;
@@ -186,14 +185,6 @@ void RenderSystem::detectGlVersion()
     int major = caps->getDriverVersion().major;
     int minor = caps->getDriverVersion().minor;
     gl_version_ = major * 100 + minor * 10;
-
-#ifdef __linux__
-    std::string gl_version_string = (const char*)glGetString(GL_VERSION);
-    // The "Mesa 2" string is intended to match "Mesa 20.", "Mesa 21." and so on
-    mesa_workaround = gl_version_string.find("Mesa 2") != std::string::npos && gl_version_ >= 320;
-#else
-    mesa_workaround = false;
-#endif
   }
 
   switch (gl_version_)
@@ -223,15 +214,6 @@ void RenderSystem::detectGlVersion()
       glsl_version_ = 0;
     }
     break;
-  }
-  if (mesa_workaround)
-  { // https://github.com/ros-visualization/rviz/issues/1508
-    ROS_INFO("OpenGl version: %.1f (GLSL %.1f) limited to GLSL 1.4 on Mesa system.",
-             (float)gl_version_ / 100.0, (float)glsl_version_ / 100.0);
-
-    gl_version_ = 310;
-    glsl_version_ = 140;
-    return;
   }
   ROS_INFO("OpenGl version: %.1f (GLSL %.1f).", (float)gl_version_ / 100.0, (float)glsl_version_ / 100.0);
 }


### PR DESCRIPTION
As pointed out in #1721, Mesa doesn't correctly render PointCloud geoms other than points with GLSL 150, while NVIDIA renders them fine.
The problem is that Mesa uses are more strict GLSL compiler than NVIDIA, thus rejecting the existing scripts. Essentially, `Mesa` doesn't support the `compatibility` profile. Further, it's not allowed to redefine `gl_PerVertex` or use the `gl_` prefix for user variables (https://github.com/ros-visualization/rviz/issues/1721#issuecomment-1062205008).

I was able to fix most syntax issues, such that `glslangValidator` doesn't complain anymore.
However, the `compatibility` issue remains. Using the `compatibility` profile, color values can be passed from CPU to GPU as packed values (`uint`):
https://github.com/ros-visualization/rviz/blob/ce068cbd932d4c3f971df2ed0f9d60b9f5aa5d81/src/rviz/ogre_helpers/point_cloud.cpp#L532
and be read in GLSL via `gl_Color` - as a `vec4`:
https://github.com/ros-visualization/rviz/blob/697ed3ff0496b79b1bb4270aabf457ee2f2ae736/ogre_media/materials/glsl150/pass_pos_color.vert#L13
However, when dropping `compatibility` profile, we need to unpack the color ourselves:
```
in vec3 position;
in uint packed_color;
```
But, I have no idea, how to accomplish that... I'm stuck here.