### PR TITLE
Add better support for Qt5 style slots

### DIFF
--- a/src/rviz/properties/bool_property.cpp
+++ b/src/rviz/properties/bool_property.cpp
@@ -44,6 +44,17 @@ BoolProperty::BoolProperty(const QString& name,
 {
 }
 
+BoolProperty::BoolProperty(const QString& name,
+                           bool default_value,
+                           const QString& description,
+                           Property* parent,
+                           std::function<void()> changed_slot,
+                           QObject* receiver)
+  : Property(name, default_value, description, parent, changed_slot, receiver)
+  , disable_children_if_false_(false)
+{
+}
+
 BoolProperty::~BoolProperty()
 {
 }

--- a/src/rviz/properties/bool_property.h
+++ b/src/rviz/properties/bool_property.h
@@ -46,17 +46,12 @@ public:
                const char* changed_slot = nullptr,
                QObject* receiver = nullptr);
 
-  template <class Functor>
-  BoolProperty(const QString& name = QString(),
-               bool default_value = false,
-               const QString& description = QString(),
-               Property* parent = nullptr,
-               Functor method = [] {},
-               QObject* context = nullptr)
-    : Property(name, default_value, description, parent, method, context)
-    , disable_children_if_false_(false)
-  {
-  }
+  BoolProperty(const QString& name,
+               bool default_value,
+               const QString& description,
+               Property* parent,
+               std::function<void()> changed_slot,
+               QObject* receiver = nullptr);
 
   ~BoolProperty() override;
 

--- a/src/rviz/properties/bool_property.h
+++ b/src/rviz/properties/bool_property.h
@@ -46,6 +46,18 @@ public:
                const char* changed_slot = nullptr,
                QObject* receiver = nullptr);
 
+  template <class Functor>
+  BoolProperty(const QString& name = QString(),
+               bool default_value = false,
+               const QString& description = QString(),
+               Property* parent = nullptr,
+               Functor method = [] {},
+               QObject* context = nullptr)
+    : Property(name, default_value, description, parent, method, context)
+    , disable_children_if_false_(false)
+  {
+  }
+
   ~BoolProperty() override;
 
   virtual bool getBool() const;

--- a/src/rviz/properties/color_property.cpp
+++ b/src/rviz/properties/color_property.cpp
@@ -49,6 +49,17 @@ ColorProperty::ColorProperty(const QString& name,
   updateString();
 }
 
+ColorProperty::ColorProperty(const QString& name,
+                             const QColor& default_value,
+                             const QString& description,
+                             Property* parent,
+                             std::function<void()> changed_slot,
+                             QObject* receiver)
+  : Property(name, QVariant(), description, parent, changed_slot, receiver), color_(default_value)
+{
+  updateString();
+}
+
 bool ColorProperty::setColor(const QColor& new_color)
 {
   if (new_color != color_)

--- a/src/rviz/properties/color_property.h
+++ b/src/rviz/properties/color_property.h
@@ -48,6 +48,13 @@ public:
                 const char* changed_slot = nullptr,
                 QObject* receiver = nullptr);
 
+  ColorProperty(const QString& name,
+                const QColor& default_value,
+                const QString& description,
+                Property* parent,
+                std::function<void()> changed_slot,
+                QObject* receiver = nullptr);
+
   bool setValue(const QVariant& new_value) override;
 
   bool paint(QPainter* painter, const QStyleOptionViewItem& option) const override;

--- a/src/rviz/properties/display_group_visibility_property.cpp
+++ b/src/rviz/properties/display_group_visibility_property.cpp
@@ -66,6 +66,29 @@ DisplayGroupVisibilityProperty::DisplayGroupVisibilityProperty(uint32_t vis_bit,
   initialize_this();
 }
 
