### PR TITLE
Added regex filter field for TF  display

### DIFF
--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -466,7 +466,6 @@ void TFDisplay::updateFrames()
       ++it;
   }
 
-  // sort kept frames (frames.begin..end) and filtered ones (end..frames.end) separately
   std::sort(frames.begin(), end);
   std::sort(end, frames.end());
 
@@ -777,18 +776,8 @@ void TFDisplay::updateFrame(FrameInfo* frame)
       ;                              // nothing more to do
     else if (!frame->tree_property_) // create new property
     {
-      auto name = QString::fromStdString(frame->name_);
-      // try to find existing property node
-      for (int i = 0, end = parent_tree_property->numChildren(); i != end; ++i)
-      {
-        if (parent_tree_property->childAtUnchecked(i)->getName() == name)
-        {
-          frame->tree_property_ = parent_tree_property->childAtUnchecked(i);
-          break;
-        }
-      }
-      if (!frame->tree_property_) // only create a new node otherwise
-        frame->tree_property_ = new Property(name, QVariant(), "", parent_tree_property);
+      frame->tree_property_ =
+          new Property(QString::fromStdString(frame->name_), QVariant(), "", parent_tree_property);
     }
     else // update property
     {

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -28,7 +28,6 @@
  */
 
 #include <boost/bind.hpp>
-#include <algorithm>
 #include <regex>
 
 #include <OgreSceneNode.h>
@@ -334,7 +333,7 @@ void TFDisplay::clear()
 
   // Clear all frames
   while (!frames_.empty())
-    deleteFrame(frames_.begin(), false, false);
+    deleteFrame(frames_.begin(), false);
 
   update_timer_ = 0.0f;
 
@@ -467,7 +466,6 @@ void TFDisplay::updateFrames()
   }
 
   std::sort(frames.begin(), end);
-  std::sort(end, frames.end());
 
   S_FrameInfo current_frames;
   for (it = frames.begin(); it != end; ++it)
@@ -485,12 +483,10 @@ void TFDisplay::updateFrames()
     current_frames.insert(info);
   }
 
-  it = end;
-  end = frames.end();
   for (auto frame_it = frames_.begin(), frame_end = frames_.end(); frame_it != frame_end;)
   {
     if (current_frames.find(frame_it->second) == current_frames.end())
-      frame_it = deleteFrame(frame_it, true, std::lower_bound(it, end, frame_it->first) == end);
+      frame_it = deleteFrame(frame_it, true);
     else
       ++frame_it;
   }
@@ -791,8 +787,7 @@ void TFDisplay::updateFrame(FrameInfo* frame)
   frame->selection_handler_->setParentName(frame->parent_);
 }
 
