### PR TITLE
use static QCoreApplication::processEvents() function without a QApplication instance.

### DIFF
--- a/src/rviz/main.cpp
+++ b/src/rviz/main.cpp
@@ -36,7 +36,6 @@ int main(int argc, char** argv)
   QApplication qapp(argc, argv);
 
   rviz::VisualizerApp vapp;
-  vapp.setApp(&qapp);
   if (vapp.init(argc, argv))
   {
     return qapp.exec();

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -749,7 +749,9 @@ bool VisualizationFrame::loadDisplayConfigHelper(const std::string& full_path, c
     dialog.reset(new LoadingDialog(this));
     dialog->show();
     connect(this, SIGNAL(statusUpdate(const QString&)), dialog.get(), SLOT(showMessage(const QString&)));
-    QCoreApplication::processEvents(); // make the window correctly appear although running a long-term function
+
+    // make the window correctly appear although running a long-term function
+    QCoreApplication::processEvents();
   }
 
   YamlConfigReader reader;

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -33,6 +33,7 @@
 #include <QAction>
 #include <QShortcut>
 #include <QApplication>
+#include <QCoreApplication>
 #include <QCloseEvent>
 #include <QDesktopServices>
 #include <QDockWidget>
@@ -103,7 +104,6 @@ namespace rviz
 {
 VisualizationFrame::VisualizationFrame(QWidget* parent)
   : QMainWindow(parent)
-  , app_(nullptr)
   , render_panel_(nullptr)
   , show_help_action_(nullptr)
   , preferences_(new Preferences())
@@ -166,7 +166,7 @@ VisualizationFrame::~VisualizationFrame()
 
 void VisualizationFrame::setApp(QApplication* app)
 {
-  app_ = app;
+  Q_UNUSED(app);
 }
 
 void VisualizationFrame::setStatus(const QString& message)
@@ -258,8 +258,7 @@ void VisualizationFrame::initialize(const QString& display_config_file)
 
   // Periodically process events for the splash screen.
   // See: http://doc.qt.io/qt-5/qsplashscreen.html#details
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   if (!ros::isInitialized())
   {
@@ -268,8 +267,7 @@ void VisualizationFrame::initialize(const QString& display_config_file)
   }
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   QWidget* central_widget = new QWidget(this);
   QHBoxLayout* central_layout = new QHBoxLayout;
@@ -305,40 +303,34 @@ void VisualizationFrame::initialize(const QString& display_config_file)
   central_widget->setLayout(central_layout);
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   initMenus();
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   initToolbars();
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   setCentralWidget(central_widget);
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   manager_ = new VisualizationManager(render_panel_, this);
   manager_->setHelpPath(help_path_);
   connect(manager_, SIGNAL(escapePressed()), this, SLOT(exitFullScreen()));
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   render_panel_->initialize(manager_->getSceneManager(), manager_);
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   ToolManager* tool_man = manager_->getToolManager();
 
@@ -351,8 +343,7 @@ void VisualizationFrame::initialize(const QString& display_config_file)
   manager_->initialize();
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   if (display_config_file != "")
   {
@@ -364,8 +355,7 @@ void VisualizationFrame::initialize(const QString& display_config_file)
   }
 
   // Periodically process events for the splash screen.
-  if (app_)
-    app_->processEvents();
+  QCoreApplication::processEvents();
 
   delete splash_;
   splash_ = nullptr;
@@ -759,7 +749,7 @@ bool VisualizationFrame::loadDisplayConfigHelper(const std::string& full_path, c
     dialog.reset(new LoadingDialog(this));
     dialog->show();
     connect(this, SIGNAL(statusUpdate(const QString&)), dialog.get(), SLOT(showMessage(const QString&)));
-    app_->processEvents(); // make the window correctly appear although running a long-term function
+    QCoreApplication::processEvents(); // make the window correctly appear although running a long-term function
   }
 
   YamlConfigReader reader;

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -78,7 +78,7 @@ public:
   VisualizationFrame(QWidget* parent = nullptr);
   ~VisualizationFrame() override;
 
-  // now deprecated
+  [[deprecated("setApp() not needed anymore")]]
   void setApp(QApplication* app);
 
   /** @brief Call this @e before initialize() to have it take effect. */

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -78,8 +78,7 @@ public:
   VisualizationFrame(QWidget* parent = nullptr);
   ~VisualizationFrame() override;
 
-  [[deprecated("setApp() not needed anymore")]]
-  void setApp(QApplication* app);
+  [[deprecated("setApp() not needed anymore")]] void setApp(QApplication* app);
 
   /** @brief Call this @e before initialize() to have it take effect. */
   void setShowChooseNewMaster(bool show);

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -78,6 +78,7 @@ public:
   VisualizationFrame(QWidget* parent = nullptr);
   ~VisualizationFrame() override;
 
+  // now deprecated
   void setApp(QApplication* app);
 
   /** @brief Call this @e before initialize() to have it take effect. */
@@ -327,8 +328,6 @@ protected:
   void setDisplayConfigFile(const std::string& path);
 
   void hideDockImpl(Qt::DockWidgetArea area, bool hide);
-
-  QApplication* app_;
 
   RenderPanel* render_panel_;
 

--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -100,13 +100,13 @@ bool reloadShaders(std_srvs::Empty::Request& /*unused*/, std_srvs::Empty::Respon
   return true;
 }
 
-VisualizerApp::VisualizerApp() : app_(nullptr), continue_timer_(nullptr), frame_(nullptr)
+VisualizerApp::VisualizerApp() : continue_timer_(nullptr), frame_(nullptr)
 {
 }
 
 void VisualizerApp::setApp(QApplication* app)
 {
-  app_ = app;
+  Q_UNUSED(app);
 }
 
 bool VisualizerApp::init(int argc, char** argv)
@@ -202,7 +202,6 @@ bool VisualizerApp::init(int argc, char** argv)
       RenderSystem::forceNoStereo();
 
     frame_ = new VisualizationFrame();
-    frame_->setApp(this->app_);
     if (!help_path.empty())
     {
       frame_->setHelpPath(QString::fromStdString(help_path));

--- a/src/rviz/visualizer_app.h
+++ b/src/rviz/visualizer_app.h
@@ -51,8 +51,7 @@ public:
   VisualizerApp();
   ~VisualizerApp() override;
 
-  [[deprecated("setApp() not needed anymore")]]
-  void setApp(QApplication* app);
+  [[deprecated("setApp() not needed anymore")]] void setApp(QApplication* app);
 
   /** Start everything.  Pass in command line arguments.
    * @return false on failure, true on success. */

--- a/src/rviz/visualizer_app.h
+++ b/src/rviz/visualizer_app.h
@@ -29,7 +29,6 @@
 #ifndef RVIZ_VISUALIZER_APP_H
 #define RVIZ_VISUALIZER_APP_H
 
-#include <QApplication>
 #include <QObject>
 
 #ifndef Q_MOC_RUN // See: https://bugreports.qt-project.org/browse/QTBUG-22829
@@ -38,6 +37,7 @@
 #include <rviz/SendFilePath.h>
 #endif
 
+class QApplication;
 class QTimer;
 
 namespace rviz
@@ -51,6 +51,7 @@ public:
   VisualizerApp();
   ~VisualizerApp() override;
 
+  // now deprecated
   void setApp(QApplication* app);
 
   /** Start everything.  Pass in command line arguments.
@@ -67,7 +68,6 @@ private:
   bool loadConfigDiscardingCallback(rviz::SendFilePathRequest& req, rviz::SendFilePathResponse& res);
   bool saveConfigCallback(rviz::SendFilePathRequest& req, rviz::SendFilePathResponse& res);
 
-  QApplication* app_;
   QTimer* continue_timer_;
   VisualizationFrame* frame_;
   ros::NodeHandlePtr nh_;

--- a/src/rviz/visualizer_app.h
+++ b/src/rviz/visualizer_app.h
@@ -51,7 +51,7 @@ public:
   VisualizerApp();
   ~VisualizerApp() override;
 
-  // now deprecated
+  [[deprecated("setApp() not needed anymore")]]
   void setApp(QApplication* app);
 
   /** Start everything.  Pass in command line arguments.


### PR DESCRIPTION
This removes the need for the `setApp()` call.

<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

As seen in the Qt [documentation](https://doc.qt.io/qt-5/qcoreapplication.html#processEvents) `processEvents` is a static function so no member of `QCoreApplication` is required. Removing this takes away the need for `setApp()` in `VisualizationFrame` and `VisualizerApp` which i have keept for now, but should be marked as deprecated and get removed in the future.
Removing this requirement of QApplication help to ease the step of integrating rviz into other possibly quite big Qt-Applications, if there is no need to pass around a pointer to the main Application.

### Checklist

- [ ] If you are addressing rendering issues, please provide:
  - [ ] Images of both, broken and fixed renderings.
  - [ ] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [ ] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