+DisplayGroupVisibilityProperty::DisplayGroupVisibilityProperty(uint32_t vis_bit,
+                                                               DisplayGroup* display_group,
+                                                               Display* parent_display,
+                                                               const QString& name,
+                                                               bool default_value,
+                                                               const QString& description,
+                                                               Property* parent,
+                                                               std::function<void()> changed_slot,
+                                                               QObject* receiver)
+  : DisplayVisibilityProperty(vis_bit,
+                              display_group,
+                              name,
+                              default_value,
+                              description,
+                              parent,
+                              changed_slot,
+                              receiver)
+  , display_group_(display_group)
+  , parent_display_(parent_display)
+{
+  initialize_this();
+}
+
 void DisplayGroupVisibilityProperty::initialize_this()
 {
   connect(display_group_, SIGNAL(displayAdded(rviz::Display*)), this,

--- a/src/rviz/properties/display_group_visibility_property.cpp
+++ b/src/rviz/properties/display_group_visibility_property.cpp
@@ -63,15 +63,20 @@ DisplayGroupVisibilityProperty::DisplayGroupVisibilityProperty(uint32_t vis_bit,
   , display_group_(display_group)
   , parent_display_(parent_display)
 {
-  connect(display_group, SIGNAL(displayAdded(rviz::Display*)), this,
+  initialize_this();
+}
+
+void DisplayGroupVisibilityProperty::initialize_this()
+{
+  connect(display_group_, SIGNAL(displayAdded(rviz::Display*)), this,
           SLOT(onDisplayAdded(rviz::Display*)));
-  connect(display_group, SIGNAL(displayRemoved(rviz::Display*)), this,
+  connect(display_group_, SIGNAL(displayRemoved(rviz::Display*)), this,
           SLOT(onDisplayRemoved(rviz::Display*)));
 
-  for (int i = 0; i < display_group->numDisplays(); i++)
+  for (int i = 0; i < display_group_->numDisplays(); i++)
   {
-    rviz::Display* display = display_group->getDisplayAt(i);
-    if (display != parent_display)
+    rviz::Display* display = display_group_->getDisplayAt(i);
+    if (display != parent_display_)
     {
       onDisplayAdded(display);
     }

--- a/src/rviz/properties/display_group_visibility_property.h
+++ b/src/rviz/properties/display_group_visibility_property.h
@@ -72,29 +72,15 @@ public:
                                  const char* changed_slot = nullptr,
                                  QObject* receiver = nullptr);
 
-  template <class Functor>
   DisplayGroupVisibilityProperty(uint32_t vis_bit,
                                  DisplayGroup* display_group,
                                  Display* parent_display,
-                                 const QString& name = QString(),
-                                 bool default_value = false,
-                                 const QString& description = QString(),
-                                 Property* parent = nullptr,
-                                 Functor method = [] {},
-                                 QObject* context = nullptr)
-    : DisplayVisibilityProperty(vis_bit,
-                                display_group,
-                                name,
-                                default_value,
-                                description,
-                                parent,
-                                method,
-                                context)
-    , display_group_(display_group)
-    , parent_display_(parent_display)
-  {
-    initialize_this();
-  }
+                                 const QString& name,
+                                 bool default_value,
+                                 const QString& description,
+                                 Property* parent,
+                                 std::function<void()> changed_slot,
+                                 QObject* receiver = nullptr);
 
   ~DisplayGroupVisibilityProperty() override;
 

--- a/src/rviz/properties/display_group_visibility_property.h
+++ b/src/rviz/properties/display_group_visibility_property.h
@@ -71,6 +71,31 @@ public:
                                  Property* parent = nullptr,
                                  const char* changed_slot = nullptr,
                                  QObject* receiver = nullptr);
+
+  template <class Functor>
+  DisplayGroupVisibilityProperty(uint32_t vis_bit,
+                                 DisplayGroup* display_group,
+                                 Display* parent_display,
+                                 const QString& name = QString(),
+                                 bool default_value = false,
+                                 const QString& description = QString(),
+                                 Property* parent = nullptr,
+                                 Functor method = [] {},
+                                 QObject* context = nullptr)
+    : DisplayVisibilityProperty(vis_bit,
+                                display_group,
+                                name,
+                                default_value,
+                                description,
+                                parent,
+                                method,
+                                context)
+    , display_group_(display_group)
+    , parent_display_(parent_display)
+  {
+    initialize_this();
+  }
+
   ~DisplayGroupVisibilityProperty() override;
 
   // @brief Update visibility masks of all objects in the Ogre scene
@@ -85,6 +110,8 @@ private:
   // sort the properties in the same way as in the
   // root display group
   void sortDisplayList();
+
+  void initialize_this();
 
   DisplayGroup* display_group_;
   std::map<rviz::Display*, DisplayVisibilityProperty*> disp_vis_props_;

--- a/src/rviz/properties/display_visibility_property.cpp
+++ b/src/rviz/properties/display_visibility_property.cpp
@@ -53,6 +53,22 @@ DisplayVisibilityProperty::DisplayVisibilityProperty(uint32_t vis_bit,
   DisplayVisibilityProperty::update();
 }
 
+DisplayVisibilityProperty::DisplayVisibilityProperty(uint32_t vis_bit,
+                                                     Display* display,
+                                                     const QString& name,
+                                                     bool default_value,
+                                                     const QString& description,
+                                                     Property* parent,
+                                                     std::function<void()> changed_slot,
+                                                     QObject* receiver)
+  : BoolProperty(name, default_value, description, parent, changed_slot, receiver)
+  , vis_bit_(vis_bit)
+  , display_(display)
+{
+  custom_name_ = (name.size() != 0);
+  DisplayVisibilityProperty::update();
+}
+
 DisplayVisibilityProperty::~DisplayVisibilityProperty()
 {
 }

--- a/src/rviz/properties/display_visibility_property.h
+++ b/src/rviz/properties/display_visibility_property.h
@@ -65,6 +65,23 @@ public:
                             const char* changed_slot = nullptr,
                             QObject* receiver = nullptr);
 
+  template <class Functor>
+  DisplayVisibilityProperty(uint32_t vis_bit,
+                            Display* display,
+                            const QString& name = QString(),
+                            bool default_value = false,
+                            const QString& description = QString(),
+                            Property* parent = nullptr,
+                            Functor method = [] {},
+                            QObject* context = nullptr)
+    : BoolProperty(name, default_value, description, parent, method, context)
+    , vis_bit_(vis_bit)
+    , display_(display)
+  {
+    custom_name_ = (name.size() != 0);
+    DisplayVisibilityProperty::update();
+  }
+
   ~DisplayVisibilityProperty() override;
 
   virtual void update();

--- a/src/rviz/properties/display_visibility_property.h
+++ b/src/rviz/properties/display_visibility_property.h
@@ -65,22 +65,14 @@ public:
                             const char* changed_slot = nullptr,
                             QObject* receiver = nullptr);
 
-  template <class Functor>
   DisplayVisibilityProperty(uint32_t vis_bit,
                             Display* display,
-                            const QString& name = QString(),
-                            bool default_value = false,
-                            const QString& description = QString(),
-                            Property* parent = nullptr,
-                            Functor method = [] {},
-                            QObject* context = nullptr)
-    : BoolProperty(name, default_value, description, parent, method, context)
-    , vis_bit_(vis_bit)
-    , display_(display)
-  {
-    custom_name_ = (name.size() != 0);
-    DisplayVisibilityProperty::update();
-  }
+                            const QString& name,
+                            bool default_value,
+                            const QString& description,
+                            Property* parent,
+                            std::function<void()> changed_slot,
+                            QObject* receiver = nullptr);
 
   ~DisplayVisibilityProperty() override;
 

--- a/src/rviz/properties/editable_enum_property.cpp
+++ b/src/rviz/properties/editable_enum_property.cpp
@@ -44,6 +44,16 @@ EditableEnumProperty::EditableEnumProperty(const QString& name,
 {
 }
 
+EditableEnumProperty::EditableEnumProperty(const QString& name,
+                                           const QString& default_value,
+                                           const QString& description,
+                                           Property* parent,
+                                           std::function<void()> changed_slot,
+                                           QObject* receiver)
+  : StringProperty(name, default_value, description, parent, changed_slot, receiver)
+{
+}
+
 void EditableEnumProperty::clearOptions()
 {
   strings_.clear();

--- a/src/rviz/properties/editable_enum_property.h
+++ b/src/rviz/properties/editable_enum_property.h
@@ -51,6 +51,17 @@ public:
                        const char* changed_slot = nullptr,
                        QObject* receiver = nullptr);
 
+  template <class Functor>
+  EditableEnumProperty(const QString& name = QString(),
+                       const QString& default_value = QString(),
+                       const QString& description = QString(),
+                       Property* parent = nullptr,
+                       Functor method = [] {},
+                       QObject* context = nullptr)
+    : StringProperty(name, default_value, description, parent, method, context)
+  {
+  }
+
   virtual void clearOptions();
   virtual void addOption(const QString& option);
   void addOptionStd(const std::string& option)

--- a/src/rviz/properties/editable_enum_property.h
+++ b/src/rviz/properties/editable_enum_property.h
@@ -51,16 +51,12 @@ public:
                        const char* changed_slot = nullptr,
                        QObject* receiver = nullptr);
 
-  template <class Functor>
-  EditableEnumProperty(const QString& name = QString(),
-                       const QString& default_value = QString(),
-                       const QString& description = QString(),
-                       Property* parent = nullptr,
-                       Functor method = [] {},
-                       QObject* context = nullptr)
-    : StringProperty(name, default_value, description, parent, method, context)
-  {
-  }
+  EditableEnumProperty(const QString& name,
+                       const QString& default_value,
+                       const QString& description,
+                       Property* parent,
+                       std::function<void()> changed_slot,
+                       QObject* receiver = nullptr);
 
   virtual void clearOptions();
   virtual void addOption(const QString& option);

--- a/src/rviz/properties/enum_property.cpp
+++ b/src/rviz/properties/enum_property.cpp
@@ -43,6 +43,16 @@ EnumProperty::EnumProperty(const QString& name,
 {
 }
 
+EnumProperty::EnumProperty(const QString& name,
+                           const QString& default_value,
+                           const QString& description,
+                           Property* parent,
+                           std::function<void()> changed_slot,
+                           QObject* receiver)
+  : StringProperty(name, default_value, description, parent, changed_slot, receiver)
+{
+}
+
 void EnumProperty::clearOptions()
 {
   strings_.clear();

--- a/src/rviz/properties/enum_property.h
+++ b/src/rviz/properties/enum_property.h
@@ -54,6 +54,17 @@ public:
                const char* changed_slot = nullptr,
                QObject* receiver = nullptr);
 
+  template <class Functor>
+  EnumProperty(const QString& name = QString(),
+               const QString& default_value = QString(),
+               const QString& description = QString(),
+               Property* parent = nullptr,
+               Functor method = [] {},
+               QObject* context = nullptr)
+    : StringProperty(name, default_value, description, parent, method, context)
+  {
+  }
+
   /** @brief Clear the list of options.
    *
    * Does not change the current value of the property. */

--- a/src/rviz/properties/enum_property.h
+++ b/src/rviz/properties/enum_property.h
@@ -54,16 +54,12 @@ public:
                const char* changed_slot = nullptr,
                QObject* receiver = nullptr);
 
-  template <class Functor>
-  EnumProperty(const QString& name = QString(),
-               const QString& default_value = QString(),
-               const QString& description = QString(),
-               Property* parent = nullptr,
-               Functor method = [] {},
-               QObject* context = nullptr)
-    : StringProperty(name, default_value, description, parent, method, context)
-  {
-  }
+  EnumProperty(const QString& name,
+               const QString& default_value,
+               const QString& description,
+               Property* parent,
+               std::function<void()> changed_slot,
+               QObject* receiver = nullptr);
 
   /** @brief Clear the list of options.
    *

--- a/src/rviz/properties/float_property.cpp
+++ b/src/rviz/properties/float_property.cpp
@@ -47,6 +47,18 @@ FloatProperty::FloatProperty(const QString& name,
 {
 }
 
+FloatProperty::FloatProperty(const QString& name,
+                             float default_value,
+                             const QString& description,
+                             Property* parent,
+                             std::function<void()> changed_slot,
+                             QObject* receiver)
+  : Property(name, default_value, description, parent, changed_slot, receiver)
+  , min_(-FLT_MAX)
+  , max_(FLT_MAX)
+{
+}
+
 bool FloatProperty::setValue(const QVariant& new_value)
 {
   return Property::setValue(qBound(min_, new_value.toFloat(), max_));

--- a/src/rviz/properties/float_property.h
+++ b/src/rviz/properties/float_property.h
@@ -31,6 +31,8 @@
 
 #include <rviz/properties/property.h>
 
+#include <cfloat>
+
 namespace rviz
 {
 /** @brief Property specialized to enforce floating point max/min. */
@@ -44,6 +46,19 @@ public:
                 Property* parent = nullptr,
                 const char* changed_slot = nullptr,
                 QObject* receiver = nullptr);
