### PR TITLE
RobotLink: Simplify material mode handling

### DIFF
--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -705,13 +705,13 @@ void Robot::update(const LinkUpdater& updater)
   {
     RobotLink* link = link_it->second;
 
-    link->setToNormalMaterial();
-
     Ogre::Vector3 visual_position, collision_position;
     Ogre::Quaternion visual_orientation, collision_orientation;
     if (updater.getLinkTransforms(link->getName(), visual_position, visual_orientation,
                                   collision_position, collision_orientation))
     {
+      link->setToNormalMaterial();
+
       // Check if visual_orientation, visual_position, collision_orientation, and collision_position are
       // NaN.
       if (visual_orientation.isNaN())

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -84,6 +84,14 @@ typedef boost::shared_ptr<RobotLinkSelectionHandler> RobotLinkSelectionHandlerPt
 class RobotLink : public QObject
 {
   Q_OBJECT
+
+  enum MaterialMode
+  {
+    ORIGINAL = 0,
+    COLOR = 1,
+    ERROR = 2,
+  };
+
 public:
   RobotLink(Robot* robot,
             const urdf::LinkConstSharedPtr& link,
@@ -182,6 +190,7 @@ private Q_SLOTS:
   void updateAxes();
 
 private:
+  void setMaterialMode(unsigned char mode_flags);
   void setRenderQueueGroup(Ogre::uint8 group);
   bool getEnabled() const;
   void createEntityForGeometryElement(const urdf::LinkConstSharedPtr& link,
@@ -249,7 +258,7 @@ private:
   RobotLinkSelectionHandlerPtr selection_handler_;
 
   Ogre::MaterialPtr color_material_;
-  bool using_color_;
+  unsigned char material_mode_flags_;
 
   friend class RobotLinkSelectionHandler;
 };


### PR DESCRIPTION
rviz::RobotLink knows 3 material modes, showing:
- original material of the mesh
- a user-selected color
- an error color (uniform white)

Switching between these modes requires iterating through all subentities of the link, 
which might be rather time-consuming. Also, this was done in each update() cycle!

This commit simplifies the handling, performing the costly update only if really necessary.