### PR TITLE
avoid Ogre::ItemIItemIdentityException in Ogre 1.12 when the same material is used multiple times

### DIFF
--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -672,7 +672,11 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
         *active = *sub->getMaterial();
         sub->setMaterial(active);
         // create a backup of the material as we will modify the active one e.g. in updateAlpha()
-        original = active->clone(sub->getMaterial()->getName() + "_original");
+        // need to have a unique name in case the same material is used multiple times or
+        // the same RobotModel is loaded multiple times
+        static int material_count = 0;
+        original = active->clone(sub->getMaterial()->getName() + "_" + std::to_string(material_count++) +
+                                 "_original");
       }
       materials_[sub] = std::make_pair(active, original);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

The issue can be shown by building rviz with Ogre 1.12 and launching https://github.com/lucasw/gazebo_ros_demos/blob/noetic-devel/rrbot_description/launch/rrbot_rviz.launch then add a second RobotModel to rviz (probably two instance of any RobotModel that uses the `_original` postfix code path will fail in the same way):

```
terminate called after throwing an instance of 'Ogre::ItemIdentityException'
  what():  ItemIdentityException: Material with the name package://rrbot_description/meshes/hokuyo.daeMaterial0_original already exists. in ResourceManager::add at ./OgreMain/src/OgreResourceManager.cpp (line 148)
[rviz-3] process has died [pid 9096, exit code -6, cmd /home/lucasw/base_catkin_ws/devel/lib/rviz/rviz -d /home/lucasw/base_catkin_ws/src/ros/gazebo_ros_demos/rrbot_description/launch/rrbot.rviz __name:=rviz __log:=/home/lucasw/.ros/log/affefeb0-d77c-11ec-9be6-b72d65a8c914/rviz-3.log].
log file: /home/lucasw/.ros/log/affefeb0-d77c-11ec-9be6-b72d65a8c914/rviz-3*.log
```

The solution is similar to `material_count` used in https://github.com/ros2/rviz/blob/ros2/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp#L708-L751

### Checklist

- [ ] If you are addressing rendering issues, please provide:
  - [ ] Images of both, broken and fixed renderings.
  - [ ] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [x] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