+
+  template <class Functor>
+  FloatProperty(const QString& name = QString(),
+                float default_value = 0,
+                const QString& description = QString(),
+                Property* parent = nullptr,
+                Functor method = [] {},
+                QObject* context = nullptr)
+    : Property(name, default_value, description, parent, method, context)
+    , min_(-FLT_MAX)
+    , max_(FLT_MAX)
+  {
+  }
 
   /** @brief Set the new value for this property.  Returns true if the
    * new value is different from the old value, false if same.

--- a/src/rviz/properties/float_property.h
+++ b/src/rviz/properties/float_property.h
@@ -31,8 +31,6 @@
 
 #include <rviz/properties/property.h>
 
-#include <cfloat>
-
 namespace rviz
 {
 /** @brief Property specialized to enforce floating point max/min. */

--- a/src/rviz/properties/float_property.h
+++ b/src/rviz/properties/float_property.h
@@ -47,18 +47,12 @@ public:
                 const char* changed_slot = nullptr,
                 QObject* receiver = nullptr);
 
-  template <class Functor>
-  FloatProperty(const QString& name = QString(),
-                float default_value = 0,
-                const QString& description = QString(),
-                Property* parent = nullptr,
-                Functor method = [] {},
-                QObject* context = nullptr)
-    : Property(name, default_value, description, parent, method, context)
-    , min_(-FLT_MAX)
-    , max_(FLT_MAX)
-  {
-  }
+  FloatProperty(const QString& name,
+                float default_value,
+                const QString& description,
+                Property* parent,
+                std::function<void()> changed_slot,
+                QObject* receiver = nullptr);
 
   /** @brief Set the new value for this property.  Returns true if the
    * new value is different from the old value, false if same.

--- a/src/rviz/properties/int_property.cpp
+++ b/src/rviz/properties/int_property.cpp
@@ -48,6 +48,18 @@ IntProperty::IntProperty(const QString& name,
 {
 }
 
+IntProperty::IntProperty(const QString& name,
+                         int default_value,
+                         const QString& description,
+                         Property* parent,
+                         std::function<void()> changed_slot,
+                         QObject* receiver)
+  : Property(name, default_value, description, parent, changed_slot, receiver)
+  , min_(INT_MIN)
+  , max_(INT_MAX)
+{
+}
+
 bool IntProperty::setValue(const QVariant& new_value)
 {
   return Property::setValue(qBound(min_, new_value.toInt(), max_));

--- a/src/rviz/properties/int_property.h
+++ b/src/rviz/properties/int_property.h
@@ -58,18 +58,12 @@ public:
               const char* changed_slot = nullptr,
               QObject* receiver = nullptr);
 
-  template <class Functor>
-  IntProperty(const QString& name = QString(),
-              int default_value = 0,
-              const QString& description = QString(),
-              Property* parent = nullptr,
-              Functor method = [] {},
-              QObject* context = nullptr)
-    : Property(name, default_value, description, parent, method, context)
-    , min_(INT_MIN)
-    , max_(INT_MAX)
-  {
-  }
+  IntProperty(const QString& name,
+              int default_value,
+              const QString& description,
+              Property* parent,
+              std::function<void()> changed_slot,
+              QObject* receiver = nullptr);
 
   /** @brief Set the new value for this property.  Returns true if the
    * new value is different from the old value, false if same.

--- a/src/rviz/properties/int_property.h
+++ b/src/rviz/properties/int_property.h
@@ -58,6 +58,19 @@ public:
               const char* changed_slot = nullptr,
               QObject* receiver = nullptr);
 
+  template <class Functor>
+  IntProperty(const QString& name = QString(),
+              int default_value = 0,
+              const QString& description = QString(),
+              Property* parent = nullptr,
+              Functor method = [] {},
+              QObject* context = nullptr)
+    : Property(name, default_value, description, parent, method, context)
+    , min_(INT_MIN)
+    , max_(INT_MAX)
+  {
+  }
+
   /** @brief Set the new value for this property.  Returns true if the
    * new value is different from the old value, false if same.
    *

--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -85,6 +85,39 @@ Property::Property(const QString& name,
   }
 }
 
+Property::Property(const QString& name,
+                   const QVariant& default_value,
+                   const QString& description,
+                   Property* parent,
+                   std::function<void()> changed_slot,
+                   QObject* receiver)
+  : value_(default_value)
+  , model_(nullptr)
+  , child_indexes_valid_(false)
+  , parent_(nullptr)
+  , description_(description)
+  , hidden_(false)
+  , is_read_only_(false)
+  , save_(true)
+{
+  Property::setName(name);
+  if (parent)
+  {
+    parent->addChild(this);
+  }
+  if (receiver == nullptr)
+  {
+    receiver = parent;
+  }
+  if (changed_slot)
+  {
+    if (receiver)
+      connect(this, &Property::changed, receiver, changed_slot);
+    else
+      connect(this, &Property::changed, changed_slot);
+  }
+}
+
 Property::~Property()
 {
   // Disconnect myself from my parent.

--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -58,9 +58,7 @@ Property* Property::failprop_ = new FailureProperty;
 Property::Property(const QString& name,
                    const QVariant& default_value,
                    const QString& description,
-                   Property* parent,
-                   const char* changed_slot,
-                   QObject* receiver)
+                   Property* parent)
   : value_(default_value)
   , model_(nullptr)
   , child_indexes_valid_(false)
@@ -75,6 +73,16 @@ Property::Property(const QString& name,
   {
     parent->addChild(this);
   }
+}
+
+Property::Property(const QString& name,
+                   const QVariant& default_value,
+                   const QString& description,
+                   Property* parent,
+                   const char* changed_slot,
+                   QObject* receiver)
+  : Property(name, default_value, description, parent)
+{
   if (receiver == nullptr)
   {
     receiver = parent;
@@ -84,31 +92,14 @@ Property::Property(const QString& name,
     connect(this, SIGNAL(changed()), receiver, changed_slot);
   }
 }
-
 Property::Property(const QString& name,
                    const QVariant& default_value,
                    const QString& description,
                    Property* parent,
                    std::function<void()> changed_slot,
                    QObject* receiver)
-  : value_(default_value)
-  , model_(nullptr)
-  , child_indexes_valid_(false)
-  , parent_(nullptr)
-  , description_(description)
-  , hidden_(false)
-  , is_read_only_(false)
-  , save_(true)
+  : Property(name, default_value, description, parent)
 {
-  Property::setName(name);
-  if (parent)
-  {
-    parent->addChild(this);
-  }
-  if (receiver == nullptr)
-  {
-    receiver = parent;
-  }
   if (changed_slot)
   {
     if (receiver)

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -133,8 +133,13 @@ public:
   Property(const QString& name = QString(),
            const QVariant& default_value = QVariant(),
            const QString& description = QString(),
-           Property* parent = nullptr,
-           const char* changed_slot = nullptr,
+           Property* parent = nullptr);
+
+  Property(const QString& name,
+           const QVariant& default_value,
+           const QString& description,
+           Property* parent,
+           const char* changed_slot,
            QObject* receiver = nullptr);
 
   Property(const QString& name,

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -30,6 +30,7 @@
 #define PROPERTY_H
 
 #include <string>
+#include <functional>
 
 #include <QObject>
 #include <QIcon>
@@ -136,39 +137,12 @@ public:
            const char* changed_slot = nullptr,
            QObject* receiver = nullptr);
 
-  template <class Functor>
-  Property(const QString& name = QString(),
-           const QVariant& default_value = QVariant(),
-           const QString& description = QString(),
-           Property* parent = nullptr,
-           Functor method = []{},
-           QObject* context = nullptr)
-    : value_(default_value)
-    , model_(nullptr)
-    , child_indexes_valid_(false)
-    , parent_(nullptr)
-    , description_(description)
-    , hidden_(false)
-    , is_read_only_(false)
-    , save_(true)
-  {
-    Property::setName(name);
-    if (parent)
-    {
-      parent->addChild(this);
-    } else
-    {
-      parent = this;  // for context
-    }
-    if (context == nullptr)
-    {
-      context = parent;
-    }
-    if (context)
-    {
-      connect(this, &Property::changed, context, method);
-    }
-  }
+  Property(const QString& name,
+           const QVariant& default_value,
+           const QString& description,
+           Property* parent,
+           std::function<void()> changed_slot,
+           QObject* receiver = nullptr);
 
   /** @brief Destructor.  Removes this property from its parent's list
    * of children.

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -136,6 +136,40 @@ public:
            const char* changed_slot = nullptr,
            QObject* receiver = nullptr);
 
+  template <class Functor>
+  Property(const QString& name = QString(),
+           const QVariant& default_value = QVariant(),
+           const QString& description = QString(),
+           Property* parent = nullptr,
+           Functor method = []{},
+           QObject* context = nullptr)
+    : value_(default_value)
+    , model_(nullptr)
+    , child_indexes_valid_(false)
+    , parent_(nullptr)
+    , description_(description)
+    , hidden_(false)
+    , is_read_only_(false)
+    , save_(true)
+  {
+    Property::setName(name);
+    if (parent)
+    {
+      parent->addChild(this);
+    } else
+    {
+      parent = this;  // for context
+    }
+    if (context == nullptr)
+    {
+      context = parent;
+    }
+    if (context)
+    {
+      connect(this, &Property::changed, context, method);
+    }
+  }
+
   /** @brief Destructor.  Removes this property from its parent's list
    * of children.
    */

