### PR TITLE
Improve SplitterHandle of PropertyTreeWidgets

### DIFF
--- a/src/rviz/properties/property_tree_delegate.cpp
+++ b/src/rviz/properties/property_tree_delegate.cpp
@@ -28,7 +28,6 @@
  */
 
 #include <QAbstractItemView>
-#include <QPainter>
 
 #include "rviz/properties/property.h"
 #include "rviz/properties/line_edit_with_button.h"
@@ -48,9 +47,7 @@ void PropertyTreeDelegate::paint(QPainter* painter,
   Property* prop = static_cast<Property*>(index.internalPointer());
   if (!prop || !prop->paint(painter, option))
   {
-    QStyleOptionViewItem opt = option;
-    painter->fillRect(opt.rect, Qt::red);
-    QStyledItemDelegate::paint(painter, opt, index);
+    QStyledItemDelegate::paint(painter, option, index);
   }
 }
 

--- a/src/rviz/properties/property_tree_delegate.cpp
+++ b/src/rviz/properties/property_tree_delegate.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <QAbstractItemView>
+#include <QPainter>
 
 #include "rviz/properties/property.h"
 #include "rviz/properties/line_edit_with_button.h"
@@ -47,7 +48,9 @@ void PropertyTreeDelegate::paint(QPainter* painter,
   Property* prop = static_cast<Property*>(index.internalPointer());
   if (!prop || !prop->paint(painter, option))
   {
-    QStyledItemDelegate::paint(painter, option, index);
+    QStyleOptionViewItem opt = option;
+    painter->fillRect(opt.rect, Qt::red);
+    QStyledItemDelegate::paint(painter, opt, index);
   }
 }
 

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -134,7 +134,7 @@ void SplitterHandle::paintEvent(QPaintEvent* /*event*/)
   QPainter painter(this);
   painter.fillRect(0, 0, width(), height(), Qt::yellow);
   painter.setPen(color_);
