### PR TITLE
Several improvements to TF display

### DIFF
--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -564,6 +564,9 @@ void TFDisplay::updateFrame(FrameInfo* frame)
 
   setStatusStd(StatusProperty::Ok, frame->name_, "Transform OK");
 
+  float scale = scale_property_->getFloat();
+  bool frame_enabled = frame->enabled_property_->getBool();
+
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
   if (!context_->getFrameManager()->getTransform(frame->name_, ros::Time(), position, orientation))
@@ -576,26 +579,24 @@ void TFDisplay::updateFrame(FrameInfo* frame)
     frame->name_node_->setVisible(false);
     frame->axes_->getSceneNode()->setVisible(false);
     frame->parent_arrow_->getSceneNode()->setVisible(false);
-    return;
   }
+  else
+  {
+    frame->selection_handler_->setPosition(position);
+    frame->selection_handler_->setOrientation(orientation);
 
-  frame->selection_handler_->setPosition(position);
-  frame->selection_handler_->setOrientation(orientation);
+    frame->axes_->setPosition(position);
+    frame->axes_->setOrientation(orientation);
+    frame->axes_->getSceneNode()->setVisible(show_axes_property_->getBool() && frame_enabled);
+    frame->axes_->setScale(Ogre::Vector3(scale, scale, scale));
 
-  bool frame_enabled = frame->enabled_property_->getBool();
+    frame->name_node_->setPosition(position);
+    frame->name_node_->setVisible(show_names_property_->getBool() && frame_enabled);
+    frame->name_node_->setScale(scale, scale, scale);
 
-  frame->axes_->setPosition(position);
-  frame->axes_->setOrientation(orientation);
-  frame->axes_->getSceneNode()->setVisible(show_axes_property_->getBool() && frame_enabled);
-  float scale = scale_property_->getFloat();
-  frame->axes_->setScale(Ogre::Vector3(scale, scale, scale));
-
-  frame->name_node_->setPosition(position);
-  frame->name_node_->setVisible(show_names_property_->getBool() && frame_enabled);
-  frame->name_node_->setScale(scale, scale, scale);
-
-  frame->position_property_->setVector(position);
-  frame->orientation_property_->setQuaternion(orientation);
+    frame->position_property_->setVector(position);
+    frame->orientation_property_->setQuaternion(orientation);
+  }
 
   std::string old_parent = frame->parent_;
   frame->parent_.clear();

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -401,16 +401,12 @@ void TFDisplay::updateFrames()
     }
   }
 
+  for (auto frame_it = frames_.begin(), frame_end = frames_.end(); frame_it != frame_end;)
   {
-    M_FrameInfo::iterator frame_it = frames_.begin();
-    M_FrameInfo::iterator frame_end = frames_.end();
-    while (frame_it != frame_end)
-    {
-      if (current_frames.find(frame_it->second) == current_frames.end())
-        frame_it = deleteFrame(frame_it, true);
-      else
-        ++frame_it;
-    }
+    if (current_frames.find(frame_it->second) == current_frames.end())
+      frame_it = deleteFrame(frame_it, true);
+    else
+      ++frame_it;
   }
 
   context_->queueRender();
@@ -722,6 +718,12 @@ TFDisplay::M_FrameInfo::iterator TFDisplay::deleteFrame(M_FrameInfo::iterator it
   if (delete_properties)
   {
     delete frame->enabled_property_;
+    // re-parent all children to root tree node
+    for (int i = frame->tree_property_->numChildren() - 1; i >= 0; --i)
+    {
+      auto* child = frame->tree_property_->takeChild(frame->tree_property_->childAtUnchecked(i));
+      tree_category_->insertChildSorted(child);
+    }
     delete frame->tree_property_;
   }
   delete frame;

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -377,8 +377,6 @@ void TFDisplay::updateFrames()
 #ifndef _WIN32
 #pragma GCC diagnostic pop
 #endif
-  std::sort(frames.begin(), frames.end());
-
   S_FrameInfo current_frames;
 
   {
@@ -445,8 +443,9 @@ FrameInfo* TFDisplay::createFrame(const std::string& frame)
   info->parent_arrow_->setShaftColor(ARROW_SHAFT_COLOR);
 
   info->enabled_property_ = new BoolProperty(QString::fromStdString(info->name_), true,
-                                             "Enable or disable this individual frame.",
-                                             frames_category_, SLOT(updateVisibilityFromFrame()), info);
+                                             "Enable or disable this individual frame.", nullptr,
+                                             SLOT(updateVisibilityFromFrame()), info);
+  frames_category_->insertChildSorted(info->enabled_property_);
 
   info->parent_property_ =
       new StringProperty("Parent", "", "Parent of this frame.  (Not editable)", info->enabled_property_);
@@ -698,13 +697,14 @@ void TFDisplay::updateFrame(FrameInfo* frame)
     else if (!frame->tree_property_) // create new property
     {
       frame->tree_property_ =
-          new Property(QString::fromStdString(frame->name_), QVariant(), "", parent_tree_property);
+          new Property(QString::fromStdString(frame->name_), QVariant(), "");
+      parent_tree_property->insertChildSorted(frame->tree_property_);
     }
     else // update property
     {
       // re-parent the tree property
       frame->tree_property_->getParent()->takeChild(frame->tree_property_);
-      parent_tree_property->addChild(frame->tree_property_);
+      parent_tree_property->insertChildSorted(frame->tree_property_);
     }
   }
 

--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -381,6 +381,15 @@ void Property::addChild(Property* child, int index)
   Q_EMIT childListChanged(this);
 }
 
+void Property::insertChildSorted(Property* child)
+{
+  auto it = std::lower_bound(children_.cbegin(), children_.cend(), child,
+                             [](Property* element, Property* child) {
+                               return element->getName() < child->getName();
+                             });
+  addChild(child, it - children_.cbegin());
+}
+
 void Property::setModel(PropertyTreeModel* model)
 {
   model_ = model;

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -346,6 +346,9 @@ public:
    *   child will be added at the end. */
   virtual void addChild(Property* child, int index = -1);
 
+  /** @brief Insert a child property, sorted by name */
+  void insertChildSorted(Property* child);
+
   /** @brief Set the model managing this Property and all its child properties, recursively. */
   void setModel(PropertyTreeModel* model);
 


### PR DESCRIPTION
This improves the TF display in multiple ways:
- Insert all known frames to the tree (before only ones that were connected to rviz' global frame).  
  This allows spotting disconnected trees in a glance.
- Ensure that frames are inserted in sorted fashion.
- Improve insertion and re-parenting of tree nodes