-TFDisplay::M_FrameInfo::iterator
-TFDisplay::deleteFrame(M_FrameInfo::iterator it, bool delete_properties, bool delete_tree_property)
+TFDisplay::M_FrameInfo::iterator TFDisplay::deleteFrame(M_FrameInfo::iterator it, bool delete_properties)
 {
   FrameInfo* frame = it->second;
   it = frames_.erase(it);
@@ -805,8 +800,7 @@ TFDisplay::deleteFrame(M_FrameInfo::iterator it, bool delete_properties, bool de
   if (delete_properties)
   {
     delete frame->enabled_property_;
-    if (delete_tree_property)
-      delete frame->tree_property_;
+    delete frame->tree_property_;
   }
   delete frame;
   return it;

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -466,6 +466,7 @@ void TFDisplay::updateFrames()
       ++it;
   }
 
+  // sort kept frames (frames.begin..end) and filtered ones (end..frames.end) separately
   std::sort(frames.begin(), end);
   std::sort(end, frames.end());
 
@@ -776,8 +777,18 @@ void TFDisplay::updateFrame(FrameInfo* frame)
       ;                              // nothing more to do
     else if (!frame->tree_property_) // create new property
     {
-      frame->tree_property_ =
-          new Property(QString::fromStdString(frame->name_), QVariant(), "", parent_tree_property);
+      auto name = QString::fromStdString(frame->name_);
+      // try to find existing property node
+      for (int i = 0, end = parent_tree_property->numChildren(); i != end; ++i)
+      {
+        if (parent_tree_property->childAtUnchecked(i)->getName() == name)
+        {
+          frame->tree_property_ = parent_tree_property->childAtUnchecked(i);
+          break;
+        }
+      }
+      if (!frame->tree_property_) // only create a new node otherwise
+        frame->tree_property_ = new Property(name, QVariant(), "", parent_tree_property);
     }
     else // update property
     {

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -254,9 +254,6 @@ TFDisplay::TFDisplay() : Display(), update_timer_(0.0f), changing_single_frame_e
   scale_property_ =
       new FloatProperty("Marker Scale", 1, "Scaling factor for all names, axes and arrows.", this);
 
-  filter_whitelist_property_ = new RegexFilterProperty("Filter (whitelist)", std::regex(""), this);
-  filter_blacklist_property_ = new RegexFilterProperty("Filter (blacklist)", std::regex(), this);
-
   update_rate_property_ = new FloatProperty("Update Interval", 0,
                                             "The interval, in seconds, at which to update the frame "
                                             "transforms. 0 means to do so every update cycle.",
@@ -270,6 +267,9 @@ TFDisplay::TFDisplay() : Display(), update_timer_(0.0f), changing_single_frame_e
       " and then it will fade out completely.",
       this);
   frame_timeout_property_->setMin(1);
+
+  filter_whitelist_property_ = new RegexFilterProperty("Filter (whitelist)", std::regex(""), this);
+  filter_blacklist_property_ = new RegexFilterProperty("Filter (blacklist)", std::regex(), this);
 
   frames_category_ = new Property("Frames", QVariant(), "The list of all frames.", this);
 

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -32,7 +32,6 @@
 
 #include <map>
 #include <set>
-#include <regex>
 
 #include <OgreQuaternion.h>
 #include <OgreVector3.h>
@@ -60,6 +59,7 @@ class VectorProperty;
 class FrameInfo;
 class FrameSelectionHandler;
 typedef boost::shared_ptr<FrameSelectionHandler> FrameSelectionHandlerPtr;
+class RegexFilterProperty;
 
 /** @brief Displays a visual representation of the TF hierarchy. */
 class TFDisplay : public Display
@@ -79,7 +79,6 @@ protected:
   void reset() override;
 
 private Q_SLOTS:
-  void updateFilterRegex(StringProperty* prop, std::regex& regex);
   void updateShowAxes();
   void updateShowArrows();
   void updateShowNames();
@@ -121,13 +120,10 @@ private:
   BoolProperty* all_enabled_property_;
 
   FloatProperty* scale_property_;
-  StringProperty* filter_whitelist_property_;
-  StringProperty* filter_blacklist_property_;
+  RegexFilterProperty* filter_whitelist_property_;
+  RegexFilterProperty* filter_blacklist_property_;
   Property* frames_category_;
   Property* tree_category_;
-
-  std::regex filter_whitelist_regex_;
-  std::regex filter_blacklist_regex_;
 
   bool changing_single_frame_enabled_state_;
   friend class FrameInfo;

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -32,6 +32,7 @@
 
 #include <map>
 #include <set>
+#include <regex>
 
 #include <OgreQuaternion.h>
 #include <OgreVector3.h>
@@ -78,6 +79,7 @@ protected:
   void reset() override;
 
 private Q_SLOTS:
+  void updateFilterRegex(StringProperty* prop, std::regex& regex);
   void updateShowAxes();
   void updateShowArrows();
   void updateShowNames();
@@ -123,6 +125,9 @@ private:
   StringProperty* filter_blacklist_property_;
   Property* frames_category_;
   Property* tree_category_;
+
+  std::regex filter_whitelist_regex_;
+  std::regex filter_blacklist_regex_;
 
   bool changing_single_frame_enabled_state_;
   friend class FrameInfo;

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -119,7 +119,7 @@ private:
   BoolProperty* all_enabled_property_;
 
   FloatProperty* scale_property_;
-  StringProperty* filter_property_;
+  StringProperty* filter_whitelist_property_;
   StringProperty* filter_blacklist_property_;
   Property* frames_category_;
   Property* tree_category_;

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -90,7 +90,8 @@ private:
   void updateFrames();
   FrameInfo* createFrame(const std::string& frame);
   void updateFrame(FrameInfo* frame);
-  M_FrameInfo::iterator deleteFrame(M_FrameInfo::iterator it, bool delete_properties);
+  M_FrameInfo::iterator
+  deleteFrame(M_FrameInfo::iterator it, bool delete_properties, bool delete_tree_property);
 
   FrameInfo* getFrameInfo(const std::string& frame);
 

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -90,8 +90,7 @@ private:
   void updateFrames();
   FrameInfo* createFrame(const std::string& frame);
   void updateFrame(FrameInfo* frame);
-  M_FrameInfo::iterator
-  deleteFrame(M_FrameInfo::iterator it, bool delete_properties, bool delete_tree_property);
+  M_FrameInfo::iterator deleteFrame(M_FrameInfo::iterator it, bool delete_properties);
 
   FrameInfo* getFrameInfo(const std::string& frame);
 

--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -119,7 +119,8 @@ private:
   BoolProperty* all_enabled_property_;
 
   FloatProperty* scale_property_;
-
+  StringProperty* filter_property_;
+  StringProperty* filter_blacklist_property_;
   Property* frames_category_;
   Property* tree_category_;
 


### PR DESCRIPTION
### Description

When there is a lot of frames on `/tf` it can be hard to properly visualize them in RViz especially if frames overlap. Usually solution to this is to enable and disable desired frames in `Frames` field of the `TF display`. But it quickly become very annoying task if there is a lot of frames (e.g.  100 +) and each one needs to be found in a long list first and then disabled/enabled.

Because of that I suggest adding regex field which filters frames and displays only the ones matching entered expression. For convenience I also suggest adding additional field for blacklist filter.
Benefit of this approach is that user can quickly setup one or more displays, each showing specific group of frames and he can turn each one on/off as needed.
Scene with a lot of frames ...
![image](https://user-images.githubusercontent.com/22647774/168610888-9de6f8a2-b26d-4b9d-86ff-250726e57524.png)
... can be easily filtered so only interesting frames are displayed
![image](https://user-images.githubusercontent.com/22647774/168612056-0212f0fc-3417-4904-b1a8-51885f467101.png)

Example when multiple TF displays are added. Each one has its own settings and frame filter.
![image](https://user-images.githubusercontent.com/22647774/168614669-64887ca6-c086-4af3-8250-0e971ddd4744.png)