--- a/src/rviz/properties/quaternion_property.cpp
+++ b/src/rviz/properties/quaternion_property.cpp
@@ -47,6 +47,19 @@ QuaternionProperty::QuaternionProperty(const QString& name,
   initialize_this();
 }
 
+QuaternionProperty::QuaternionProperty(const QString& name,
+                                       const Ogre::Quaternion& default_value,
+                                       const QString& description,
+                                       Property* parent,
+                                       std::function<void()> changed_slot,
+                                       QObject* receiver)
+  : Property(name, QVariant(), description, parent, changed_slot, receiver)
+  , quaternion_(default_value)
+  , ignore_child_updates_(false)
+{
+  initialize_this();
+}
+
 void QuaternionProperty::initialize_this()
 {
   x_ = new Property("X", quaternion_.x, "X coordinate", this);

--- a/src/rviz/properties/quaternion_property.cpp
+++ b/src/rviz/properties/quaternion_property.cpp
@@ -44,6 +44,11 @@ QuaternionProperty::QuaternionProperty(const QString& name,
   , quaternion_(default_value)
   , ignore_child_updates_(false)
 {
+  initialize_this();
+}
+
+void QuaternionProperty::initialize_this()
+{
   x_ = new Property("X", quaternion_.x, "X coordinate", this);
   y_ = new Property("Y", quaternion_.y, "Y coordinate", this);
   z_ = new Property("Z", quaternion_.z, "Z coordinate", this);

--- a/src/rviz/properties/quaternion_property.h
+++ b/src/rviz/properties/quaternion_property.h
@@ -46,6 +46,20 @@ public:
                      const char* changed_slot = nullptr,
                      QObject* receiver = nullptr);
 
+  template <class Functor>
+  QuaternionProperty(const QString& name = QString(),
+                     const Ogre::Quaternion& default_value = Ogre::Quaternion::IDENTITY,
+                     const QString& description = QString(),
+                     Property* parent = nullptr,
+                     Functor method = []{},
+                     QObject* context = nullptr)
+    : Property(name, QVariant(), description, parent, method, context)
+    , quaternion_(default_value)
+    , ignore_child_updates_(false)
+  {
+    initialize_this();
+  }
+
   virtual bool setQuaternion(const Ogre::Quaternion& quaternion);
   virtual Ogre::Quaternion getQuaternion() const
   {
@@ -69,6 +83,7 @@ private Q_SLOTS:
 
 private:
   void updateString();
+  void initialize_this();
 
   Ogre::Quaternion quaternion_;
   Property* x_;

--- a/src/rviz/properties/quaternion_property.h
+++ b/src/rviz/properties/quaternion_property.h
@@ -46,19 +46,12 @@ public:
                      const char* changed_slot = nullptr,
                      QObject* receiver = nullptr);
 
-  template <class Functor>
-  QuaternionProperty(const QString& name = QString(),
-                     const Ogre::Quaternion& default_value = Ogre::Quaternion::IDENTITY,
-                     const QString& description = QString(),
-                     Property* parent = nullptr,
-                     Functor method = []{},
-                     QObject* context = nullptr)
-    : Property(name, QVariant(), description, parent, method, context)
-    , quaternion_(default_value)
-    , ignore_child_updates_(false)
-  {
-    initialize_this();
-  }
+  QuaternionProperty(const QString& name,
+                     const Ogre::Quaternion& default_value,
+                     const QString& description,
+                     Property* parent,
+                     std::function<void()> changed_slot,
+                     QObject* receiver = nullptr);
 
   virtual bool setQuaternion(const Ogre::Quaternion& quaternion);
   virtual Ogre::Quaternion getQuaternion() const

--- a/src/rviz/properties/ros_topic_property.cpp
+++ b/src/rviz/properties/ros_topic_property.cpp
@@ -49,6 +49,19 @@ RosTopicProperty::RosTopicProperty(const QString& name,
   connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillTopicList()));
 }
 
