### PR TITLE
Don't disable display if associated widget tab changes

### DIFF
--- a/src/rviz/display.cpp
+++ b/src/rviz/display.cpp
@@ -386,9 +386,6 @@ void Display::setAssociatedWidget(QWidget* widget)
 
 void Display::associatedPanelVisibilityChange(bool visible)
 {
-  if (associated_widget_panel_) // consider the actual visibility of the panel
-    visible = associated_widget_panel_->isVisible();
-
   associated_widget_visible_ = visible;
   // If something external makes the panel visible/invisible, make sure to enable/disable the display
   setEnabled(visible);

--- a/src/rviz/display.cpp
+++ b/src/rviz/display.cpp
@@ -386,6 +386,9 @@ void Display::setAssociatedWidget(QWidget* widget)
 
 void Display::associatedPanelVisibilityChange(bool visible)
 {
+  if (associated_widget_panel_) // consider the actual visibility of the panel
+    visible = associated_widget_panel_->isVisible();
+
   associated_widget_visible_ = visible;
   // If something external makes the panel visible/invisible, make sure to enable/disable the display
   setEnabled(visible);

--- a/src/rviz/display.h
+++ b/src/rviz/display.h
@@ -328,7 +328,7 @@ private:
   uint32_t visibility_bits_;
   QWidget* associated_widget_;
   PanelDockWidget* associated_widget_panel_;
-  bool associated_widget_visible_;
+  bool suppress_hiding_associated_widget_panel_;
 };
 
 } // end namespace rviz


### PR DESCRIPTION
Fixes #1738

If an associated widget is tabbed and deselected, its visibility changes to false, which triggers disabling the display.
However, in this case, the widget is still there and thus the display shouldn't be disabled.