-  painter.drawLine(1 + width() / 2, 0, 1 + width() / 2, height());
+  painter.drawLine(width() / 2, 0, width() / 2, height());
 }
 
 } // end namespace rviz

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -49,9 +49,7 @@ SplitterHandle::SplitterHandle(QTreeView* parent)
 
 bool SplitterHandle::eventFilter(QObject* event_target, QEvent* event)
 {
-  if (event_target == parent_ &&
-      (event->type() == QEvent::Resize || event->type() == QEvent::LayoutRequest ||
-       event->type() == QEvent::Show))
+  if (event_target == parent_ && event->type() == QEvent::Resize)
   {
     updateGeometry();
   }
@@ -61,11 +59,12 @@ bool SplitterHandle::eventFilter(QObject* event_target, QEvent* event)
 void SplitterHandle::updateGeometry()
 {
   int w = 7;
-  int new_column_width = int(first_column_size_ratio_ * parent_->contentsRect().width());
-  parent_->setColumnWidth(0, new_column_width);
-  parent_->setColumnWidth(1, parent_->viewport()->contentsRect().width() - new_column_width);
+  const auto& content = parent_->contentsRect();
+  int new_column_width = int(first_column_size_ratio_ * content.width());
+  parent_->header()->resizeSection(0, new_column_width); // fixed size for name column
+  parent_->header()->resizeSection(1, content.width() - new_column_width);
 
-  int new_x = new_column_width - w / 2 + parent_->columnViewportPosition(0);
+  int new_x = new_column_width - w / 2;
   if (new_x != x() || parent_->height() != height())
     setGeometry(new_x, 0, w, parent_->height());
 }
@@ -98,7 +97,7 @@ void SplitterHandle::mouseMoveEvent(QMouseEvent* event)
   {
     QPoint pos_rel_parent = parent_->mapFromGlobal(event->globalPos());
 
-    int new_x = pos_rel_parent.x() - x_press_offset_ - parent_->columnViewportPosition(0);
+    int new_x = pos_rel_parent.x() - x_press_offset_;
 
     if (new_x > parent_->width() - width() - padding)
     {

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -107,23 +107,15 @@ void SplitterHandle::mouseMoveEvent(QMouseEvent* event)
   if (event->buttons() & Qt::LeftButton)
   {
     QPoint pos_rel_parent = parent_->mapFromGlobal(event->globalPos());
+    const auto& content = parent_->contentsRect();
 
-    int new_x = pos_rel_parent.x() - x_press_offset_;
-
-    if (new_x > parent_->width() - width() - padding)
-    {
-      new_x = parent_->width() - width() - padding;
-    }
-
-    if (new_x < padding)
-    {
-      new_x = padding;
-    }
+    int new_x =
+        qBound(padding, pos_rel_parent.x() - x_press_offset_, parent_->width() - width() - padding);
 
     if (new_x != x())
     {
-      int new_column_width = new_x + width() / 2 - parent_->contentsRect().x();
-      first_column_size_ratio_ = new_column_width / (float)parent_->contentsRect().width();
+      int new_column_width = new_x + width() / 2 - content.x();
+      first_column_size_ratio_ = new_column_width / (float)content.width();
       updateGeometry();
     }
   }

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -33,6 +33,8 @@
 #include <QPainter>
 #include <QTreeView>
 #include <QHeaderView>
+#include <QAction>
+#include <QDebug>
 
 #include "rviz/properties/splitter_handle.h"
 
@@ -45,6 +47,13 @@ SplitterHandle::SplitterHandle(QTreeView* parent)
   updateGeometry();
   parent_->header()->setStretchLastSection(false);
   parent_->installEventFilter(this);
+
+  parent->setStyleSheet("border-width: 1 1 1 10; border-style: solid; border-color: magenta");
+  auto act = new QAction("Update Geometry", this);
+  act->setShortcut(QKeySequence("F5"));
+  act->setShortcutContext(Qt::WidgetShortcut);
+  parent->addAction(act);
+  connect(act, &QAction::triggered, this, &SplitterHandle::updateGeometry);
 }
 
 bool SplitterHandle::eventFilter(QObject* event_target, QEvent* event)
@@ -61,6 +70,8 @@ void SplitterHandle::updateGeometry()
   int w = 7;
   const auto& content = parent_->contentsRect();
   int new_column_width = int(first_column_size_ratio_ * content.width());
+  qDebug() << parent_->contentsRect() << parent_->contentsRect().width() << parent_->width()
+           << new_column_width;
   parent_->header()->resizeSection(0, new_column_width); // fixed size for name column
   parent_->header()->resizeSection(1, content.width() - new_column_width);
 
@@ -121,6 +132,7 @@ void SplitterHandle::mouseMoveEvent(QMouseEvent* event)
 void SplitterHandle::paintEvent(QPaintEvent* /*event*/)
 {
   QPainter painter(this);
+  painter.fillRect(0, 0, width(), height(), Qt::yellow);
   painter.setPen(color_);
   painter.drawLine(1 + width() / 2, 0, 1 + width() / 2, height());
 }

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -33,8 +33,6 @@
 #include <QPainter>
 #include <QTreeView>
 #include <QHeaderView>
-#include <QAction>
-#include <QDebug>
 
 #include "rviz/properties/splitter_handle.h"
 
@@ -47,13 +45,6 @@ SplitterHandle::SplitterHandle(QTreeView* parent)
   updateGeometry();
   parent_->header()->setStretchLastSection(false);
   parent_->installEventFilter(this);
-
-  parent->setStyleSheet("border-width: 1 1 1 10; border-style: solid; border-color: magenta");
-  auto act = new QAction("Update Geometry", this);
-  act->setShortcut(QKeySequence("F5"));
-  act->setShortcutContext(Qt::WidgetShortcut);
-  parent->addAction(act);
-  connect(act, &QAction::triggered, this, &SplitterHandle::updateGeometry);
 }
 
 bool SplitterHandle::eventFilter(QObject* event_target, QEvent* event)
@@ -70,8 +61,6 @@ void SplitterHandle::updateGeometry()
   int w = 7;
   const auto& content = parent_->contentsRect();
   int new_column_width = int(first_column_size_ratio_ * content.width());
-  qDebug() << parent_->contentsRect() << parent_->contentsRect().width() << parent_->width()
-           << new_column_width;
   parent_->header()->resizeSection(0, new_column_width); // fixed size for name column
   parent_->header()->resizeSection(1, content.width() - new_column_width);
 
@@ -143,7 +132,6 @@ void SplitterHandle::mouseDoubleClickEvent(QMouseEvent* /*event*/)
 void SplitterHandle::paintEvent(QPaintEvent* /*event*/)
 {
   QPainter painter(this);
-  painter.fillRect(0, 0, width(), height(), Qt::yellow);
   painter.setPen(color_);
   painter.drawLine(width() / 2, 0, width() / 2, height());
 }

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -91,6 +91,20 @@ float SplitterHandle::getRatio()
   return first_column_size_ratio_;
 }
 