+RosTopicProperty::RosTopicProperty(const QString& name,
+                                   const QString& default_value,
+                                   const QString& message_type,
+                                   const QString& description,
+                                   Property* parent,
+                                   std::function<void()> changed_slot,
+                                   QObject* receiver)
+  : EditableEnumProperty(name, default_value, description, parent, changed_slot, receiver)
+  , message_type_(message_type)
+{
+  connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillTopicList()));
+}
+
 void RosTopicProperty::setMessageType(const QString& message_type)
 {
   message_type_ = message_type;

--- a/src/rviz/properties/ros_topic_property.h
+++ b/src/rviz/properties/ros_topic_property.h
@@ -48,19 +48,13 @@ public:
                    const char* changed_slot = nullptr,
                    QObject* receiver = nullptr);
 
-  template <class Functor>
-  RosTopicProperty(const QString& name = QString(),
-                   const QString& default_value = QString(),
-                   const QString& message_type = QString(),
-                   const QString& description = QString(),
-                   Property* parent = nullptr,
-                   Functor method = []{},
-                   QObject* context = nullptr)
-    : EditableEnumProperty(name, default_value, description, parent, method, context)
-    , message_type_(message_type)
-  {
-    connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillTopicList()));
-  }
+  RosTopicProperty(const QString& name,
+                   const QString& default_value,
+                   const QString& message_type,
+                   const QString& description,
+                   Property* parent,
+                   std::function<void()> changed_slot,
+                   QObject* receiver = nullptr);
 
   void setMessageType(const QString& message_type);
   QString getMessageType() const

