### PR TITLE
OgreVector3.h is deprecated in favor of OgreVector.h

### DIFF
--- a/src/rviz/default_plugin/covariance_visual.h
+++ b/src/rviz/default_plugin/covariance_visual.h
@@ -40,7 +40,7 @@
 
 #include <Eigen/Dense>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreColourValue.h>
 
 namespace Ogre

--- a/src/rviz/default_plugin/effort_visual.cpp
+++ b/src/rviz/default_plugin/effort_visual.cpp
@@ -1,4 +1,4 @@
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.h
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.h
@@ -36,7 +36,7 @@
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #endif
 

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker_control.h
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker_control.h
@@ -35,7 +35,7 @@
 #include <boost/enable_shared_from_this.hpp>
 
 #include <OgreRay.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneManager.h>
 #endif

--- a/src/rviz/default_plugin/map_display.h
+++ b/src/rviz/default_plugin/map_display.h
@@ -35,7 +35,7 @@
 
 #include <OgreTexture.h>
 #include <OgreMaterial.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreSharedPtr.h>
 #endif
 

--- a/src/rviz/default_plugin/markers/arrow_marker.cpp
+++ b/src/rviz/default_plugin/markers/arrow_marker.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>

--- a/src/rviz/default_plugin/markers/line_list_marker.cpp
+++ b/src/rviz/default_plugin/markers/line_list_marker.cpp
@@ -34,7 +34,7 @@
 
 #include <rviz/ogre_helpers/billboard_line.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneNode.h>
 

--- a/src/rviz/default_plugin/markers/line_strip_marker.cpp
+++ b/src/rviz/default_plugin/markers/line_strip_marker.cpp
@@ -36,7 +36,7 @@
 
 #include <rviz/ogre_helpers/billboard_line.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneNode.h>
 

--- a/src/rviz/default_plugin/markers/marker_selection_handler.cpp
+++ b/src/rviz/default_plugin/markers/marker_selection_handler.cpp
@@ -28,7 +28,7 @@
  */
 
 #include <OgreQuaternion.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <rviz/default_plugin/interactive_markers/interactive_marker_control.h>
 #include <rviz/default_plugin/marker_display.h>

--- a/src/rviz/default_plugin/markers/points_marker.cpp
+++ b/src/rviz/default_plugin/markers/points_marker.cpp
@@ -35,7 +35,7 @@
 
 #include <rviz/ogre_helpers/point_cloud.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>

--- a/src/rviz/default_plugin/point_cloud_transformer.h
+++ b/src/rviz/default_plugin/point_cloud_transformer.h
@@ -35,7 +35,7 @@
 #include <ros/message_forward.h>
 
 #ifndef Q_MOC_RUN
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreColourValue.h>
 
 #include <rviz/ogre_helpers/point_cloud.h>

--- a/src/rviz/default_plugin/point_cloud_transformers.cpp
+++ b/src/rviz/default_plugin/point_cloud_transformers.cpp
@@ -29,7 +29,7 @@
 
 #include <OgreColourValue.h>
 #include <OgreMatrix4.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <rviz/properties/bool_property.h>
 #include <rviz/properties/color_property.h>

--- a/src/rviz/default_plugin/point_visual.cpp
+++ b/src/rviz/default_plugin/point_visual.cpp
@@ -1,4 +1,4 @@
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 

--- a/src/rviz/default_plugin/robot_model_display.h
+++ b/src/rviz/default_plugin/robot_model_display.h
@@ -32,7 +32,7 @@
 
 #include <rviz/display.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <map>
 

--- a/src/rviz/default_plugin/screw_visual.cpp
+++ b/src/rviz/default_plugin/screw_visual.cpp
@@ -1,4 +1,4 @@
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -34,7 +34,7 @@
 #include <set>
 
 #include <OgreQuaternion.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <rviz/selection/forwards.h>
 

--- a/src/rviz/default_plugin/tools/focus_tool.cpp
+++ b/src/rviz/default_plugin/tools/focus_tool.cpp
@@ -28,7 +28,7 @@
  */
 
 #include <OgreRay.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreViewport.h>
 #include <OgreCamera.h>
 

