### PR TITLE
Fix panel deletion

### DIFF
--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1348,10 +1348,8 @@ void VisualizationFrame::onDeletePanel()
         custom_panels_.removeAt(i);
         setDisplayConfigModified();
         action->deleteLater();
-        if (delete_view_menu_->actions().size() == 1 && delete_view_menu_->actions().first() == action)
-        {
-          delete_view_menu_->setEnabled(false);
-        }
+        delete_view_menu_->removeAction(action);
+        delete_view_menu_->setDisabled(delete_view_menu_->actions().isEmpty());
         return;
       }
     }

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -1331,6 +1331,23 @@ QWidget* VisualizationFrame::getParentWindow()
   return this;
 }
 
+void VisualizationFrame::onPanelDeleted(QObject* dock)
+{
+  for (int i = 0; i < custom_panels_.size(); ++i)
+  {
+    if (custom_panels_[i].dock == dock)
+    {
+      auto& record = custom_panels_[i];
+      record.delete_action->deleteLater();
+      delete_view_menu_->removeAction(record.delete_action);
+      delete_view_menu_->setDisabled(delete_view_menu_->actions().isEmpty());
+      custom_panels_.removeAt(i);
+      setDisplayConfigModified();
+      return;
+    }
+  }
+}
+
 void VisualizationFrame::onDeletePanel()
 {
   // This should only be called as a SLOT from a QAction in the
@@ -1345,11 +1362,6 @@ void VisualizationFrame::onDeletePanel()
       if (custom_panels_[i].delete_action == action)
       {
         delete custom_panels_[i].dock;
-        custom_panels_.removeAt(i);
-        setDisplayConfigModified();
-        action->deleteLater();
-        delete_view_menu_->removeAction(action);
-        delete_view_menu_->setDisabled(delete_view_menu_->actions().isEmpty());
         return;
       }
     }
@@ -1402,6 +1414,7 @@ QDockWidget* VisualizationFrame::addPanelByName(const QString& name,
   record.panel = panel;
   record.name = name;
   record.delete_action = delete_view_menu_->addAction(name, this, SLOT(onDeletePanel()));
+  connect(record.dock, &QObject::destroyed, this, &VisualizationFrame::onPanelDeleted);
   custom_panels_.append(record);
   delete_view_menu_->setEnabled(true);
 

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -267,6 +267,7 @@ protected Q_SLOTS:
 
   void reset();
 
+  void onPanelDeleted(QObject* dock);
   void onHelpDestroyed();
 
   void hideLeftDock(bool hide);


### PR DESCRIPTION
When deleting a PanelDockWidget directly (i.e. not using the corresponding menu action), a dangling pointer was maintained (causing a crash e.g. on next Save) and the menu action wasn't removed. 
Now, if the dock is removed, the cleanup happens as well.