--- a/src/rviz/properties/ros_topic_property.h
+++ b/src/rviz/properties/ros_topic_property.h
@@ -48,6 +48,20 @@ public:
                    const char* changed_slot = nullptr,
                    QObject* receiver = nullptr);
 
+  template <class Functor>
+  RosTopicProperty(const QString& name = QString(),
+                   const QString& default_value = QString(),
+                   const QString& message_type = QString(),
+                   const QString& description = QString(),
+                   Property* parent = nullptr,
+                   Functor method = []{},
+                   QObject* context = nullptr)
+    : EditableEnumProperty(name, default_value, description, parent, method, context)
+    , message_type_(message_type)
+  {
+    connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillTopicList()));
+  }
+
   void setMessageType(const QString& message_type);
   QString getMessageType() const
   {

--- a/src/rviz/properties/string_property.cpp
+++ b/src/rviz/properties/string_property.cpp
@@ -41,4 +41,14 @@ StringProperty::StringProperty(const QString& name,
 {
 }
 
+StringProperty::StringProperty(const QString& name,
+                               const QString& default_value,
+                               const QString& description,
+                               Property* parent,
+                               std::function<void()> changed_slot,
+                               QObject* receiver)
+  : Property(name, default_value, description, parent, changed_slot, receiver)
+{
+}
+
 } // end namespace rviz

--- a/src/rviz/properties/string_property.h
+++ b/src/rviz/properties/string_property.h
@@ -47,6 +47,17 @@ public:
                  const char* changed_slot = nullptr,
                  QObject* receiver = nullptr);
 