--- a/src/rviz/default_plugin/tools/measure_tool.h
+++ b/src/rviz/default_plugin/tools/measure_tool.h
@@ -38,7 +38,7 @@
 
 #include <rviz/tool.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 namespace rviz
 {

--- a/src/rviz/default_plugin/tools/point_tool.cpp
+++ b/src/rviz/default_plugin/tools/point_tool.cpp
@@ -28,7 +28,7 @@
  */
 
 #include <OgreRay.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <rviz/viewport_mouse_event.h>
 #include <rviz/load_resource.h>

--- a/src/rviz/default_plugin/tools/pose_tool.h
+++ b/src/rviz/default_plugin/tools/pose_tool.h
@@ -30,7 +30,7 @@
 #ifndef RVIZ_POSE_TOOL_H
 #define RVIZ_POSE_TOOL_H
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <QCursor>
 

--- a/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/fixed_orientation_ortho_view_controller.cpp
@@ -31,7 +31,7 @@
 #include <OgreQuaternion.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreViewport.h>
 
 #include <rviz/display_context.h>

--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.cpp
@@ -33,7 +33,7 @@
 #include <OgreQuaternion.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreViewport.h>
 
 #include <rviz/display_context.h>

--- a/src/rviz/default_plugin/view_controllers/orbit_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/orbit_view_controller.h
@@ -30,7 +30,7 @@
 #ifndef RVIZ_ORBIT_VIEW_CONTROLLER_H
 #define RVIZ_ORBIT_VIEW_CONTROLLER_H
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <QCursor>
 

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.cpp
@@ -36,7 +36,7 @@
 #include <OgreQuaternion.h>
 #include <OgreRay.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreViewport.h>
 #include <OgreMath.h>
 

--- a/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/third_person_follower_view_controller.h
@@ -32,7 +32,7 @@
 
 #include <rviz/default_plugin/view_controllers/orbit_view_controller.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 namespace Ogre
 {

--- a/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.cpp
@@ -36,7 +36,7 @@
 #include <OgreQuaternion.h>
 #include <OgreRay.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreViewport.h>
 
 #include <rviz/display_context.h>

--- a/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.h
+++ b/src/rviz/default_plugin/view_controllers/xy_orbit_view_controller.h
@@ -32,7 +32,7 @@
 
 #include <rviz/default_plugin/view_controllers/orbit_view_controller.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 namespace Ogre
 {

--- a/src/rviz/frame_manager.h
+++ b/src/rviz/frame_manager.h
@@ -38,7 +38,7 @@
 #include <tf2_ros/buffer.h>
 #include <geometry_msgs/Pose.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 
 #include <boost/thread/mutex.hpp>

--- a/src/rviz/frame_position_tracking_view_controller.h
+++ b/src/rviz/frame_position_tracking_view_controller.h
@@ -31,7 +31,7 @@
 #define RVIZ_FRAME_POSITION_TRACKING_VIEW_CONTROLLER_H
 
 #include <OgreQuaternion.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <rviz/view_controller.h>
 #include <rviz/rviz_export.h>

--- a/src/rviz/msg_conversions.h
+++ b/src/rviz/msg_conversions.h
@@ -29,7 +29,7 @@
 #ifndef MSG_CONVERSIONS_H
 #define MSG_CONVERSIONS_H
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 
 #include <geometry_msgs/Point.h>

--- a/src/rviz/ogre_helpers/arrow.cpp
+++ b/src/rviz/ogre_helpers/arrow.cpp
@@ -32,7 +32,7 @@
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 
 #include <sstream>

--- a/src/rviz/ogre_helpers/axes.cpp
+++ b/src/rviz/ogre_helpers/axes.cpp
@@ -32,7 +32,7 @@
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 
 #include <sstream>

--- a/src/rviz/ogre_helpers/billboard_line.cpp
+++ b/src/rviz/ogre_helpers/billboard_line.cpp
@@ -31,7 +31,7 @@
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreBillboardChain.h>
 #include <OgreMaterialManager.h>

--- a/src/rviz/ogre_helpers/billboard_line.h
+++ b/src/rviz/ogre_helpers/billboard_line.h
@@ -35,7 +35,7 @@
 #include <stdint.h>
 
 #include <vector>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreColourValue.h>
 #include <OgreMaterial.h>
 #include <OgreSharedPtr.h>

--- a/src/rviz/ogre_helpers/camera_base.cpp
+++ b/src/rviz/ogre_helpers/camera_base.cpp
@@ -32,7 +32,7 @@
 #include <OgreCamera.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 
 #include <stdint.h>

--- a/src/rviz/ogre_helpers/camera_base.h
+++ b/src/rviz/ogre_helpers/camera_base.h
@@ -30,7 +30,7 @@
 #ifndef OGRE_TOOLS_CAMERA_BASE_H_
 #define OGRE_TOOLS_CAMERA_BASE_H_
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 
 namespace Ogre

--- a/src/rviz/ogre_helpers/grid.cpp
+++ b/src/rviz/ogre_helpers/grid.cpp
@@ -32,7 +32,7 @@
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>

--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -42,7 +42,7 @@
 #include "movable_text.h"
 #include <rviz/ogre_helpers/version_check.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreRoot.h>
 #include <OgreCamera.h>

--- a/src/rviz/ogre_helpers/ogre_vector.h
+++ b/src/rviz/ogre_helpers/ogre_vector.h
@@ -1,0 +1,8 @@
+// OgrePrerequisites.h is needed for version_check to work
+#include <OgrePrerequisites.h>
+#include <rviz/ogre_helpers/version_check.h>
+#if OGRE_VERSION < OGRE_VERSION_CHECK(1, 12, 0)
+#include <OgreVector3.h>
+#else
+#include <OgreVector.h>
+#endif

--- a/src/rviz/ogre_helpers/orbit_camera.cpp
+++ b/src/rviz/ogre_helpers/orbit_camera.cpp
@@ -33,7 +33,7 @@
 #include <OgreCamera.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreViewport.h>
 

--- a/src/rviz/ogre_helpers/orbit_camera.h
+++ b/src/rviz/ogre_helpers/orbit_camera.h
@@ -31,7 +31,7 @@
 #define OGRE_TOOLS_ORBIT_CAMERA_H_
 
 #include "camera_base.h"
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 namespace Ogre
 {

--- a/src/rviz/ogre_helpers/point_cloud.cpp
+++ b/src/rviz/ogre_helpers/point_cloud.cpp
@@ -33,7 +33,7 @@
 
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>

--- a/src/rviz/ogre_helpers/point_cloud.h
+++ b/src/rviz/ogre_helpers/point_cloud.h
@@ -34,7 +34,7 @@
 #include <OgreMovableObject.h>
 #include <OgreString.h>
 #include <OgreAxisAlignedBox.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreMaterial.h>
 #include <OgreColourValue.h>
 #include <OgreRoot.h>

--- a/src/rviz/ogre_helpers/shape.cpp
+++ b/src/rviz/ogre_helpers/shape.cpp
@@ -33,7 +33,7 @@
 #include <rviz/ogre_helpers/version_check.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreEntity.h>
 #include <OgreMaterialManager.h>

--- a/src/rviz/ogre_helpers/shape.h
+++ b/src/rviz/ogre_helpers/shape.h
@@ -33,7 +33,7 @@
 #include "object.h"
 
 #include <OgreMaterial.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreSharedPtr.h>
 
 namespace Ogre

--- a/src/rviz/properties/vector_property.h
+++ b/src/rviz/properties/vector_property.h
@@ -29,7 +29,7 @@
 #ifndef VECTOR_PROPERTY_H
 #define VECTOR_PROPERTY_H
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 
 #include <rviz/properties/property.h>
 #include <rviz/rviz_export.h>

--- a/src/rviz/robot/robot.h
+++ b/src/rviz/robot/robot.h
@@ -35,7 +35,7 @@
 #include <string>
 #include <map>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 

--- a/src/rviz/robot/robot_joint.h
+++ b/src/rviz/robot/robot_joint.h
@@ -36,7 +36,7 @@
 #include <QObject>
 
 #ifndef Q_MOC_RUN
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 #include <OgreMaterial.h>

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -36,7 +36,7 @@
 #include <QObject>
 
 #ifndef Q_MOC_RUN
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 #include <OgreMaterial.h>

--- a/src/rviz/robot/tf_link_updater.cpp
+++ b/src/rviz/robot/tf_link_updater.cpp
@@ -31,7 +31,7 @@
 #include <rviz/frame_manager.h>
 #include <rviz/helpers/tf_prefix.h>
 
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 
 namespace rviz

--- a/src/rviz/validate_floats.h
+++ b/src/rviz/validate_floats.h
@@ -38,7 +38,7 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Twist.h>
 #include <std_msgs/ColorRGBA.h>
-#include <OgreVector3.h>
+#include <rviz/ogre_helpers/ogre_vector.h>
 #include <OgreQuaternion.h>
 
 #include <boost/array.hpp>


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

Replace all includes of OgreVector3.h with OgreVector.h for Ogre 1.12 (I noticed this because locus Fuse has Werror and errored on the OgreVector3.h with ogre 1.12).

### Checklist

- [ ] If you are addressing rendering issues, please provide:
  - [ ] Images of both, broken and fixed renderings.
  - [ ] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [ ] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