+void SplitterHandle::setDesiredWidth(int width)
+{
+  const auto& content = parent_->contentsRect();
+  int new_column_width = qBound(parent_->header()->minimumSectionSize(), // minimum
+                                width,                                   // desired
+                                content.width());                        // maximum
+
+  if (new_column_width != parent_->header()->sectionSize(0))
+  {
+    first_column_size_ratio_ = new_column_width / (float)content.width();
+    updateGeometry();
+  }
+}
+
 void SplitterHandle::mousePressEvent(QMouseEvent* event)
 {
   if (event->button() == Qt::LeftButton)
@@ -105,17 +119,7 @@ void SplitterHandle::mouseMoveEvent(QMouseEvent* event)
   if (event->buttons() & Qt::LeftButton)
   {
     QPoint pos_rel_parent = parent_->mapFromGlobal(event->globalPos());
-    const auto& content = parent_->contentsRect();
-
-    int new_column_width = qBound(parent_->header()->minimumSectionSize(),            // minimum
-                                  pos_rel_parent.x() - content.x() - x_press_offset_, // desired
-                                  content.width());                                   // maximum
-
-    if (new_column_width != parent_->header()->sectionSize(0))
-    {
-      first_column_size_ratio_ = new_column_width / (float)content.width();
-      updateGeometry();
-    }
+    setDesiredWidth(pos_rel_parent.x() - parent_->contentsRect().x() - x_press_offset_);
   }
 }
 

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -95,26 +95,24 @@ void SplitterHandle::mousePressEvent(QMouseEvent* event)
 {
   if (event->button() == Qt::LeftButton)
   {
-    // position of mouse press inside this QWidget
-    x_press_offset_ = event->x();
+    // position of mouse press relative to splitter line / the center of the widget
+    x_press_offset_ = event->x() - width() / 2;
   }
 }
 
 void SplitterHandle::mouseMoveEvent(QMouseEvent* event)
 {
-  int padding = 55;
-
   if (event->buttons() & Qt::LeftButton)
   {
     QPoint pos_rel_parent = parent_->mapFromGlobal(event->globalPos());
     const auto& content = parent_->contentsRect();
 
-    int new_x =
-        qBound(padding, pos_rel_parent.x() - x_press_offset_, parent_->width() - width() - padding);
+    int new_column_width = qBound(parent_->header()->minimumSectionSize(),            // minimum
+                                  pos_rel_parent.x() - content.x() - x_press_offset_, // desired
+                                  content.width());                                   // maximum
 
-    if (new_x != x())
+    if (new_column_width != parent_->header()->sectionSize(0))
     {
-      int new_column_width = new_x + width() / 2 - content.x();
       first_column_size_ratio_ = new_column_width / (float)content.width();
       updateGeometry();
     }

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -123,6 +123,23 @@ void SplitterHandle::mouseMoveEvent(QMouseEvent* event)
   }
 }
 
+// adjust splitter position to optimally fit content
+void SplitterHandle::mouseDoubleClickEvent(QMouseEvent* /*event*/)
+{
+  int available_width = parent_->contentsRect().width();
+  int default_width = 0.5f * available_width;
+  // missing width to default
+  int col0 = static_cast<QAbstractItemView*>(parent_)->sizeHintForColumn(0) - default_width;
+  int col1 = static_cast<QAbstractItemView*>(parent_)->sizeHintForColumn(1) - default_width;
+
+  if (col0 <= 0 && col1 <= 0) // each column fits
+    setDesiredWidth(default_width);
+  else if (col0 + col1 <= 0) // both columns fit together, but require a non-default splitting
+    setDesiredWidth(default_width + col0 + 0.5f * std::abs(col0 + col1)); // uniformly split extra space
+  else
+    setDesiredWidth(default_width + col0 - 0.5f * (col0 + col1)); // uniformly cut missing space
+}
+
 void SplitterHandle::paintEvent(QPaintEvent* /*event*/)
 {
   QPainter painter(this);

--- a/src/rviz/properties/splitter_handle.cpp
+++ b/src/rviz/properties/splitter_handle.cpp
@@ -75,9 +75,9 @@ void SplitterHandle::updateGeometry()
   parent_->header()->resizeSection(0, new_column_width); // fixed size for name column
   parent_->header()->resizeSection(1, content.width() - new_column_width);
 
-  int new_x = new_column_width - w / 2;
-  if (new_x != x() || parent_->height() != height())
-    setGeometry(new_x, 0, w, parent_->height());
+  int new_x = content.x() + new_column_width - w / 2;
+  if (new_x != x() || content.height() != height())
+    setGeometry(new_x, content.y(), w, content.height());
 }
 
 void SplitterHandle::setRatio(float ratio)

--- a/src/rviz/properties/splitter_handle.h
+++ b/src/rviz/properties/splitter_handle.h
@@ -51,6 +51,9 @@ public:
   /** @brief Get the ratio of the parent's left column to the parent widget width. */
   float getRatio();
 
+  /** @brief Set desired width of first column - subject to clamping */
+  void setDesiredWidth(int width);
+
   /** @brief Catch resize events sent to parent to update splitter's
    * geometry.  Always returns false. */
   bool eventFilter(QObject* event_target, QEvent* event) override;

--- a/src/rviz/properties/splitter_handle.h
+++ b/src/rviz/properties/splitter_handle.h
@@ -71,6 +71,7 @@ public:
 protected:
   void mousePressEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
+  void mouseDoubleClickEvent(QMouseEvent* event) override;
   void paintEvent(QPaintEvent* event) override;
 
 private:


### PR DESCRIPTION
Various fixes and improvements to the SplitterHandle used in PropertyTreeWidgets. Fixes #1758.

| before | after |
|----------|---------|
| ![image](https://user-images.githubusercontent.com/5376030/182017093-23214040-ba0e-4768-b45b-1c0d8fff7052.png) | ![image](https://user-images.githubusercontent.com/5376030/182017184-de507a1e-4e8d-4242-8313-20e7e848023a.png) |