+  template <class Functor>
+  StringProperty(const QString& name = QString(),
+                 const QString& default_value = QString(),
+                 const QString& description = QString(),
+                 Property* parent = nullptr,
+                 Functor method = []{},
+                 QObject* context = nullptr)
+    : Property(name, default_value, description, parent, method, context)
+  {
+  }
+
   std::string getStdString()
   {
     return getValue().toString().toStdString();

--- a/src/rviz/properties/string_property.h
+++ b/src/rviz/properties/string_property.h
@@ -47,16 +47,12 @@ public:
                  const char* changed_slot = nullptr,
                  QObject* receiver = nullptr);
 
-  template <class Functor>
-  StringProperty(const QString& name = QString(),
-                 const QString& default_value = QString(),
-                 const QString& description = QString(),
-                 Property* parent = nullptr,
-                 Functor method = []{},
-                 QObject* context = nullptr)
-    : Property(name, default_value, description, parent, method, context)
-  {
-  }
+  StringProperty(const QString& name,
+                 const QString& default_value,
+                 const QString& description,
+                 Property* parent,
+                 std::function<void()> changed_slot,
+                 QObject* receiver = nullptr);
 
   std::string getStdString()
   {

--- a/src/rviz/properties/tf_frame_property.cpp
+++ b/src/rviz/properties/tf_frame_property.cpp
@@ -54,6 +54,23 @@ TfFrameProperty::TfFrameProperty(const QString& name,
   setFrameManager(frame_manager);
 }
 
+TfFrameProperty::TfFrameProperty(const QString& name,
+                                 const QString& default_value,
+                                 const QString& description,
+                                 Property* parent,
+                                 FrameManager* frame_manager,
+                                 bool include_fixed_frame_string,
+                                 std::function<void()> changed_slot,
+                                 QObject* receiver)
+  : EditableEnumProperty(name, default_value, description, parent, changed_slot, receiver)
+  , frame_manager_(nullptr)
+  , include_fixed_frame_string_(include_fixed_frame_string)
+{
+  // Parent class EditableEnumProperty has requestOptions() signal.
+  connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillFrameList()));
+  setFrameManager(frame_manager);
+}
+
 bool TfFrameProperty::setValue(const QVariant& new_value)
 {
   QString new_string = new_value.toString();

--- a/src/rviz/properties/tf_frame_property.h
+++ b/src/rviz/properties/tf_frame_property.h
@@ -51,6 +51,24 @@ public:
                   const char* changed_slot = nullptr,
                   QObject* receiver = nullptr);
 
+  template <class Functor>
+  TfFrameProperty(const QString& name = QString(),
+                  const QString& default_value = QString(),
+                  const QString& description = QString(),
+                  Property* parent = nullptr,
+                  FrameManager* frame_manager = nullptr,
+                  bool include_fixed_frame_string = false,
+                  Functor method = []{},
+                  QObject* context = nullptr)
+    : EditableEnumProperty(name, default_value, description, parent, method, context)
+    , frame_manager_(nullptr)
+    , include_fixed_frame_string_(include_fixed_frame_string)
+  {
+    // Parent class EditableEnumProperty has requestOptions() signal.
+    connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillFrameList()));
+    setFrameManager(frame_manager);
+  }
+
   /** @brief Override from Property to resolve the frame name on the way in. */
   bool setValue(const QVariant& new_value) override;
 

--- a/src/rviz/properties/tf_frame_property.h
+++ b/src/rviz/properties/tf_frame_property.h
@@ -51,23 +51,14 @@ public:
                   const char* changed_slot = nullptr,
                   QObject* receiver = nullptr);
 
-  template <class Functor>
-  TfFrameProperty(const QString& name = QString(),
-                  const QString& default_value = QString(),
-                  const QString& description = QString(),
-                  Property* parent = nullptr,
-                  FrameManager* frame_manager = nullptr,
-                  bool include_fixed_frame_string = false,
-                  Functor method = []{},
-                  QObject* context = nullptr)
-    : EditableEnumProperty(name, default_value, description, parent, method, context)
-    , frame_manager_(nullptr)
-    , include_fixed_frame_string_(include_fixed_frame_string)
-  {
-    // Parent class EditableEnumProperty has requestOptions() signal.
-    connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillFrameList()));
-    setFrameManager(frame_manager);
-  }
+  TfFrameProperty(const QString& name,
+                  const QString& default_value,
+                  const QString& description,
+                  Property* parent,
+                  FrameManager* frame_manager,
+                  bool include_fixed_frame_string,
+                  std::function<void()> changed_slot,
+                  QObject* receiver = nullptr);
 
   /** @brief Override from Property to resolve the frame name on the way in. */
   bool setValue(const QVariant& new_value) override;

--- a/src/rviz/properties/vector_property.cpp
+++ b/src/rviz/properties/vector_property.cpp
@@ -44,6 +44,11 @@ VectorProperty::VectorProperty(const QString& name,
   , vector_(default_value)
   , ignore_child_updates_(false)
 {
+  initialize_this();
+}
+
+void VectorProperty::initialize_this()
+{
   x_ = new Property("X", vector_.x, "X coordinate", this);
   y_ = new Property("Y", vector_.y, "Y coordinate", this);
   z_ = new Property("Z", vector_.z, "Z coordinate", this);

--- a/src/rviz/properties/vector_property.cpp
+++ b/src/rviz/properties/vector_property.cpp
@@ -47,6 +47,19 @@ VectorProperty::VectorProperty(const QString& name,
   initialize_this();
 }
 
+VectorProperty::VectorProperty(const QString& name,
+                 const Ogre::Vector3& default_value,
+                 const QString& description,
+                 Property* parent,
+                 std::function<void()> changed_slot,
+                 QObject* receiver)
+  : Property(name, QVariant(), description, parent, changed_slot, receiver)
+  , vector_(default_value)
+  , ignore_child_updates_(false)
+{
+  initialize_this();
+}
+
 void VectorProperty::initialize_this()
 {
   x_ = new Property("X", vector_.x, "X coordinate", this);

--- a/src/rviz/properties/vector_property.h
+++ b/src/rviz/properties/vector_property.h
@@ -47,19 +47,12 @@ public:
                  const char* changed_slot = nullptr,
                  QObject* receiver = nullptr);
 
-  template <class Functor>
-  VectorProperty(const QString& name = QString(),
-                 const Ogre::Vector3& default_value = Ogre::Vector3::ZERO,
-                 const QString& description = QString(),
-                 Property* parent = nullptr,
-                 Functor method = []{},
-                 QObject* context = nullptr)
-    : Property(name, QVariant(), description, parent, method, context)
-    , vector_(default_value)
-    , ignore_child_updates_(false)
-  {
-    initialize_this();
-  }
+  VectorProperty(const QString& name,
+                 const Ogre::Vector3& default_value,
+                 const QString& description,
+                 Property* parent,
+                 std::function<void()> changed_slot,
+                 QObject* receiver = nullptr);
 
   virtual bool setVector(const Ogre::Vector3& vector);
   virtual Ogre::Vector3 getVector() const

--- a/src/rviz/properties/vector_property.h
+++ b/src/rviz/properties/vector_property.h
@@ -47,6 +47,20 @@ public:
                  const char* changed_slot = nullptr,
                  QObject* receiver = nullptr);
 
+  template <class Functor>
+  VectorProperty(const QString& name = QString(),
+                 const Ogre::Vector3& default_value = Ogre::Vector3::ZERO,
+                 const QString& description = QString(),
+                 Property* parent = nullptr,
+                 Functor method = []{},
+                 QObject* context = nullptr)
+    : Property(name, QVariant(), description, parent, method, context)
+    , vector_(default_value)
+    , ignore_child_updates_(false)
+  {
+    initialize_this();
+  }
+
   virtual bool setVector(const Ogre::Vector3& vector);
   virtual Ogre::Vector3 getVector() const
   {
@@ -71,6 +85,7 @@ private Q_SLOTS:
 
 private:
   void updateString();
+  void initialize_this();
 
   Ogre::Vector3 vector_;
   Property* x_;


### PR DESCRIPTION
Closes #1742

Please check the proposed changes. I'll modify other properties once this is considered as an appropriate direction

API: adds ctor in properties
ABI: no change, except as indicated by API

### Description

Properties now have a ctor which allows providing normal C++ function pointers and lambda variables instead of Q_SLOTS

### Checklist

- [x] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
