### PR TITLE
Modernize to use Qt5 slots

### DIFF
--- a/src/image_view/image_view.cpp
+++ b/src/image_view/image_view.cpp
@@ -125,7 +125,7 @@ void ImageView::showEvent(QShowEvent* event)
   node->setVisible(true);
 
   QTimer* timer = new QTimer(this);
-  connect(timer, SIGNAL(timeout()), this, SLOT(onTimer()));
+  connect(timer, &QTimer::timeout, this, &ImageView::onTimer);
   timer->start(33);
 }
 

--- a/src/rviz/add_display_dialog.cpp
+++ b/src/rviz/add_display_dialog.cpp
@@ -233,20 +233,19 @@ AddDisplayDialog::AddDisplayDialog(DisplayFactory* factory,
   setLayout(main_layout);
 
   //***** Connections
-  connect(display_tree, SIGNAL(itemChanged(SelectionData*)), this,
-          SLOT(onDisplaySelected(SelectionData*)));
-  connect(display_tree, SIGNAL(itemActivated(QTreeWidgetItem*, int)), this, SLOT(accept()));
+  connect(display_tree, &DisplayTypeTree::itemChanged, this, &AddDisplayDialog::onDisplaySelected);
+  connect(display_tree, &DisplayTypeTree::itemActivated, this, &AddDisplayDialog::accept);
 
-  connect(topic_widget, SIGNAL(itemChanged(SelectionData*)), this, SLOT(onTopicSelected(SelectionData*)));
-  connect(topic_widget, SIGNAL(itemActivated(QTreeWidgetItem*, int)), this, SLOT(accept()));
+  connect(topic_widget, &TopicDisplayWidget::itemChanged, this, &AddDisplayDialog::onTopicSelected);
+  connect(topic_widget, &TopicDisplayWidget::itemActivated, this, &AddDisplayDialog::accept);
 
-  connect(button_box_, SIGNAL(accepted()), this, SLOT(accept()));
-  connect(button_box_, SIGNAL(rejected()), this, SLOT(reject()));
+  connect(button_box_, &QDialogButtonBox::accepted, this, &AddDisplayDialog::accept);
+  connect(button_box_, &QDialogButtonBox::rejected, this, &AddDisplayDialog::reject);
 
-  connect(tab_widget_, SIGNAL(currentChanged(int)), this, SLOT(onTabChanged(int)));
+  connect(tab_widget_, &QTabWidget::currentChanged, this, &AddDisplayDialog::onTabChanged);
   if (display_name_output_)
   {
-    connect(name_editor_, SIGNAL(textEdited(const QString&)), this, SLOT(onNameChanged()));
+    connect(name_editor_, &QLineEdit::textEdited, this, &AddDisplayDialog::onNameChanged);
   }
 
   button_box_->button(QDialogButtonBox::Ok)->setEnabled(isValid());
@@ -357,9 +356,7 @@ void AddDisplayDialog::accept()
 DisplayTypeTree::DisplayTypeTree()
 {
   setHeaderHidden(true);
-
-  connect(this, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this,
-          SLOT(onCurrentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)));
+  connect(this, &DisplayTypeTree::currentItemChanged, this, &DisplayTypeTree::onCurrentItemChanged);
 }
 
 void DisplayTypeTree::onCurrentItemChanged(QTreeWidgetItem* curr, QTreeWidgetItem* /*prev*/)
@@ -439,14 +436,12 @@ TopicDisplayWidget::TopicDisplayWidget()
   layout->addWidget(tree_);
   layout->addWidget(enable_hidden_box_);
 
-  connect(tree_, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this,
-          SLOT(onCurrentItemChanged(QTreeWidgetItem*)));
   // Forward signals from tree_
-  connect(tree_, SIGNAL(itemActivated(QTreeWidgetItem*, int)), this,
-          SIGNAL(itemActivated(QTreeWidgetItem*, int)));
+  connect(tree_, &QTreeWidget::currentItemChanged, this, &TopicDisplayWidget::onCurrentItemChanged);
+  connect(tree_, &QTreeWidget::itemActivated, this, &TopicDisplayWidget::itemActivated);
 
   // Connect signal from checkbox
-  connect(enable_hidden_box_, SIGNAL(stateChanged(int)), this, SLOT(stateChanged(int)));
+  connect(enable_hidden_box_, &QCheckBox::stateChanged, this, &TopicDisplayWidget::stateChanged);
 
   setLayout(layout);
 }
@@ -531,8 +526,7 @@ void TopicDisplayWidget::fill(DisplayFactory* factory)
       if (info.topic_suffixes.size() > 1)
       {
         EmbeddableComboBox* box = new EmbeddableComboBox(row, 1);
-        connect(box, SIGNAL(itemClicked(QTreeWidgetItem*, int)), this,
-                SLOT(onComboBoxClicked(QTreeWidgetItem*)));
+        connect(box, &EmbeddableComboBox::itemClicked, this, &TopicDisplayWidget::onComboBoxClicked);
         for (int i = 0; i < info.topic_suffixes.size(); ++i)
         {
           box->addItem(info.topic_suffixes[i], info.datatypes[i]);

--- a/src/rviz/add_display_dialog.h
+++ b/src/rviz/add_display_dialog.h
@@ -212,17 +212,11 @@ class EmbeddableComboBox : public QComboBox
 public:
   EmbeddableComboBox(QTreeWidgetItem* parent, int col) : parent_(parent), column_(col)
   {
-    connect(this, SIGNAL(activated(int)), this, SLOT(onActivated(int)));
+    connect(this, qOverload<int>(&QComboBox::activated), this, [this] { itemClicked(parent_, column_); });
   }
 
 Q_SIGNALS:
   void itemClicked(QTreeWidgetItem* item, int column);
-
-private Q_SLOTS:
-  void onActivated(int /*index*/)
-  {
-    Q_EMIT itemClicked(parent_, column_);
-  }
 
 private:
   QTreeWidgetItem* parent_;

--- a/src/rviz/default_plugin/axes_display.cpp
+++ b/src/rviz/default_plugin/axes_display.cpp
@@ -47,22 +47,22 @@ AxesDisplay::AxesDisplay() : Display(), axes_(nullptr), trail_(nullptr)
 {
   frame_property_ = new TfFrameProperty("Reference Frame", TfFrameProperty::FIXED_FRAME_STRING,
                                         "The TF frame these axes will use for their origin.", this,
-                                        nullptr, true, SLOT(resetTrail()));
+                                        nullptr, true, [this] { resetTrail(); });
 
-  length_property_ =
-      new FloatProperty("Length", 1.0, "Length of each axis, in meters.", this, SLOT(updateShape()));
+  length_property_ = new FloatProperty("Length", 1.0, "Length of each axis, in meters.", this,
+                                       &AxesDisplay::updateShape);
   length_property_->setMin(0.0001);
 
-  radius_property_ =
-      new FloatProperty("Radius", 0.1, "Radius of each axis, in meters.", this, SLOT(updateShape()));
+  radius_property_ = new FloatProperty("Radius", 0.1, "Radius of each axis, in meters.", this,
+                                       &AxesDisplay::updateShape);
   radius_property_->setMin(0.0001);
 
   trail_property_ =
       new Property("Show Trail", false, "Enable/disable a 2 meter \"ribbon\" which follows this frame.",
-                   this, SLOT(updateTrail()));
+                   this, &AxesDisplay::updateTrail);
 
-  alpha_property_ =
-      new FloatProperty("Alpha", 1.0, "Alpha channel value of each axis.", this, SLOT(updateShape()));
+  alpha_property_ = new FloatProperty("Alpha", 1.0, "Alpha channel value of each axis.", this,
+                                      &AxesDisplay::updateShape);
   alpha_property_->setMin(0.0);
   alpha_property_->setMax(1.0);
 }

--- a/src/rviz/default_plugin/camera_display.cpp
+++ b/src/rviz/default_plugin/camera_display.cpp
@@ -84,7 +84,7 @@ CameraDisplay::CameraDisplay()
   image_position_property_ =
       new EnumProperty("Image Rendering", BOTH,
                        "Render the image behind all other geometry or overlay it on top, or both.", this,
-                       SLOT(forceRender()));
+                       &CameraDisplay::forceRender);
   image_position_property_->addOption(BACKGROUND);
   image_position_property_->addOption(OVERLAY);
   image_position_property_->addOption(BOTH);
@@ -92,14 +92,14 @@ CameraDisplay::CameraDisplay()
   alpha_property_ = new FloatProperty(
       "Overlay Alpha", 0.5,
       "The amount of transparency to apply to the camera image when rendered as overlay.", this,
-      SLOT(updateAlpha()));
+      &CameraDisplay::updateAlpha);
   alpha_property_->setMin(0);
   alpha_property_->setMax(1);
 
   zoom_property_ = new FloatProperty(
       "Zoom Factor", 1.0,
       "Set a zoom factor below 1 to see a larger part of the world, above 1 to magnify the image.", this,
-      SLOT(forceRender()));
+      &CameraDisplay::forceRender);
   zoom_property_->setMin(0.00001);
   zoom_property_->setMax(100000);
 }

--- a/src/rviz/default_plugin/covariance_property.cpp
+++ b/src/rviz/default_plugin/covariance_property.cpp
@@ -44,9 +44,7 @@ namespace rviz
 CovarianceProperty::CovarianceProperty(const QString& name,
                                        bool default_value,
                                        const QString& description,
-                                       Property* parent,
-                                       const char* changed_slot,
-                                       QObject* receiver)
+                                       Property* parent)
   // NOTE: changed() signal will only be initialized at the end of this constructor
   : BoolProperty(name, default_value, description, parent)
 {
@@ -115,16 +113,6 @@ CovarianceProperty::CovarianceProperty(const QString& name,
   orientation_scale_property_->setMin(0);
 
   connect(this, &Property::changed, this, qOverload<>(&CovarianceProperty::updateVisibility));
-
-  // Connect changed() signal here instead of doing it through the initialization of BoolProperty().
-  // We do this here to make changed_slot be called _after_ updateVisibility()
-  if (changed_slot)
-  {
-    if (receiver)
-      connect(receiver, SLOT(changed_slot));
-    else if (parent)
-      connect(parent, SLOT(changed_slot));
-  }
 
   setDisableChildrenIfFalse(true);
 }

--- a/src/rviz/default_plugin/covariance_property.cpp
+++ b/src/rviz/default_plugin/covariance_property.cpp
@@ -50,16 +50,18 @@ CovarianceProperty::CovarianceProperty(const QString& name,
 {
   position_property_ =
       new BoolProperty("Position", true, "Whether or not to show the position part of covariances", this,
-                       SLOT(updateVisibility()));
+                       qOverload<>(&CovarianceProperty::updateVisibility));
   position_property_->setDisableChildrenIfFalse(true);
 
   position_color_property_ =
       new ColorProperty("Color", QColor(204, 51, 204), "Color to draw the position covariance ellipse.",
-                        position_property_, SLOT(updateColorAndAlphaAndScaleAndOffset()), this);
+                        position_property_,
+                        qOverload<>(&CovarianceProperty::updateColorAndAlphaAndScaleAndOffset), this);
 
   position_alpha_property_ =
       new FloatProperty("Alpha", 0.3f, "0 is fully transparent, 1.0 is fully opaque.",
-                        position_property_, SLOT(updateColorAndAlphaAndScaleAndOffset()), this);
+                        position_property_,
+                        qOverload<>(&CovarianceProperty::updateColorAndAlphaAndScaleAndOffset), this);
   position_alpha_property_->setMin(0);
   position_alpha_property_->setMax(1);
 
@@ -67,34 +69,38 @@ CovarianceProperty::CovarianceProperty(const QString& name,
       new FloatProperty("Scale", 1.0f,
                         "Scale factor to be applied to covariance ellipse. "
                         "Corresponds to the number of standard deviations to display",
-                        position_property_, SLOT(updateColorAndAlphaAndScaleAndOffset()), this);
+                        position_property_,
+                        qOverload<>(&CovarianceProperty::updateColorAndAlphaAndScaleAndOffset), this);
   position_scale_property_->setMin(0);
 
   orientation_property_ =
       new BoolProperty("Orientation", true, "Whether or not to show the orientation part of covariances",
-                       this, SLOT(updateVisibility()));
+                       this, qOverload<>(&CovarianceProperty::updateVisibility));
   orientation_property_->setDisableChildrenIfFalse(true);
 
   orientation_frame_property_ =
       new EnumProperty("Frame", "Local", "The frame used to display the orientation covariance.",
-                       orientation_property_, SLOT(updateOrientationFrame()), this);
+                       orientation_property_, qOverload<>(&CovarianceProperty::updateOrientationFrame),
+                       this);
   orientation_frame_property_->addOption("Local", Local);
   orientation_frame_property_->addOption("Fixed", Fixed);
 
   orientation_colorstyle_property_ = new EnumProperty(
       "Color Style", "Unique",
       "Style to color the orientation covariance: XYZ with same unique color or following RGB order",
-      orientation_property_, SLOT(updateColorStyleChoice()), this);
+      orientation_property_, &CovarianceProperty::updateColorStyleChoice, this);
   orientation_colorstyle_property_->addOption("Unique", Unique);
   orientation_colorstyle_property_->addOption("RGB", RGB);
 
   orientation_color_property_ =
       new ColorProperty("Color", QColor(255, 255, 127), "Color to draw the covariance ellipse.",
-                        orientation_property_, SLOT(updateColorAndAlphaAndScaleAndOffset()), this);
+                        orientation_property_,
+                        qOverload<>(&CovarianceProperty::updateColorAndAlphaAndScaleAndOffset), this);
 
   orientation_alpha_property_ =
       new FloatProperty("Alpha", 0.5f, "0 is fully transparent, 1.0 is fully opaque.",
-                        orientation_property_, SLOT(updateColorAndAlphaAndScaleAndOffset()), this);
+                        orientation_property_,
+                        qOverload<>(&CovarianceProperty::updateColorAndAlphaAndScaleAndOffset), this);
   orientation_alpha_property_->setMin(0);
   orientation_alpha_property_->setMax(1);
 
@@ -102,14 +108,16 @@ CovarianceProperty::CovarianceProperty(const QString& name,
       "Offset", 1.0f,
       "For 3D poses is the distance where to position the ellipses representing orientation covariance. "
       "For 2D poses is the height of the triangle representing the variance on yaw.",
-      orientation_property_, SLOT(updateColorAndAlphaAndScaleAndOffset()), this);
+      orientation_property_, qOverload<>(&CovarianceProperty::updateColorAndAlphaAndScaleAndOffset),
+      this);
   orientation_offset_property_->setMin(0);
 
   orientation_scale_property_ =
       new FloatProperty("Scale", 1.0f,
                         "Scale factor to be applied to orientation covariance shapes. "
                         "Corresponds to the number of standard deviations to display.",
-                        orientation_property_, SLOT(updateColorAndAlphaAndScaleAndOffset()), this);
+                        orientation_property_,
+                        qOverload<>(&CovarianceProperty::updateColorAndAlphaAndScaleAndOffset), this);
   orientation_scale_property_->setMin(0);
 
   connect(this, &Property::changed, this, qOverload<>(&CovarianceProperty::updateVisibility));

--- a/src/rviz/default_plugin/covariance_property.cpp
+++ b/src/rviz/default_plugin/covariance_property.cpp
@@ -114,16 +114,16 @@ CovarianceProperty::CovarianceProperty(const QString& name,
                         orientation_property_, SLOT(updateColorAndAlphaAndScaleAndOffset()), this);
   orientation_scale_property_->setMin(0);
 
-  connect(this, SIGNAL(changed()), this, SLOT(updateVisibility()));
+  connect(this, &Property::changed, this, qOverload<>(&CovarianceProperty::updateVisibility));
 
   // Connect changed() signal here instead of doing it through the initialization of BoolProperty().
   // We do this here to make changed_slot be called _after_ updateVisibility()
-  if (changed_slot && (parent || receiver))
+  if (changed_slot)
   {
     if (receiver)
-      connect(this, SIGNAL(changed()), receiver, changed_slot);
-    else
-      connect(this, SIGNAL(changed()), parent, changed_slot);
+      connect(receiver, SLOT(changed_slot));
+    else if (parent)
+      connect(parent, SLOT(changed_slot));
   }
 
   setDisableChildrenIfFalse(true);

--- a/src/rviz/default_plugin/covariance_property.h
+++ b/src/rviz/default_plugin/covariance_property.h
@@ -89,10 +89,10 @@ public:
   // this variant is required to allow omitting the receiver argument
   template <typename Func, typename P>
   CovarianceProperty(const QString& name,
-               bool default_value,
-               const QString& description,
-               P* parent,
-               Func&& changed_slot)
+                     bool default_value,
+                     const QString& description,
+                     P* parent,
+                     Func&& changed_slot)
     : CovarianceProperty(name, default_value, description, parent)
   {
     connect(parent, std::forward<Func>(changed_slot));

--- a/src/rviz/default_plugin/covariance_property.h
+++ b/src/rviz/default_plugin/covariance_property.h
@@ -72,9 +72,31 @@ public:
   CovarianceProperty(const QString& name = "Covariance",
                      bool default_value = false,
                      const QString& description = QString(),
-                     rviz::Property* parent = nullptr,
-                     const char* changed_slot = nullptr,
-                     QObject* receiver = nullptr);
+                     rviz::Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  CovarianceProperty(const QString& name,
+                     bool default_value,
+                     const QString& description,
+                     rviz::Property* parent,
+                     Func&& changed_slot,
+                     const R* receiver)
+    : CovarianceProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  CovarianceProperty(const QString& name,
+               bool default_value,
+               const QString& description,
+               P* parent,
+               Func&& changed_slot)
+    : CovarianceProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   ~CovarianceProperty() override;
 

--- a/src/rviz/default_plugin/depth_cloud_display.cpp
+++ b/src/rviz/default_plugin/depth_cloud_display.cpp
@@ -94,8 +94,8 @@ DepthCloudDisplay::DepthCloudDisplay()
       new EnumProperty("Depth Map Transport Hint", "raw", "Preferred method of sending images.", this,
                        SLOT(updateTopic()));
 
-  connect(depth_transport_property_, SIGNAL(requestOptions(EnumProperty*)), this,
-          SLOT(fillTransportOptionList(EnumProperty*)));
+  connect(depth_transport_property_, &EnumProperty::requestOptions, this,
+          &DepthCloudDisplay::fillTransportOptionList);
 
   depth_transport_property_->setStdString("raw");
 
@@ -112,8 +112,8 @@ DepthCloudDisplay::DepthCloudDisplay()
       "Color Transport Hint", "raw", "Preferred method of sending images.", this, SLOT(updateTopic()));
 
 
-  connect(color_transport_property_, SIGNAL(requestOptions(EnumProperty*)), this,
-          SLOT(fillTransportOptionList(EnumProperty*)));
+  connect(color_transport_property_, &EnumProperty::requestOptions, this,
+          &DepthCloudDisplay::fillTransportOptionList);
 
   color_transport_property_->setStdString("raw");
 

--- a/src/rviz/default_plugin/depth_cloud_display.cpp
+++ b/src/rviz/default_plugin/depth_cloud_display.cpp
@@ -84,15 +84,15 @@ DepthCloudDisplay::DepthCloudDisplay()
   topic_filter_property_ =
       new Property("Topic Filter", true,
                    "List only topics with names that relate to depth and color images", this,
-                   SLOT(updateTopicFilter()));
+                   &DepthCloudDisplay::updateTopicFilter);
 
   depth_topic_property_ = new RosFilteredTopicProperty(
       "Depth Map Topic", "", QString::fromStdString(ros::message_traits::datatype<sensor_msgs::Image>()),
-      "sensor_msgs::Image topic to subscribe to.", depth_filter, this, SLOT(updateTopic()));
+      "sensor_msgs::Image topic to subscribe to.", depth_filter, this, &DepthCloudDisplay::updateTopic);
 
   depth_transport_property_ =
       new EnumProperty("Depth Map Transport Hint", "raw", "Preferred method of sending images.", this,
-                       SLOT(updateTopic()));
+                       &DepthCloudDisplay::updateTopic);
 
   connect(depth_transport_property_, &EnumProperty::requestOptions, this,
           &DepthCloudDisplay::fillTransportOptionList);
@@ -106,10 +106,11 @@ DepthCloudDisplay::DepthCloudDisplay()
   color_topic_property_ = new RosFilteredTopicProperty(
       "Color Image Topic", "",
       QString::fromStdString(ros::message_traits::datatype<sensor_msgs::Image>()),
-      "sensor_msgs::Image topic to subscribe to.", color_filter, this, SLOT(updateTopic()));
+      "sensor_msgs::Image topic to subscribe to.", color_filter, this, &DepthCloudDisplay::updateTopic);
 
-  color_transport_property_ = new EnumProperty(
-      "Color Transport Hint", "raw", "Preferred method of sending images.", this, SLOT(updateTopic()));
+  color_transport_property_ =
+      new EnumProperty("Color Transport Hint", "raw", "Preferred method of sending images.", this,
+                       &DepthCloudDisplay::updateTopic);
 
 
   connect(color_transport_property_, &EnumProperty::requestOptions, this,
@@ -123,29 +124,30 @@ DepthCloudDisplay::DepthCloudDisplay()
                       "Advanced: set the size of the incoming message queue.  Increasing this "
                       "is useful if your incoming TF data is delayed significantly from your"
                       " image data, but it can greatly increase memory usage if the messages are big.",
-                      this, SLOT(updateQueueSize()));
+                      this, &DepthCloudDisplay::updateQueueSize);
   queue_size_property_->setMin(1);
 
   use_auto_size_property_ = new BoolProperty(
       "Auto Size", true,
       "Automatically scale each point based on its depth value and the camera parameters.", this,
-      SLOT(updateUseAutoSize()), this);
+      &DepthCloudDisplay::updateUseAutoSize, this);
 
   auto_size_factor_property_ =
       new FloatProperty("Auto Size Factor", 1, "Scaling factor to be applied to the auto size.",
-                        use_auto_size_property_, SLOT(updateAutoSizeFactor()), this);
+                        use_auto_size_property_, &DepthCloudDisplay::updateAutoSizeFactor, this);
   auto_size_factor_property_->setMin(0.0001);
 
   use_occlusion_compensation_property_ =
       new BoolProperty("Occlusion Compensation", false,
                        "Keep points alive after they have been occluded by a closer point. Points are "
                        "removed after a timeout or when the camera frame moves.",
-                       this, SLOT(updateUseOcclusionCompensation()), this);
+                       this, &DepthCloudDisplay::updateUseOcclusionCompensation, this);
 
   occlusion_shadow_timeout_property_ =
       new FloatProperty("Occlusion Time-Out", 30.0f,
                         "Amount of seconds before removing occluded points from the depth cloud",
-                        use_occlusion_compensation_property_, SLOT(updateOcclusionTimeOut()), this);
+                        use_occlusion_compensation_property_, &DepthCloudDisplay::updateOcclusionTimeOut,
+                        this);
 }
 
 void DepthCloudDisplay::onInitialize()

--- a/src/rviz/default_plugin/depth_cloud_display.h
+++ b/src/rviz/default_plugin/depth_cloud_display.h
@@ -82,13 +82,39 @@ public:
                            const QString& message_type = QString(),
                            const QString& description = QString(),
                            const QRegExp& filter = QRegExp(),
-                           Property* parent = nullptr,
-                           const char* changed_slot = nullptr,
-                           QObject* receiver = nullptr)
-    : RosTopicProperty(name, default_value, message_type, description, parent, changed_slot, receiver)
+                           Property* parent = nullptr)
+    : RosTopicProperty(name, default_value, message_type, description, parent)
     , filter_(filter)
     , filter_enabled_(true)
   {
+  }
+
+  template <typename Func, typename R>
+  RosFilteredTopicProperty(const QString& name,
+                           const QString& default_value,
+                           const QString& message_type,
+                           const QString& description,
+                           const QRegExp& filter,
+                           Property* parent,
+                           Func&& changed_slot,
+                           const R* receiver)
+    : RosFilteredTopicProperty(name, default_value, message_type, description, filter, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  RosFilteredTopicProperty(const QString& name,
+                           const QString& default_value,
+                           const QString& message_type,
+                           const QString& description,
+                           const QRegExp& filter,
+                           P* parent,
+                           Func&& changed_slot)
+    : RosFilteredTopicProperty(name, default_value, message_type, description, filter, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
   }
 
 public:

--- a/src/rviz/default_plugin/effort_display.cpp
+++ b/src/rviz/default_plugin/effort_display.cpp
@@ -26,7 +26,7 @@ JointInfo::JointInfo(const std::string& name, rviz::Property* parent_category)
   // info->category_ = new Property( QString::fromStdString( info->name_ ) , QVariant(), "",
   // joints_category_);
   category_ = new rviz::Property(QString::fromStdString(name_), true, "", parent_category,
-                                 SLOT(updateVisibility()), this);
+                                 &JointInfo::updateVisibility, this);
 
   effort_property_ = new rviz::FloatProperty("Effort", 0, "Effort value of this joint.", category_);
   effort_property_->setReadOnly(true);
@@ -81,17 +81,17 @@ JointInfo* EffortDisplay::createJoint(const std::string& joint)
 EffortDisplay::EffortDisplay()
 {
   alpha_property_ = new rviz::FloatProperty("Alpha", 1.0, "0 is fully transparent, 1.0 is fully opaque.",
-                                            this, SLOT(updateColorAndAlpha()));
+                                            this, &EffortDisplay::updateColorAndAlpha);
 
   width_property_ = new rviz::FloatProperty("Width", 0.02, "Width to drow effort circle", this,
-                                            SLOT(updateColorAndAlpha()));
+                                            &EffortDisplay::updateColorAndAlpha);
 
   scale_property_ = new rviz::FloatProperty("Scale", 1.0, "Scale to drow effort circle", this,
-                                            SLOT(updateColorAndAlpha()));
+                                            &EffortDisplay::updateColorAndAlpha);
 
   history_length_property_ =
       new rviz::IntProperty("History Length", 1, "Number of prior measurements to display.", this,
-                            SLOT(updateHistoryLength()));
+                            &EffortDisplay::updateHistoryLength);
   history_length_property_->setMin(1);
   history_length_property_->setMax(100000);
 
@@ -99,13 +99,13 @@ EffortDisplay::EffortDisplay()
       new rviz::StringProperty("Robot Description", "robot_description",
                                "Name of the parameter to search for to load the robot "
                                "description.",
-                               this, SLOT(updateRobotDescription()));
+                               this, &EffortDisplay::updateRobotDescription);
 
   tf_prefix_property_ = new StringProperty(
       "TF Prefix", "",
       "Robot Model normally assumes the link name is the same as the tf frame name. "
       "This option allows you to set a prefix.  Mainly useful for multi-robot situations.",
-      this, SLOT(updateTfPrefix()));
+      this, &EffortDisplay::updateTfPrefix);
 
   joints_category_ = new rviz::Property("Joints", QVariant(), "", this);
 }
@@ -192,7 +192,7 @@ void EffortDisplay::load()
                   QString("Parameter [%1] does not exist, and was not found by searchParam()")
                       .arg(robot_description_property_->getString()));
         // try again in a second
-        QTimer::singleShot(1000, this, SLOT(updateRobotDescription()));
+        QTimer::singleShot(1000, this, &EffortDisplay::updateRobotDescription);
         return;
       }
     }

--- a/src/rviz/default_plugin/grid_cells_display.cpp
+++ b/src/rviz/default_plugin/grid_cells_display.cpp
@@ -50,7 +50,7 @@ GridCellsDisplay::GridCellsDisplay() : MFDClass(), last_frame_count_(uint64_t(-1
   color_property_ = new ColorProperty("Color", QColor(25, 255, 0), "Color of the grid cells.", this);
 
   alpha_property_ = new FloatProperty("Alpha", 1.0, "Amount of transparency to apply to the cells.",
-                                      this, SLOT(updateAlpha()));
+                                      this, &GridCellsDisplay::updateAlpha);
   alpha_property_->setMin(0);
   alpha_property_->setMax(1);
 }

--- a/src/rviz/default_plugin/grid_display.cpp
+++ b/src/rviz/default_plugin/grid_display.cpp
@@ -53,42 +53,42 @@ GridDisplay::GridDisplay() : Display()
 
   cell_count_property_ =
       new IntProperty("Plane Cell Count", 10, "The number of cells to draw in the plane of the grid.",
-                      this, SLOT(updateCellCount()));
+                      this, &GridDisplay::updateCellCount);
   cell_count_property_->setMin(1);
 
   height_property_ = new IntProperty("Normal Cell Count", 0,
                                      "The number of cells to draw along the normal vector of the grid. "
                                      " Setting to anything but 0 makes the grid 3D.",
-                                     this, SLOT(updateHeight()));
+                                     this, &GridDisplay::updateHeight);
   height_property_->setMin(0);
 
   cell_size_property_ =
       new FloatProperty("Cell Size", 1.0f, "The length, in meters, of the side of each cell.", this,
-                        SLOT(updateCellSize()));
+                        &GridDisplay::updateCellSize);
   cell_size_property_->setMin(0.0001);
 
   style_property_ =
       new EnumProperty("Line Style", "Lines", "The rendering operation to use to draw the grid lines.",
-                       this, SLOT(updateStyle()));
+                       this, &GridDisplay::updateStyle);
   style_property_->addOption("Lines", Grid::Lines);
   style_property_->addOption("Billboards", Grid::Billboards);
 
   line_width_property_ =
       new FloatProperty("Line Width", 0.03, "The width, in meters, of each grid line.", style_property_,
-                        SLOT(updateLineWidth()), this);
+                        &GridDisplay::updateLineWidth, this);
   line_width_property_->setMin(0.001);
   line_width_property_->hide();
 
-  color_property_ =
-      new ColorProperty("Color", Qt::gray, "The color of the grid lines.", this, SLOT(updateColor()));
+  color_property_ = new ColorProperty("Color", Qt::gray, "The color of the grid lines.", this,
+                                      &GridDisplay::updateColor);
   alpha_property_ =
       new FloatProperty("Alpha", 0.5f, "The amount of transparency to apply to the grid lines.", this,
-                        SLOT(updateColor()));
+                        &GridDisplay::updateColor);
   alpha_property_->setMin(0.0f);
   alpha_property_->setMax(1.0f);
 
-  plane_property_ =
-      new EnumProperty("Plane", "XY", "The plane to draw the grid along.", this, SLOT(updatePlane()));
+  plane_property_ = new EnumProperty("Plane", "XY", "The plane to draw the grid along.", this,
+                                     &GridDisplay::updatePlane);
   plane_property_->addOption("XY", XY);
   plane_property_->addOption("XZ", XZ);
   plane_property_->addOption("YZ", YZ);
@@ -96,7 +96,7 @@ GridDisplay::GridDisplay() : Display()
   offset_property_ = new VectorProperty(
       "Offset", Ogre::Vector3::ZERO,
       "Allows you to offset the grid from the origin of the reference frame.  In meters.", this,
-      SLOT(updateOffset()));
+      &GridDisplay::updateOffset);
 }
 
 GridDisplay::~GridDisplay()

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -59,17 +59,17 @@ ImageDisplay::ImageDisplay() : ImageDisplayBase(), texture_()
   normalize_property_ = new BoolProperty(
       "Normalize Range", true,
       "If set to true, will try to estimate the range of possible values from the received images.",
-      this, SLOT(updateNormalizeOptions()));
+      this, &ImageDisplay::updateNormalizeOptions);
 
   min_property_ = new FloatProperty("Min Value", 0.0, "Value which will be displayed as black.", this,
-                                    SLOT(updateNormalizeOptions()));
+                                    &ImageDisplay::updateNormalizeOptions);
 
   max_property_ = new FloatProperty("Max Value", 1.0, "Value which will be displayed as white.", this,
-                                    SLOT(updateNormalizeOptions()));
+                                    &ImageDisplay::updateNormalizeOptions);
 
   median_buffer_size_property_ =
       new IntProperty("Median window", 5, "Window size for median filter used for computin min/max.",
-                      this, SLOT(updateNormalizeOptions()));
+                      this, &ImageDisplay::updateNormalizeOptions);
 
   got_float_image_ = false;
 }

--- a/src/rviz/default_plugin/interactive_marker_display.cpp
+++ b/src/rviz/default_plugin/interactive_marker_display.cpp
@@ -81,27 +81,29 @@ bool validateQuaternions(const visualization_msgs::InteractiveMarker& marker)
 
 InteractiveMarkerDisplay::InteractiveMarkerDisplay() : Display()
 {
-  marker_update_topic_property_ = new RosTopicProperty(
-      "Update Topic", "", ros::message_traits::datatype<visualization_msgs::InteractiveMarkerUpdate>(),
-      "visualization_msgs::InteractiveMarkerUpdate topic to subscribe to.", this, SLOT(updateTopic()));
+  marker_update_topic_property_ =
+      new RosTopicProperty("Update Topic", "",
+                           ros::message_traits::datatype<visualization_msgs::InteractiveMarkerUpdate>(),
+                           "visualization_msgs::InteractiveMarkerUpdate topic to subscribe to.", this,
+                           &InteractiveMarkerDisplay::updateTopic);
 
   show_descriptions_property_ =
       new BoolProperty("Show Descriptions", true,
                        "Whether or not to show the descriptions of each Interactive Marker.", this,
-                       SLOT(updateShowDescriptions()));
+                       &InteractiveMarkerDisplay::updateShowDescriptions);
 
   show_axes_property_ =
       new BoolProperty("Show Axes", false, "Whether or not to show the axes of each Interactive Marker.",
-                       this, SLOT(updateShowAxes()));
+                       this, &InteractiveMarkerDisplay::updateShowAxes);
 
   show_visual_aids_property_ = new BoolProperty(
       "Show Visual Aids", false,
       "Whether or not to show visual helpers while moving/rotating Interactive Markers.", this,
-      SLOT(updateShowVisualAids()));
+      &InteractiveMarkerDisplay::updateShowVisualAids);
   enable_transparency_property_ = new BoolProperty(
       "Enable Transparency", true,
       "Whether or not to allow transparency for auto-completed markers (e.g. rings and arrows).", this,
-      SLOT(updateEnableTransparency()));
+      &InteractiveMarkerDisplay::updateEnableTransparency);
 }
 
 void InteractiveMarkerDisplay::onInitialize()

--- a/src/rviz/default_plugin/interactive_marker_display.cpp
+++ b/src/rviz/default_plugin/interactive_marker_display.cpp
@@ -255,12 +255,10 @@ void InteractiveMarkerDisplay::updateMarkers(
           im_map
               .insert(std::make_pair(marker.name, IMPtr(new InteractiveMarker(getSceneNode(), context_))))
               .first;
-      connect(int_marker_entry->second.get(),
-              SIGNAL(userFeedback(visualization_msgs::InteractiveMarkerFeedback&)), this,
-              SLOT(publishFeedback(visualization_msgs::InteractiveMarkerFeedback&)));
-      connect(int_marker_entry->second.get(),
-              SIGNAL(statusUpdate(StatusProperty::Level, const std::string&, const std::string&)), this,
-              SLOT(onStatusUpdate(StatusProperty::Level, const std::string&, const std::string&)));
+      connect(int_marker_entry->second.get(), &InteractiveMarker::userFeedback, this,
+              &InteractiveMarkerDisplay::publishFeedback);
+      connect(int_marker_entry->second.get(), &InteractiveMarker::statusUpdate, this,
+              &InteractiveMarkerDisplay::onStatusUpdate);
     }
 
     if (int_marker_entry->second->processMessage(marker))

--- a/src/rviz/default_plugin/interactive_markers/integer_action.cpp
+++ b/src/rviz/default_plugin/interactive_markers/integer_action.cpp
@@ -33,7 +33,7 @@ namespace rviz
 IntegerAction::IntegerAction(const QString& text, QObject* parent, int id)
   : QAction(text, parent), id_(id)
 {
-  connect(this, SIGNAL(triggered(bool)), this, SLOT(emitId()));
+  connect(this, &QAction::triggered, this, &IntegerAction::emitId);
 }
 
 void IntegerAction::emitId()

--- a/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
+++ b/src/rviz/default_plugin/interactive_markers/interactive_marker.cpp
@@ -261,7 +261,7 @@ void InteractiveMarker::populateMenu(QMenu* menu, std::vector<uint32_t>& ids)
     {
       IntegerAction* action =
           new IntegerAction(makeMenuString(node.entry.title), menu, (int)node.entry.id);
-      connect(action, SIGNAL(triggered(int)), this, SLOT(handleMenuSelect(int)));
+      connect(action, &IntegerAction::triggered, this, &InteractiveMarker::handleMenuSelect);
       menu->addAction(action);
     }
     else

--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -224,15 +224,15 @@ MapDisplay::MapDisplay() : Display(), loaded_(false), resolution_(0.0f), width_(
   connect(this, &MapDisplay::mapUpdated, this, &MapDisplay::showMap);
   topic_property_ = new RosTopicProperty(
       "Topic", "", QString::fromStdString(ros::message_traits::datatype<nav_msgs::OccupancyGrid>()),
-      "nav_msgs::OccupancyGrid topic to subscribe to.", this, SLOT(updateTopic()));
+      "nav_msgs::OccupancyGrid topic to subscribe to.", this, &MapDisplay::updateTopic);
 
   alpha_property_ = new FloatProperty("Alpha", 0.7, "Amount of transparency to apply to the map.", this,
-                                      SLOT(updateAlpha()));
+                                      &MapDisplay::updateAlpha);
   alpha_property_->setMin(0);
   alpha_property_->setMax(1);
 
   color_scheme_property_ = new EnumProperty("Color Scheme", "map", "How to color the occupancy values.",
-                                            this, SLOT(updatePalette()));
+                                            this, &MapDisplay::updatePalette);
   // Option values here must correspond to indices in palette_textures_ array in onInitialize() below.
   color_scheme_property_->addOption("map", 0);
   color_scheme_property_->addOption("costmap", 1);
@@ -241,7 +241,7 @@ MapDisplay::MapDisplay() : Display(), loaded_(false), resolution_(0.0f), width_(
   draw_under_property_ = new Property(
       "Draw Behind", false,
       "Rendering option, controls whether or not the map is always drawn behind everything else.", this,
-      SLOT(updateDrawUnder()));
+      &MapDisplay::updateDrawUnder);
 
   resolution_property_ =
       new FloatProperty("Resolution", 0, "Resolution of the map. (not editable)", this);
@@ -263,11 +263,12 @@ MapDisplay::MapDisplay() : Display(), loaded_(false), resolution_(0.0f), width_(
                                                  "Orientation of the map. (not editable)", this);
   orientation_property_->setReadOnly(true);
 
-  unreliable_property_ =
-      new BoolProperty("Unreliable", false, "Prefer UDP topic transport", this, SLOT(updateTopic()));
+  unreliable_property_ = new BoolProperty("Unreliable", false, "Prefer UDP topic transport", this,
+                                          &MapDisplay::updateTopic);
 
-  transform_timestamp_property_ = new BoolProperty(
-      "Use Timestamp", false, "Use map header timestamp when transforming", this, SLOT(transformMap()));
+  transform_timestamp_property_ =
+      new BoolProperty("Use Timestamp", false, "Use map header timestamp when transforming", this,
+                       &MapDisplay::transformMap);
 }
 
 MapDisplay::~MapDisplay()

--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -221,7 +221,7 @@ void Swatch::updateData()
 
 MapDisplay::MapDisplay() : Display(), loaded_(false), resolution_(0.0f), width_(0), height_(0)
 {
-  connect(this, SIGNAL(mapUpdated()), this, SLOT(showMap()));
+  connect(this, &MapDisplay::mapUpdated, this, &MapDisplay::showMap);
   topic_property_ = new RosTopicProperty(
       "Topic", "", QString::fromStdString(ros::message_traits::datatype<nav_msgs::OccupancyGrid>()),
       "nav_msgs::OccupancyGrid topic to subscribe to.", this, SLOT(updateTopic()));

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -459,7 +459,7 @@ MarkerNamespace::MarkerNamespace(const QString& name, Property* parent_property,
   // Can't do this connect in chained constructor above because at
   // that point it doesn't really know that "this" is a
   // MarkerNamespace*, so the signal doesn't get connected.
-  connect(this, SIGNAL(changed()), this, SLOT(onEnableChanged()));
+  connect(this, &Property::changed, this, &MarkerNamespace::onEnableChanged);
 }
 
 void MarkerNamespace::onEnableChanged()

--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -56,14 +56,14 @@ MarkerDisplay::MarkerDisplay() : Display(), tf_filter_(nullptr)
       QString::fromStdString(ros::message_traits::datatype<visualization_msgs::Marker>()),
       "visualization_msgs::Marker topic to subscribe to.  <topic>_array will also"
       " automatically be subscribed with type visualization_msgs::MarkerArray.",
-      this, SLOT(updateTopic()));
+      this, &MarkerDisplay::updateTopic);
 
   queue_size_property_ =
       new IntProperty("Queue Size", 100,
                       "Advanced: set the size of the incoming Marker message queue.  Increasing this is"
                       " useful if your incoming TF data is delayed significantly from your Marker data, "
                       "but it can greatly increase memory usage if the messages are big.",
-                      this, SLOT(updateQueueSize()));
+                      this, &MarkerDisplay::updateQueueSize);
   queue_size_property_->setMin(0);
 
   namespaces_category_ = new Property("Namespaces", QVariant(), "", this);

--- a/src/rviz/default_plugin/odometry_display.cpp
+++ b/src/rviz/default_plugin/odometry_display.cpp
@@ -66,46 +66,46 @@ OdometryDisplay::OdometryDisplay()
   keep_property_->setMin(0);
 
   shape_property_ = new EnumProperty("Shape", "Arrow", "Shape to display the pose as.", this,
-                                     SLOT(updateShapeChoice()));
+                                     &OdometryDisplay::updateShapeChoice);
   shape_property_->addOption("Arrow", ArrowShape);
   shape_property_->addOption("Axes", AxesShape);
 
   color_property_ = new ColorProperty("Color", QColor(255, 25, 0), "Color of the arrows.",
-                                      shape_property_, SLOT(updateColorAndAlpha()), this);
+                                      shape_property_, &OdometryDisplay::updateColorAndAlpha, this);
 
   alpha_property_ = new FloatProperty("Alpha", 1, "Amount of transparency to apply to the arrow.",
-                                      shape_property_, SLOT(updateColorAndAlpha()), this);
+                                      shape_property_, &OdometryDisplay::updateColorAndAlpha, this);
   alpha_property_->setMin(0);
   alpha_property_->setMax(1);
 
   shaft_length_property_ =
       new FloatProperty("Shaft Length", 1, "Length of the each arrow's shaft, in meters.",
-                        shape_property_, SLOT(updateArrowsGeometry()), this);
+                        shape_property_, &OdometryDisplay::updateArrowsGeometry, this);
 
   // aleeper: default changed from 0.1 to match change in arrow.cpp
   shaft_radius_property_ =
       new FloatProperty("Shaft Radius", 0.05, "Radius of the each arrow's shaft, in meters.",
-                        shape_property_, SLOT(updateArrowsGeometry()), this);
+                        shape_property_, &OdometryDisplay::updateArrowsGeometry, this);
 
   head_length_property_ =
       new FloatProperty("Head Length", 0.3, "Length of the each arrow's head, in meters.",
-                        shape_property_, SLOT(updateArrowsGeometry()), this);
+                        shape_property_, &OdometryDisplay::updateArrowsGeometry, this);
 
   // aleeper: default changed from 0.2 to match change in arrow.cpp
   head_radius_property_ =
       new FloatProperty("Head Radius", 0.1, "Radius of the each arrow's head, in meters.",
-                        shape_property_, SLOT(updateArrowsGeometry()), this);
+                        shape_property_, &OdometryDisplay::updateArrowsGeometry, this);
 
   axes_length_property_ = new FloatProperty("Axes Length", 1, "Length of each axis, in meters.",
-                                            shape_property_, SLOT(updateAxisGeometry()), this);
+                                            shape_property_, &OdometryDisplay::updateAxisGeometry, this);
 
   axes_radius_property_ = new FloatProperty("Axes Radius", 0.1, "Radius of each axis, in meters.",
-                                            shape_property_, SLOT(updateAxisGeometry()), this);
+                                            shape_property_, &OdometryDisplay::updateAxisGeometry, this);
 
   covariance_property_ =
       new CovarianceProperty("Covariance", true,
                              "Whether or not the covariances of the messages should be shown.", this,
-                             SLOT(queueRender()));
+                             &OdometryDisplay::queueRender);
 }
 
 OdometryDisplay::~OdometryDisplay()

--- a/src/rviz/default_plugin/path_display.cpp
+++ b/src/rviz/default_plugin/path_display.cpp
@@ -53,7 +53,7 @@ PathDisplay::PathDisplay()
 {
   style_property_ =
       new EnumProperty("Line Style", "Lines", "The rendering operation to use to draw the grid lines.",
-                       this, SLOT(updateStyle()));
+                       this, &PathDisplay::updateStyle);
 
   style_property_->addOption("Lines", LINES);
   style_property_->addOption("Billboards", BILLBOARDS);
@@ -61,7 +61,7 @@ PathDisplay::PathDisplay()
   line_width_property_ = new FloatProperty(
       "Line Width", 0.03,
       "The width, in meters, of each path line. Only works with the 'Billboards' style.", this,
-      SLOT(updateLineWidth()), this);
+      &PathDisplay::updateLineWidth, this);
   line_width_property_->setMin(0.001);
   line_width_property_->hide();
 
@@ -71,36 +71,37 @@ PathDisplay::PathDisplay()
       new FloatProperty("Alpha", 1.0, "Amount of transparency to apply to the path.", this);
 
   buffer_length_property_ = new IntProperty("Buffer Length", 1, "Number of paths to display.", this,
-                                            SLOT(updateBufferLength()));
+                                            &PathDisplay::updateBufferLength);
   buffer_length_property_->setMin(1);
 
   offset_property_ = new VectorProperty(
       "Offset", Ogre::Vector3::ZERO,
       "Allows you to offset the path from the origin of the reference frame.  In meters.", this,
-      SLOT(updateOffset()));
+      &PathDisplay::updateOffset);
 
   pose_style_property_ = new EnumProperty("Pose Style", "None", "Shape to display the pose as.", this,
-                                          SLOT(updatePoseStyle()));
+                                          &PathDisplay::updatePoseStyle);
   pose_style_property_->addOption("None", NONE);
   pose_style_property_->addOption("Axes", AXES);
   pose_style_property_->addOption("Arrows", ARROWS);
 
   pose_axes_length_property_ = new rviz::FloatProperty("Length", 0.3, "Length of the axes.", this,
-                                                       SLOT(updatePoseAxisGeometry()));
+                                                       &PathDisplay::updatePoseAxisGeometry);
   pose_axes_radius_property_ = new rviz::FloatProperty("Radius", 0.03, "Radius of the axes.", this,
-                                                       SLOT(updatePoseAxisGeometry()));
+                                                       &PathDisplay::updatePoseAxisGeometry);
 
   pose_arrow_color_property_ =
       new ColorProperty("Pose Color", QColor(255, 85, 255), "Color to draw the poses.", this,
-                        SLOT(updatePoseArrowColor()));
+                        &PathDisplay::updatePoseArrowColor);
   pose_arrow_shaft_length_property_ = new rviz::FloatProperty(
-      "Shaft Length", 0.1, "Length of the arrow shaft.", this, SLOT(updatePoseArrowGeometry()));
+      "Shaft Length", 0.1, "Length of the arrow shaft.", this, &PathDisplay::updatePoseArrowGeometry);
   pose_arrow_head_length_property_ = new rviz::FloatProperty(
-      "Head Length", 0.2, "Length of the arrow head.", this, SLOT(updatePoseArrowGeometry()));
-  pose_arrow_shaft_diameter_property_ = new rviz::FloatProperty(
-      "Shaft Diameter", 0.1, "Diameter of the arrow shaft.", this, SLOT(updatePoseArrowGeometry()));
+      "Head Length", 0.2, "Length of the arrow head.", this, &PathDisplay::updatePoseArrowGeometry);
+  pose_arrow_shaft_diameter_property_ =
+      new rviz::FloatProperty("Shaft Diameter", 0.1, "Diameter of the arrow shaft.", this,
+                              &PathDisplay::updatePoseArrowGeometry);
   pose_arrow_head_diameter_property_ = new rviz::FloatProperty(
-      "Head Diameter", 0.3, "Diameter of the arrow head.", this, SLOT(updatePoseArrowGeometry()));
+      "Head Diameter", 0.3, "Diameter of the arrow head.", this, &PathDisplay::updatePoseArrowGeometry);
   pose_axes_length_property_->hide();
   pose_axes_radius_property_->hide();
   pose_arrow_color_property_->hide();

--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -316,11 +316,11 @@ PointCloudCommon::PointCloudCommon(Display* display)
   selectable_property_ =
       new BoolProperty("Selectable", true,
                        "Whether or not the points in this point cloud are selectable.", display_,
-                       SLOT(updateSelectable()), this);
+                       &PointCloudCommon::updateSelectable, this);
 
   style_property_ = new EnumProperty("Style", "Flat Squares",
                                      "Rendering mode to use, in order of computational complexity.",
-                                     display_, SLOT(updateStyle()), this);
+                                     display_, &PointCloudCommon::updateStyle, this);
   style_property_->addOption("Points", PointCloud::RM_POINTS);
   style_property_->addOption("Squares", PointCloud::RM_SQUARES);
   style_property_->addOption("Flat Squares", PointCloud::RM_FLAT_SQUARES);
@@ -328,37 +328,37 @@ PointCloudCommon::PointCloudCommon(Display* display)
   style_property_->addOption("Boxes", PointCloud::RM_BOXES);
 
   point_world_size_property_ = new FloatProperty("Size (m)", 0.01, "Point size in meters.", display_,
-                                                 SLOT(updateBillboardSize()), this);
+                                                 &PointCloudCommon::updateBillboardSize, this);
   point_world_size_property_->setMin(0.0001);
 
   point_pixel_size_property_ = new FloatProperty("Size (Pixels)", 3, "Point size in pixels.", display_,
-                                                 SLOT(updateBillboardSize()), this);
+                                                 &PointCloudCommon::updateBillboardSize, this);
   point_pixel_size_property_->setMin(1);
 
   alpha_property_ = new FloatProperty("Alpha", 1.0,
                                       "Amount of transparency to apply to the points. "
                                       "Note that this is experimental and does not always look correct.",
-                                      display_, SLOT(updateAlpha()), this);
+                                      display_, &PointCloudCommon::updateAlpha, this);
   alpha_property_->setMin(0);
   alpha_property_->setMax(1);
 
   decay_time_property_ = new FloatProperty(
       "Decay Time", 0,
       "Duration, in seconds, to keep the incoming points.  0 means only show the latest points.",
-      display_, SLOT(queueRender()));
+      display_, &Display::queueRender);
   decay_time_property_->setMin(0);
 
   xyz_transformer_property_ =
       new EnumProperty("Position Transformer", "",
                        "Set the transformer to use to set the position of the points.", display_,
-                       SLOT(updateXyzTransformer()), this);
+                       &PointCloudCommon::updateXyzTransformer, this);
   connect(xyz_transformer_property_, &EnumProperty::requestOptions, this,
           &PointCloudCommon::setXyzTransformerOptions);
 
   color_transformer_property_ =
       new EnumProperty("Color Transformer", "",
                        "Set the transformer to use to set the color of the points.", display_,
-                       SLOT(updateColorTransformer()), this);
+                       &PointCloudCommon::updateColorTransformer, this);
   connect(color_transformer_property_, &EnumProperty::requestOptions, this,
           &PointCloudCommon::setColorTransformerOptions);
 }

--- a/src/rviz/default_plugin/point_cloud_common.cpp
+++ b/src/rviz/default_plugin/point_cloud_common.cpp
@@ -352,15 +352,15 @@ PointCloudCommon::PointCloudCommon(Display* display)
       new EnumProperty("Position Transformer", "",
                        "Set the transformer to use to set the position of the points.", display_,
                        SLOT(updateXyzTransformer()), this);
-  connect(xyz_transformer_property_, SIGNAL(requestOptions(EnumProperty*)), this,
-          SLOT(setXyzTransformerOptions(EnumProperty*)));
+  connect(xyz_transformer_property_, &EnumProperty::requestOptions, this,
+          &PointCloudCommon::setXyzTransformerOptions);
 
   color_transformer_property_ =
       new EnumProperty("Color Transformer", "",
                        "Set the transformer to use to set the color of the points.", display_,
                        SLOT(updateColorTransformer()), this);
-  connect(color_transformer_property_, SIGNAL(requestOptions(EnumProperty*)), this,
-          SLOT(setColorTransformerOptions(EnumProperty*)));
+  connect(color_transformer_property_, &EnumProperty::requestOptions, this,
+          &PointCloudCommon::setColorTransformerOptions);
 }
 
 void PointCloudCommon::initialize(DisplayContext* context, Ogre::SceneNode* scene_node)
@@ -404,7 +404,8 @@ void PointCloudCommon::loadTransformers()
 
     PointCloudTransformerPtr trans(transformer_class_loader_->createUnmanagedInstance(lookup_name));
     trans->init();
-    connect(trans.get(), SIGNAL(needRetransform()), this, SLOT(causeRetransform()));
+    connect(trans.get(), &PointCloudTransformer::needRetransform, this,
+            &PointCloudCommon::causeRetransform);
 
     TransformerInfo info;
     info.transformer = trans;

--- a/src/rviz/default_plugin/point_cloud_transformers.cpp
+++ b/src/rviz/default_plugin/point_cloud_transformers.cpp
@@ -267,13 +267,15 @@ void IntensityPCTransformer::updateAutoComputeIntensityBounds()
   max_intensity_property_->setReadOnly(auto_compute);
   if (auto_compute)
   {
-    disconnect(min_intensity_property_, SIGNAL(changed()), this, SIGNAL(needRetransform()));
-    disconnect(max_intensity_property_, SIGNAL(changed()), this, SIGNAL(needRetransform()));
+    disconnect(min_intensity_property_, &Property::changed, this,
+               &IntensityPCTransformer::needRetransform);
+    disconnect(max_intensity_property_, &Property::changed, this,
+               &IntensityPCTransformer::needRetransform);
   }
   else
   {
-    connect(min_intensity_property_, SIGNAL(changed()), this, SIGNAL(needRetransform()));
-    connect(max_intensity_property_, SIGNAL(changed()), this, SIGNAL(needRetransform()));
+    connect(min_intensity_property_, &Property::changed, this, &IntensityPCTransformer::needRetransform);
+    connect(max_intensity_property_, &Property::changed, this, &IntensityPCTransformer::needRetransform);
   }
   Q_EMIT needRetransform();
 }
@@ -696,13 +698,13 @@ void AxisColorPCTransformer::updateAutoComputeBounds()
   max_value_property_->setHidden(auto_compute);
   if (auto_compute)
   {
-    disconnect(min_value_property_, SIGNAL(changed()), this, SIGNAL(needRetransform()));
-    disconnect(max_value_property_, SIGNAL(changed()), this, SIGNAL(needRetransform()));
+    disconnect(min_value_property_, &Property::changed, this, &AxisColorPCTransformer::needRetransform);
+    disconnect(max_value_property_, &Property::changed, this, &AxisColorPCTransformer::needRetransform);
   }
   else
   {
-    connect(min_value_property_, SIGNAL(changed()), this, SIGNAL(needRetransform()));
-    connect(max_value_property_, SIGNAL(changed()), this, SIGNAL(needRetransform()));
+    connect(min_value_property_, &Property::changed, this, &AxisColorPCTransformer::needRetransform);
+    connect(max_value_property_, &Property::changed, this, &AxisColorPCTransformer::needRetransform);
     auto_compute_bounds_property_->expand();
   }
   Q_EMIT needRetransform();

--- a/src/rviz/default_plugin/point_cloud_transformers.cpp
+++ b/src/rviz/default_plugin/point_cloud_transformers.cpp
@@ -186,30 +186,35 @@ void IntensityPCTransformer::createProperties(Property* parent_property,
     channel_name_property_ =
         new EditableEnumProperty("Channel Name", "intensity",
                                  "Select the channel to use to compute the intensity", parent_property,
-                                 SIGNAL(needRetransform()), this);
+                                 &IntensityPCTransformer::needRetransform, this);
 
     use_rainbow_property_ =
         new BoolProperty("Use rainbow", true,
                          "Whether to use a rainbow of colors or interpolate between two",
-                         parent_property, SLOT(updateUseRainbow()), this);
+                         parent_property, &IntensityPCTransformer::updateUseRainbow, this);
     invert_rainbow_property_ =
         new BoolProperty("Invert Rainbow", false, "Whether to invert rainbow colors", parent_property,
-                         SLOT(updateUseRainbow()), this);
+                         &IntensityPCTransformer::updateUseRainbow, this);
 
-    min_color_property_ = new ColorProperty("Min Color", Qt::black,
-                                            "Color to assign the points with the minimum intensity.  "
-                                            "Actual color is interpolated between this and Max Color.",
-                                            parent_property, SIGNAL(needRetransform()), this);
+    min_color_property_ =
+        new ColorProperty("Min Color", Qt::black,
+                          "Color to assign the points with the minimum intensity.  "
+                          "Actual color is interpolated between this and Max Color.",
+                          parent_property,
+                          &IntensityPCTransformer::IntensityPCTransformer::needRetransform, this);
 
-    max_color_property_ = new ColorProperty("Max Color", Qt::white,
-                                            "Color to assign the points with the maximum intensity.  "
-                                            "Actual color is interpolated between this and Min Color.",
-                                            parent_property, SIGNAL(needRetransform()), this);
+    max_color_property_ =
+        new ColorProperty("Max Color", Qt::white,
+                          "Color to assign the points with the maximum intensity.  "
+                          "Actual color is interpolated between this and Min Color.",
+                          parent_property,
+                          &IntensityPCTransformer::IntensityPCTransformer::needRetransform, this);
 
     auto_compute_intensity_bounds_property_ =
         new BoolProperty("Autocompute Intensity Bounds", true,
                          "Whether to automatically compute the intensity min/max values.",
-                         parent_property, SLOT(updateAutoComputeIntensityBounds()), this);
+                         parent_property, &IntensityPCTransformer::updateAutoComputeIntensityBounds,
+                         this);
 
     min_intensity_property_ = new FloatProperty(
         "Min Intensity", 0,
@@ -553,7 +558,7 @@ void FlatColorPCTransformer::createProperties(Property* parent_property,
   if (mask & Support_Color)
   {
     color_property_ = new ColorProperty("Color", Qt::white, "Color to assign to every point.",
-                                        parent_property, SIGNAL(needRetransform()), this);
+                                        parent_property, &IntensityPCTransformer::needRetransform, this);
     out_props.push_back(color_property_);
   }
 }
@@ -658,7 +663,7 @@ void AxisColorPCTransformer::createProperties(Property* parent_property,
   if (mask & Support_Color)
   {
     axis_property_ = new EnumProperty("Axis", "Z", "The axis to interpolate the color along.",
-                                      parent_property, SIGNAL(needRetransform()), this);
+                                      parent_property, &IntensityPCTransformer::needRetransform, this);
     axis_property_->addOption("X", AXIS_X);
     axis_property_->addOption("Y", AXIS_Y);
     axis_property_->addOption("Z", AXIS_Z);
@@ -666,7 +671,7 @@ void AxisColorPCTransformer::createProperties(Property* parent_property,
     auto_compute_bounds_property_ =
         new BoolProperty("Autocompute Value Bounds", true,
                          "Whether to automatically compute the value min/max values.", parent_property,
-                         SLOT(updateAutoComputeBounds()), this);
+                         &AxisColorPCTransformer::updateAutoComputeBounds, this);
 
     min_value_property_ =
         new FloatProperty("Min Value", -10,
@@ -681,7 +686,7 @@ void AxisColorPCTransformer::createProperties(Property* parent_property,
     use_fixed_frame_property_ = new BoolProperty(
         "Use Fixed Frame", true,
         "Whether to color the cloud based on its fixed frame position or its local frame position.",
-        parent_property, SIGNAL(needRetransform()), this);
+        parent_property, &IntensityPCTransformer::needRetransform, this);
 
     out_props.push_back(axis_property_);
     out_props.push_back(auto_compute_bounds_property_);

--- a/src/rviz/default_plugin/point_display.cpp
+++ b/src/rviz/default_plugin/point_display.cpp
@@ -17,17 +17,17 @@ namespace rviz
 PointStampedDisplay::PointStampedDisplay()
 {
   color_property_ = new rviz::ColorProperty("Color", QColor(204, 41, 204), "Color of a point", this,
-                                            SLOT(updateColorAndAlpha()));
+                                            &PointStampedDisplay::updateColorAndAlpha);
 
   alpha_property_ = new rviz::FloatProperty("Alpha", 1.0, "0 is fully transparent, 1.0 is fully opaque.",
-                                            this, SLOT(updateColorAndAlpha()));
+                                            this, &PointStampedDisplay::updateColorAndAlpha);
 
-  radius_property_ =
-      new rviz::FloatProperty("Radius", 0.2, "Radius of a point", this, SLOT(updateColorAndAlpha()));
+  radius_property_ = new rviz::FloatProperty("Radius", 0.2, "Radius of a point", this,
+                                             &PointStampedDisplay::updateColorAndAlpha);
 
   history_length_property_ =
       new rviz::IntProperty("History Length", 1, "Number of prior measurements to display.", this,
-                            SLOT(updateHistoryLength()));
+                            &PointStampedDisplay::updateHistoryLength);
   history_length_property_->setMin(1);
   history_length_property_->setMax(100000);
 }

--- a/src/rviz/default_plugin/polygon_display.cpp
+++ b/src/rviz/default_plugin/polygon_display.cpp
@@ -45,9 +45,9 @@ namespace rviz
 PolygonDisplay::PolygonDisplay()
 {
   color_property_ = new ColorProperty("Color", QColor(25, 255, 0), "Color to draw the polygon.", this,
-                                      SLOT(queueRender()));
+                                      &PolygonDisplay::queueRender);
   alpha_property_ = new FloatProperty("Alpha", 1.0, "Amount of transparency to apply to the polygon.",
-                                      this, SLOT(queueRender()));
+                                      this, &PolygonDisplay::queueRender);
   alpha_property_->setMin(0);
   alpha_property_->setMax(1);
 }

--- a/src/rviz/default_plugin/pose_array_display.cpp
+++ b/src/rviz/default_plugin/pose_array_display.cpp
@@ -73,39 +73,39 @@ Ogre::Quaternion quaternionRosToOgre(geometry_msgs::Quaternion const& quaternion
 PoseArrayDisplay::PoseArrayDisplay() : manual_object_(nullptr)
 {
   shape_property_ = new EnumProperty("Shape", "Arrow (Flat)", "Shape to display the pose as.", this,
-                                     SLOT(updateShapeChoice()));
+                                     &PoseArrayDisplay::updateShapeChoice);
 
   arrow_color_property_ = new ColorProperty("Color", QColor(255, 25, 0), "Color to draw the arrows.",
-                                            this, SLOT(updateArrowColor()));
+                                            this, &PoseArrayDisplay::updateArrowColor);
 
   arrow_alpha_property_ =
       new FloatProperty("Alpha", 1, "Amount of transparency to apply to the displayed poses.", this,
-                        SLOT(updateArrowColor()));
+                        &PoseArrayDisplay::updateArrowColor);
 
   arrow2d_length_property_ = new FloatProperty("Arrow Length", 0.3, "Length of the arrows.", this,
-                                               SLOT(updateArrow2dGeometry()));
+                                               &PoseArrayDisplay::updateArrow2dGeometry);
 
   arrow3d_head_radius_property_ =
       new FloatProperty("Head Radius", 0.03, "Radius of the arrow's head, in meters.", this,
-                        SLOT(updateArrow3dGeometry()));
+                        &PoseArrayDisplay::updateArrow3dGeometry);
 
   arrow3d_head_length_property_ =
       new FloatProperty("Head Length", 0.07, "Length of the arrow's head, in meters.", this,
-                        SLOT(updateArrow3dGeometry()));
+                        &PoseArrayDisplay::updateArrow3dGeometry);
 
   arrow3d_shaft_radius_property_ =
       new FloatProperty("Shaft Radius", 0.01, "Radius of the arrow's shaft, in meters.", this,
-                        SLOT(updateArrow3dGeometry()));
+                        &PoseArrayDisplay::updateArrow3dGeometry);
 
   arrow3d_shaft_length_property_ =
       new FloatProperty("Shaft Length", 0.23, "Length of the arrow's shaft, in meters.", this,
-                        SLOT(updateArrow3dGeometry()));
+                        &PoseArrayDisplay::updateArrow3dGeometry);
 
   axes_length_property_ = new FloatProperty("Axes Length", 0.3, "Length of each axis, in meters.", this,
-                                            SLOT(updateAxesGeometry()));
+                                            &PoseArrayDisplay::updateAxesGeometry);
 
   axes_radius_property_ = new FloatProperty("Axes Radius", 0.01, "Radius of each axis, in meters.", this,
-                                            SLOT(updateAxesGeometry()));
+                                            &PoseArrayDisplay::updateAxesGeometry);
 
   shape_property_->addOption("Arrow (Flat)", ShapeType::Arrow2d);
   shape_property_->addOption("Arrow (3D)", ShapeType::Arrow3d);

--- a/src/rviz/default_plugin/pose_display.cpp
+++ b/src/rviz/default_plugin/pose_display.cpp
@@ -117,38 +117,39 @@ private:
 PoseDisplay::PoseDisplay() : pose_valid_(false)
 {
   shape_property_ = new EnumProperty("Shape", "Arrow", "Shape to display the pose as.", this,
-                                     SLOT(updateShapeChoice()));
+                                     &PoseDisplay::updateShapeChoice);
   shape_property_->addOption("Arrow", Arrow);
   shape_property_->addOption("Axes", Axes);
 
   color_property_ = new ColorProperty("Color", QColor(255, 25, 0), "Color to draw the arrow.", this,
-                                      SLOT(updateColorAndAlpha()));
+                                      &PoseDisplay::updateColorAndAlpha);
 
   alpha_property_ = new FloatProperty("Alpha", 1, "Amount of transparency to apply to the arrow.", this,
-                                      SLOT(updateColorAndAlpha()));
+                                      &PoseDisplay::updateColorAndAlpha);
   alpha_property_->setMin(0);
   alpha_property_->setMax(1);
 
-  shaft_length_property_ = new FloatProperty(
-      "Shaft Length", 1, "Length of the arrow's shaft, in meters.", this, SLOT(updateArrowGeometry()));
+  shaft_length_property_ =
+      new FloatProperty("Shaft Length", 1, "Length of the arrow's shaft, in meters.", this,
+                        &PoseDisplay::updateArrowGeometry);
 
   // aleeper: default changed from 0.1 to match change in arrow.cpp
   shaft_radius_property_ =
       new FloatProperty("Shaft Radius", 0.05, "Radius of the arrow's shaft, in meters.", this,
-                        SLOT(updateArrowGeometry()));
+                        &PoseDisplay::updateArrowGeometry);
 
   head_length_property_ = new FloatProperty("Head Length", 0.3, "Length of the arrow's head, in meters.",
-                                            this, SLOT(updateArrowGeometry()));
+                                            this, &PoseDisplay::updateArrowGeometry);
 
   // aleeper: default changed from 0.2 to match change in arrow.cpp
   head_radius_property_ = new FloatProperty("Head Radius", 0.1, "Radius of the arrow's head, in meters.",
-                                            this, SLOT(updateArrowGeometry()));
+                                            this, &PoseDisplay::updateArrowGeometry);
 
   axes_length_property_ = new FloatProperty("Axes Length", 1, "Length of each axis, in meters.", this,
-                                            SLOT(updateAxisGeometry()));
+                                            &PoseDisplay::updateAxisGeometry);
 
   axes_radius_property_ = new FloatProperty("Axes Radius", 0.1, "Radius of each axis, in meters.", this,
-                                            SLOT(updateAxisGeometry()));
+                                            &PoseDisplay::updateAxisGeometry);
 }
 
 void PoseDisplay::onInitialize()

--- a/src/rviz/default_plugin/pose_with_covariance_display.cpp
+++ b/src/rviz/default_plugin/pose_with_covariance_display.cpp
@@ -159,43 +159,44 @@ private:
 PoseWithCovarianceDisplay::PoseWithCovarianceDisplay() : pose_valid_(false)
 {
   shape_property_ = new EnumProperty("Shape", "Arrow", "Shape to display the pose as.", this,
-                                     SLOT(updateShapeChoice()));
+                                     &PoseWithCovarianceDisplay::updateShapeChoice);
   shape_property_->addOption("Arrow", Arrow);
   shape_property_->addOption("Axes", Axes);
 
   color_property_ = new ColorProperty("Color", QColor(255, 25, 0), "Color to draw the arrow.", this,
-                                      SLOT(updateColorAndAlpha()));
+                                      &PoseWithCovarianceDisplay::updateColorAndAlpha);
 
   alpha_property_ = new FloatProperty("Alpha", 1, "Amount of transparency to apply to the arrow.", this,
-                                      SLOT(updateColorAndAlpha()));
+                                      &PoseWithCovarianceDisplay::updateColorAndAlpha);
   alpha_property_->setMin(0);
   alpha_property_->setMax(1);
 
-  shaft_length_property_ = new FloatProperty(
-      "Shaft Length", 1, "Length of the arrow's shaft, in meters.", this, SLOT(updateArrowGeometry()));
+  shaft_length_property_ =
+      new FloatProperty("Shaft Length", 1, "Length of the arrow's shaft, in meters.", this,
+                        &PoseWithCovarianceDisplay::updateArrowGeometry);
 
   // aleeper: default changed from 0.1 to match change in arrow.cpp
   shaft_radius_property_ =
       new FloatProperty("Shaft Radius", 0.05, "Radius of the arrow's shaft, in meters.", this,
-                        SLOT(updateArrowGeometry()));
+                        &PoseWithCovarianceDisplay::updateArrowGeometry);
 
   head_length_property_ = new FloatProperty("Head Length", 0.3, "Length of the arrow's head, in meters.",
-                                            this, SLOT(updateArrowGeometry()));
+                                            this, &PoseWithCovarianceDisplay::updateArrowGeometry);
 
   // aleeper: default changed from 0.2 to match change in arrow.cpp
   head_radius_property_ = new FloatProperty("Head Radius", 0.1, "Radius of the arrow's head, in meters.",
-                                            this, SLOT(updateArrowGeometry()));
+                                            this, &PoseWithCovarianceDisplay::updateArrowGeometry);
 
   axes_length_property_ = new FloatProperty("Axes Length", 1, "Length of each axis, in meters.", this,
-                                            SLOT(updateAxisGeometry()));
+                                            &PoseWithCovarianceDisplay::updateAxisGeometry);
 
   axes_radius_property_ = new FloatProperty("Axes Radius", 0.1, "Radius of each axis, in meters.", this,
-                                            SLOT(updateAxisGeometry()));
+                                            &PoseWithCovarianceDisplay::updateAxisGeometry);
 
   covariance_property_ =
       new CovarianceProperty("Covariance", true,
                              "Whether or not the covariances of the messages should be shown.", this,
-                             SLOT(queueRender()));
+                             &Display::queueRender);
 }
 
 void PoseWithCovarianceDisplay::onInitialize()

--- a/src/rviz/default_plugin/range_display.cpp
+++ b/src/rviz/default_plugin/range_display.cpp
@@ -46,13 +46,14 @@ namespace rviz
 RangeDisplay::RangeDisplay()
 {
   color_property_ = new ColorProperty("Color", Qt::white, "Color to draw the range.", this,
-                                      SLOT(updateColorAndAlpha()));
+                                      &RangeDisplay::updateColorAndAlpha);
 
   alpha_property_ = new FloatProperty("Alpha", 0.5, "Amount of transparency to apply to the range.",
-                                      this, SLOT(updateColorAndAlpha()));
+                                      this, &RangeDisplay::updateColorAndAlpha);
 
-  buffer_length_property_ = new IntProperty(
-      "Buffer Length", 1, "Number of prior measurements to display.", this, SLOT(updateBufferLength()));
+  buffer_length_property_ =
+      new IntProperty("Buffer Length", 1, "Number of prior measurements to display.", this,
+                      &RangeDisplay::updateBufferLength);
   buffer_length_property_->setMin(1);
 }
 

--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -58,12 +58,12 @@ RobotModelDisplay::RobotModelDisplay()
 {
   visual_enabled_property_ =
       new Property("Visual Enabled", true, "Whether to display the visual representation of the robot.",
-                   this, SLOT(updateVisualVisible()));
+                   this, &RobotModelDisplay::updateVisualVisible);
 
   collision_enabled_property_ =
       new Property("Collision Enabled", false,
                    "Whether to display the collision representation of the robot.", this,
-                   SLOT(updateCollisionVisible()));
+                   &RobotModelDisplay::updateCollisionVisible);
 
   update_rate_property_ = new FloatProperty("Update Interval", 0,
                                             "Interval at which to update the links, in seconds. "
@@ -72,20 +72,20 @@ RobotModelDisplay::RobotModelDisplay()
   update_rate_property_->setMin(0);
 
   alpha_property_ = new FloatProperty("Alpha", 1, "Amount of transparency to apply to the links.", this,
-                                      SLOT(updateAlpha()));
+                                      &RobotModelDisplay::updateAlpha);
   alpha_property_->setMin(0.0);
   alpha_property_->setMax(1.0);
 
   robot_description_property_ =
       new StringProperty("Robot Description", "robot_description",
                          "Name of the parameter to search for to load the robot description.", this,
-                         SLOT(updateRobotDescription()));
+                         &RobotModelDisplay::updateRobotDescription);
 
   tf_prefix_property_ = new StringProperty(
       "TF Prefix", "",
       "Robot Model normally assumes the link name is the same as the tf frame name. "
       " This option allows you to set a prefix.  Mainly useful for multi-robot situations.",
-      this, SLOT(updateTfPrefix()));
+      this, &RobotModelDisplay::updateTfPrefix);
 }
 
 RobotModelDisplay::~RobotModelDisplay()
@@ -155,7 +155,7 @@ void RobotModelDisplay::load()
                   QString("Parameter [%1] does not exist, and was not found by searchParam()")
                       .arg(robot_description_property_->getString()));
         // try again in a second
-        QTimer::singleShot(1000, this, SLOT(updateRobotDescription()));
+        QTimer::singleShot(1000, this, &RobotModelDisplay::updateRobotDescription);
         return;
       }
     }

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -96,7 +96,7 @@ void FrameSelectionHandler::createProperties(const Picked& /*obj*/, Property* pa
       new Property("Frame " + QString::fromStdString(frame_->name_), QVariant(), "", parent_property);
 
   enabled_property_ = new BoolProperty("Enabled", true, "", category_property_,
-                                       SLOT(updateVisibilityFromSelection()), frame_);
+                                       &FrameInfo::updateVisibilityFromSelection, frame_);
 
   parent_property_ = new StringProperty("Parent", "", "", category_property_);
   parent_property_->setReadOnly(true);
@@ -235,15 +235,15 @@ TFDisplay::TFDisplay() : Display(), update_timer_(0.0f), changing_single_frame_e
 {
   show_names_property_ =
       new BoolProperty("Show Names", true, "Whether or not names should be shown next to the frames.",
-                       this, SLOT(updateShowNames()));
+                       this, &TFDisplay::updateShowNames);
 
   show_axes_property_ =
       new BoolProperty("Show Axes", true, "Whether or not the axes of each frame should be shown.", this,
-                       SLOT(updateShowAxes()));
+                       &TFDisplay::updateShowAxes);
 
   show_arrows_property_ = new BoolProperty("Show Arrows", true,
                                            "Whether or not arrows from child to parent should be shown.",
-                                           this, SLOT(updateShowArrows()));
+                                           this, &TFDisplay::updateShowArrows);
 
   scale_property_ =
       new FloatProperty("Marker Scale", 1, "Scaling factor for all names, axes and arrows.", this);
@@ -273,7 +273,7 @@ TFDisplay::TFDisplay() : Display(), update_timer_(0.0f), changing_single_frame_e
 
   all_enabled_property_ =
       new BoolProperty("All Enabled", true, "Whether all the frames should be enabled or not.",
-                       frames_category_, SLOT(allEnabledChanged()), this);
+                       frames_category_, &TFDisplay::allEnabledChanged, this);
 
   tree_category_ = new Property(
       "Tree", QVariant(), "A tree-view of the frames, showing the parent/child relationships.", this);
@@ -508,7 +508,7 @@ FrameInfo* TFDisplay::createFrame(const std::string& frame)
 
   info->enabled_property_ = new BoolProperty(QString::fromStdString(info->name_), true,
                                              "Enable or disable this individual frame.", nullptr,
-                                             SLOT(updateVisibilityFromFrame()), info);
+                                             &FrameInfo::updateVisibilityFromFrame, info);
   frames_category_->insertChildSorted(info->enabled_property_);
 
   info->parent_property_ =

--- a/src/rviz/default_plugin/tools/goal_tool.cpp
+++ b/src/rviz/default_plugin/tools/goal_tool.cpp
@@ -44,7 +44,7 @@ GoalTool::GoalTool()
 
   topic_property_ =
       new StringProperty("Topic", "goal", "The topic on which to publish navigation goals.",
-                         getPropertyContainer(), SLOT(updateTopic()), this);
+                         getPropertyContainer(), &GoalTool::updateTopic, this);
 }
 
 void GoalTool::onInitialize()

--- a/src/rviz/default_plugin/tools/initial_pose_tool.cpp
+++ b/src/rviz/default_plugin/tools/initial_pose_tool.cpp
@@ -45,7 +45,7 @@ InitialPoseTool::InitialPoseTool()
 
   topic_property_ =
       new StringProperty("Topic", "initialpose", "The topic on which to publish initial pose estimates.",
-                         getPropertyContainer(), SLOT(updateTopic()), this);
+                         getPropertyContainer(), &InitialPoseTool::updateTopic, this);
   std_dev_x_ = new FloatProperty("X std deviation", 0.5, "X standard deviation for initial pose [m]",
                                  getPropertyContainer());
   std_dev_y_ = new FloatProperty("Y std deviation", 0.5, "Y standard deviation for initial pose [m]",

--- a/src/rviz/default_plugin/tools/interaction_tool.cpp
+++ b/src/rviz/default_plugin/tools/interaction_tool.cpp
@@ -53,7 +53,7 @@ InteractionTool::InteractionTool()
   hide_inactive_property_ =
       new BoolProperty("Hide Inactive Objects", true,
                        "While holding down a mouse button, hide all other Interactive Objects.",
-                       getPropertyContainer(), SLOT(hideInactivePropertyChanged()), this);
+                       getPropertyContainer(), &InteractionTool::hideInactivePropertyChanged, this);
 }
 
 InteractionTool::~InteractionTool()

--- a/src/rviz/default_plugin/tools/point_tool.cpp
+++ b/src/rviz/default_plugin/tools/point_tool.cpp
@@ -54,11 +54,11 @@ PointTool::PointTool() : Tool()
 
   topic_property_ =
       new StringProperty("Topic", "/clicked_point", "The topic on which to publish points.",
-                         getPropertyContainer(), SLOT(updateTopic()), this);
+                         getPropertyContainer(), &PointTool::updateTopic, this);
 
   auto_deactivate_property_ =
       new BoolProperty("Single click", true, "Switch away from this tool after one click.",
-                       getPropertyContainer(), SLOT(updateAutoDeactivate()), this);
+                       getPropertyContainer(), &PointTool::updateAutoDeactivate, this);
 
   updateTopic();
 }

--- a/src/rviz/default_plugin/view_controllers/fps_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/fps_view_controller.cpp
@@ -52,22 +52,22 @@ FPSViewController::FPSViewController()
   invert_z_->hide();
 
   yaw_property_ = new FloatProperty("Yaw", 0, "Rotation of the camera around the Z (up) axis.", this,
-                                    SLOT(changedOrientation()), this);
+                                    &FPSViewController::changedOrientation, this);
   yaw_property_->setMax(Ogre::Math::PI);
   yaw_property_->setMin(-Ogre::Math::PI);
 
   pitch_property_ = new FloatProperty("Pitch", 0, "How much the camera is tipped downward.", this,
-                                      SLOT(changedOrientation()), this);
+                                      &FPSViewController::changedOrientation, this);
   pitch_property_->setMax(Ogre::Math::PI);
   pitch_property_->setMin(-Ogre::Math::PI);
 
   roll_property_ = new FloatProperty("Roll", 0, "Rotation about the camera's view direction.", this,
-                                     SLOT(changedOrientation()), this);
+                                     &FPSViewController::changedOrientation, this);
   roll_property_->setMax(Ogre::Math::PI);
   roll_property_->setMin(-Ogre::Math::PI);
 
   position_property_ = new VectorProperty("Position", Ogre::Vector3::ZERO, "Position of the camera.",
-                                          this, SLOT(changedPosition()), this);
+                                          this, &FPSViewController::changedPosition, this);
 }
 
 void FPSViewController::onInitialize()

--- a/src/rviz/default_plugin/view_controllers/frame_view_controller.cpp
+++ b/src/rviz/default_plugin/view_controllers/frame_view_controller.cpp
@@ -55,7 +55,7 @@ FrameViewController::FrameViewController()
 {
   axis_property_ = new EnumProperty("Point towards", fmtAxis(6),
                                     "Point the camera along the given axis of the frame.", nullptr,
-                                    SLOT(changedAxis()), this);
+                                    &FrameViewController::changedAxis, this);
   axis_property_->addOption(ANY_AXIS, -1);
   this->addChild(axis_property_, yaw_property_->rowNumberInParent());
   // x,y,z axes get integers from 1..6: +x, -x, +y, -y, +z, -z

--- a/src/rviz/display.cpp
+++ b/src/rviz/display.cpp
@@ -68,7 +68,7 @@ Display::Display()
   // Make the display-enable checkbox show up, and make it unchecked by default.
   setValue(false);
 
-  connect(this, SIGNAL(changed()), this, SLOT(onEnableChanged()));
+  connect(this, &Property::changed, this, &Display::onEnableChanged);
 
   setDisableChildrenIfFalse(true);
 }
@@ -351,9 +351,9 @@ void Display::setAssociatedWidget(QWidget* widget)
 {
   if (associated_widget_panel_)
   {
-    disconnect(associated_widget_panel_, SIGNAL(visibilityChanged(bool)), this,
-               SLOT(associatedPanelVisibilityChange(bool)));
-    disconnect(associated_widget_panel_, SIGNAL(closed()), this, SLOT(disable()));
+    disconnect(associated_widget_panel_, &PanelDockWidget::visibilityChanged, this,
+               &Display::associatedPanelVisibilityChange);
+    disconnect(associated_widget_panel_, &PanelDockWidget::closed, this, &Display::disable);
   }
 
   associated_widget_ = widget;
@@ -363,9 +363,9 @@ void Display::setAssociatedWidget(QWidget* widget)
     if (wm)
     {
       associated_widget_panel_ = wm->addPane(getName(), associated_widget_);
-      connect(associated_widget_panel_, SIGNAL(visibilityChanged(bool)), this,
-              SLOT(associatedPanelVisibilityChange(bool)));
-      connect(associated_widget_panel_, SIGNAL(closed()), this, SLOT(disable()));
+      connect(associated_widget_panel_, &PanelDockWidget::visibilityChanged, this,
+              &Display::associatedPanelVisibilityChange);
+      connect(associated_widget_panel_, &PanelDockWidget::closed, this, &Display::disable);
       associated_widget_panel_->setIcon(getIcon());
     }
     else

--- a/src/rviz/displays_panel.cpp
+++ b/src/rviz/displays_panel.cpp
@@ -85,11 +85,12 @@ DisplaysPanel::DisplaysPanel(QWidget* parent) : Panel(parent)
 
   setLayout(layout);
 
-  connect(add_button, SIGNAL(clicked(bool)), this, SLOT(onNewDisplay()));
-  connect(duplicate_button_, SIGNAL(clicked(bool)), this, SLOT(onDuplicateDisplay()));
-  connect(remove_button_, SIGNAL(clicked(bool)), this, SLOT(onDeleteDisplay()));
-  connect(rename_button_, SIGNAL(clicked(bool)), this, SLOT(onRenameDisplay()));
-  connect(property_grid_, SIGNAL(selectionHasChanged()), this, SLOT(onSelectionChanged()));
+  connect(add_button, &QPushButton::clicked, this, &DisplaysPanel::onNewDisplay);
+  connect(duplicate_button_, &QPushButton::clicked, this, &DisplaysPanel::onDuplicateDisplay);
+  connect(remove_button_, &QPushButton::clicked, this, &DisplaysPanel::onDeleteDisplay);
+  connect(rename_button_, &QPushButton::clicked, this, &DisplaysPanel::onRenameDisplay);
+  connect(property_grid_, &PropertyTreeWidget::selectionHasChanged, this,
+          &DisplaysPanel::onSelectionChanged);
 
   // additionally to buttons, allow shortcuts F2 / Del to rename / remove displays
   rename_action_ = new QAction("Rename", this);
@@ -103,8 +104,8 @@ DisplaysPanel::DisplaysPanel(QWidget* parent) : Panel(parent)
   remove_action_->setEnabled(false);
   tree_with_help_->addAction(remove_action_);
 
-  connect(rename_action_, SIGNAL(triggered(bool)), this, SLOT(onRenameDisplay()));
-  connect(remove_action_, SIGNAL(triggered(bool)), this, SLOT(onDeleteDisplay()));
+  connect(rename_action_, &QAction::triggered, this, &DisplaysPanel::onRenameDisplay);
+  connect(remove_action_, &QAction::triggered, this, &DisplaysPanel::onDeleteDisplay);
 }
 
 DisplaysPanel::~DisplaysPanel()

--- a/src/rviz/frame_position_tracking_view_controller.cpp
+++ b/src/rviz/frame_position_tracking_view_controller.cpp
@@ -73,7 +73,8 @@ void FramePositionTrackingViewController::onActivate()
   // property so that the view does not jump.  Therefore we make the
   // signal/slot connection from the property here in onActivate()
   // instead of in the constructor.
-  connect(target_frame_property_, SIGNAL(changed()), this, SLOT(updateTargetFrame()));
+  connect(target_frame_property_, &Property::changed, this,
+          &FramePositionTrackingViewController::updateTargetFrame);
 }
 
 void FramePositionTrackingViewController::update(float /*dt*/, float /*ros_dt*/)

--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -51,8 +51,8 @@ ImageDisplayBase::ImageDisplayBase() : Display(), sub_(), tf_filter_(), messages
   transport_property_ = new EnumProperty("Transport Hint", "raw", "Preferred method of sending images.",
                                          this, SLOT(updateTopic()));
 
-  connect(transport_property_, SIGNAL(requestOptions(EnumProperty*)), this,
-          SLOT(fillTransportOptionList(EnumProperty*)));
+  connect(transport_property_, &EnumProperty::requestOptions, this,
+          &ImageDisplayBase::fillTransportOptionList);
 
   queue_size_property_ =
       new IntProperty("Queue Size", 2,

--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -43,13 +43,12 @@ namespace rviz
 {
 ImageDisplayBase::ImageDisplayBase() : Display(), sub_(), tf_filter_(), messages_received_(0)
 {
-  topic_property_ =
-      new RosTopicProperty("Image Topic", "",
-                           QString::fromStdString(ros::message_traits::datatype<sensor_msgs::Image>()),
-                           "sensor_msgs::Image topic to subscribe to.", this, SLOT(updateTopic()));
+  topic_property_ = new RosTopicProperty(
+      "Image Topic", "", QString::fromStdString(ros::message_traits::datatype<sensor_msgs::Image>()),
+      "sensor_msgs::Image topic to subscribe to.", this, &ImageDisplayBase::updateTopic);
 
   transport_property_ = new EnumProperty("Transport Hint", "raw", "Preferred method of sending images.",
-                                         this, SLOT(updateTopic()));
+                                         this, &ImageDisplayBase::updateTopic);
 
   connect(transport_property_, &EnumProperty::requestOptions, this,
           &ImageDisplayBase::fillTransportOptionList);
@@ -59,13 +58,13 @@ ImageDisplayBase::ImageDisplayBase() : Display(), sub_(), tf_filter_(), messages
                       "Advanced: set the size of the incoming message queue.  Increasing this "
                       "is useful if your incoming TF data is delayed significantly from your"
                       " image data, but it can greatly increase memory usage if the messages are big.",
-                      this, SLOT(updateQueueSize()));
+                      this, &ImageDisplayBase::updateQueueSize);
   queue_size_property_->setMin(1);
 
   transport_property_->setStdString("raw");
 
-  unreliable_property_ =
-      new BoolProperty("Unreliable", false, "Prefer UDP topic transport", this, SLOT(updateTopic()));
+  unreliable_property_ = new BoolProperty("Unreliable", false, "Prefer UDP topic transport", this,
+                                          &ImageDisplayBase::updateTopic);
 }
 
 ImageDisplayBase::~ImageDisplayBase()

--- a/src/rviz/message_filter_display.h
+++ b/src/rviz/message_filter_display.h
@@ -55,15 +55,15 @@ class RVIZ_EXPORT _RosTopicDisplay : public Display
 public:
   _RosTopicDisplay()
   {
-    topic_property_ = new RosTopicProperty("Topic", "", "", "", this, SLOT(updateTopic()));
-    unreliable_property_ =
-        new BoolProperty("Unreliable", false, "Prefer UDP topic transport", this, SLOT(updateTopic()));
+    topic_property_ = new RosTopicProperty("Topic", "", "", "", this, &_RosTopicDisplay::updateTopic);
+    unreliable_property_ = new BoolProperty("Unreliable", false, "Prefer UDP topic transport", this,
+                                            &_RosTopicDisplay::updateTopic);
     queue_size_property_ =
         new IntProperty("Queue Size", 10,
                         "Size of TF message filter queue.\n"
                         "Increasing this is useful if your TF data is delayed significantly "
                         "w.r.t. your data, but it can greatly increase memory usage as well.",
-                        this, SLOT(updateQueueSize()));
+                        this, &_RosTopicDisplay::updateQueueSize);
     queue_size_property_->setMin(0);
     qRegisterMetaType<boost::shared_ptr<const void>>(); // required to send via queued connection
   }

--- a/src/rviz/new_object_dialog.cpp
+++ b/src/rviz/new_object_dialog.cpp
@@ -107,15 +107,14 @@ NewObjectDialog::NewObjectDialog(Factory* factory,
   setLayout(main_layout);
 
   //***** Connections
-  connect(tree, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this,
-          SLOT(onDisplaySelected(QTreeWidgetItem*)));
-  connect(tree, SIGNAL(itemActivated(QTreeWidgetItem*, int)), this, SLOT(accept()));
-  connect(button_box_, SIGNAL(accepted()), this, SLOT(accept()));
-  connect(button_box_, SIGNAL(rejected()), this, SLOT(reject()));
+  connect(tree, &QTreeWidget::currentItemChanged, this, &NewObjectDialog::onDisplaySelected);
+  connect(tree, &QTreeWidget::itemActivated, this, &NewObjectDialog::accept);
+  connect(button_box_, &QDialogButtonBox::accepted, this, &NewObjectDialog::accept);
+  connect(button_box_, &QDialogButtonBox::rejected, this, &NewObjectDialog::reject);
 
   if (display_name_output_)
   {
-    connect(name_editor_, SIGNAL(textEdited(const QString&)), this, SLOT(onNameChanged()));
+    connect(name_editor_, &QLineEdit::textEdited, this, &NewObjectDialog::onNameChanged);
   }
 }
 

--- a/src/rviz/panel_dock_widget.cpp
+++ b/src/rviz/panel_dock_widget.cpp
@@ -53,7 +53,7 @@ PanelDockWidget::PanelDockWidget(const QString& name)
   close_button->setIcon(QIcon::fromTheme("window-close"));
   close_button->setIconSize(QSize(10, 10));
 
-  connect(close_button, SIGNAL(clicked()), this, SLOT(close()));
+  connect(close_button, &QToolButton::clicked, this, &PanelDockWidget::close);
 
   title_label_ = new QLabel(name, this);
 
@@ -115,12 +115,12 @@ void PanelDockWidget::setContentWidget(QWidget* child)
 {
   if (widget())
   {
-    disconnect(widget(), SIGNAL(destroyed(QObject*)), this, SLOT(onChildDestroyed(QObject*)));
+    disconnect(widget(), &QObject::destroyed, this, &PanelDockWidget::onChildDestroyed);
   }
   setWidget(child);
   if (child)
   {
-    connect(child, SIGNAL(destroyed(QObject*)), this, SLOT(onChildDestroyed(QObject*)));
+    connect(child, &QObject::destroyed, this, &PanelDockWidget::onChildDestroyed);
   }
 }
 

--- a/src/rviz/preferences_dialog.cpp
+++ b/src/rviz/preferences_dialog.cpp
@@ -63,8 +63,8 @@ PreferencesDialog::PreferencesDialog(Factory* factory, Preferences* preferences_
   setLayout(main_layout);
 
   //***** Connections
-  connect(button_box_, SIGNAL(accepted()), this, SLOT(accept()));
-  connect(button_box_, SIGNAL(rejected()), this, SLOT(reject()));
+  connect(button_box_, &QDialogButtonBox::accepted, this, &PreferencesDialog::accept);
+  connect(button_box_, &QDialogButtonBox::rejected, this, &PreferencesDialog::reject);
 }
 
 QSize PreferencesDialog::sizeHint() const

--- a/src/rviz/properties/bool_property.cpp
+++ b/src/rviz/properties/bool_property.cpp
@@ -36,11 +36,8 @@ namespace rviz
 BoolProperty::BoolProperty(const QString& name,
                            bool default_value,
                            const QString& description,
-                           Property* parent,
-                           const char* changed_slot,
-                           QObject* receiver)
-  : Property(name, default_value, description, parent, changed_slot, receiver)
-  , disable_children_if_false_(false)
+                           Property* parent)
+  : Property(name, default_value, description, parent), disable_children_if_false_(false)
 {
 }
 

--- a/src/rviz/properties/bool_property.h
+++ b/src/rviz/properties/bool_property.h
@@ -42,9 +42,31 @@ public:
   BoolProperty(const QString& name = QString(),
                bool default_value = false,
                const QString& description = QString(),
-               Property* parent = nullptr,
-               const char* changed_slot = nullptr,
-               QObject* receiver = nullptr);
+               Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  BoolProperty(const QString& name,
+               bool default_value,
+               const QString& description,
+               Property* parent,
+               Func&& changed_slot,
+               const R* receiver)
+    : BoolProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  BoolProperty(const QString& name,
+               bool default_value,
+               const QString& description,
+               P* parent,
+               Func&& changed_slot)
+    : BoolProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   ~BoolProperty() override;
 

--- a/src/rviz/properties/color_editor.cpp
+++ b/src/rviz/properties/color_editor.cpp
@@ -44,7 +44,7 @@ namespace rviz
 ColorEditor::ColorEditor(ColorProperty* property, QWidget* parent)
   : LineEditWithButton(parent), property_(property)
 {
-  connect(this, SIGNAL(textChanged(const QString&)), this, SLOT(parseText()));
+  connect(this, &QLineEdit::textChanged, this, &ColorEditor::parseText);
 }
 
 void ColorEditor::paintEvent(QPaintEvent* event)
@@ -111,17 +111,15 @@ void ColorEditor::onButtonClick()
 
   QColorDialog dialog(color_, window());
 
-  connect(&dialog, SIGNAL(currentColorChanged(const QColor&)), property_, SLOT(setColor(const QColor&)));
+  connect(&dialog, &QColorDialog::currentColorChanged, property_, &ColorProperty::setColor);
 
   // Without this connection the PropertyTreeWidget does not update
-  // the color info "live" when it changes in the dialog and the 3D
-  // view.
-  connect(&dialog, SIGNAL(currentColorChanged(const QColor&)), parentWidget(), SLOT(update()));
+  // the color info "live" when it changes in the dialog and the 3D view.
+  connect(&dialog, &QColorDialog::currentColorChanged, [this]() { parentWidget()->update(); });
 
-  // On the TWM window manager under linux, and on OSX, this
-  // ColorEditor object is destroyed when (or soon after) the dialog
-  // opens.  Therefore, here we delete this ColorEditor immediately to
-  // force them all to act the same.
+  // On the TWM window manager under linux, and on OSX, this ColorEditor object is destroyed
+  // when (or soon after) the dialog opens.
+  // Therefore, here we delete this ColorEditor immediately to force them all to act the same.
   deleteLater();
 
   // dialog->exec() will call an event loop internally, so

--- a/src/rviz/properties/color_property.cpp
+++ b/src/rviz/properties/color_property.cpp
@@ -41,10 +41,8 @@ namespace rviz
 ColorProperty::ColorProperty(const QString& name,
                              const QColor& default_value,
                              const QString& description,
-                             Property* parent,
-                             const char* changed_slot,
-                             QObject* receiver)
-  : Property(name, QVariant(), description, parent, changed_slot, receiver), color_(default_value)
+                             Property* parent)
+  : Property(name, QVariant(), description, parent), color_(default_value)
 {
   updateString();
 }

--- a/src/rviz/properties/color_property.h
+++ b/src/rviz/properties/color_property.h
@@ -44,9 +44,31 @@ public:
   ColorProperty(const QString& name = QString(),
                 const QColor& default_value = Qt::black,
                 const QString& description = QString(),
-                Property* parent = nullptr,
-                const char* changed_slot = nullptr,
-                QObject* receiver = nullptr);
+                Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  ColorProperty(const QString& name,
+                const QColor& default_value,
+                const QString& description,
+                Property* parent,
+                Func&& changed_slot,
+                const R* receiver)
+    : ColorProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  ColorProperty(const QString& name,
+                const QColor& default_value,
+                const QString& description,
+                P* parent,
+                Func&& changed_slot)
+    : ColorProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   bool setValue(const QVariant& new_value) override;
 

--- a/src/rviz/properties/display_group_visibility_property.cpp
+++ b/src/rviz/properties/display_group_visibility_property.cpp
@@ -63,10 +63,10 @@ DisplayGroupVisibilityProperty::DisplayGroupVisibilityProperty(uint32_t vis_bit,
   , display_group_(display_group)
   , parent_display_(parent_display)
 {
-  connect(display_group, SIGNAL(displayAdded(rviz::Display*)), this,
-          SLOT(onDisplayAdded(rviz::Display*)));
-  connect(display_group, SIGNAL(displayRemoved(rviz::Display*)), this,
-          SLOT(onDisplayRemoved(rviz::Display*)));
+  connect(display_group, &DisplayGroup::displayAdded, this,
+          &DisplayGroupVisibilityProperty::onDisplayAdded);
+  connect(display_group, &DisplayGroup::displayRemoved, this,
+          &DisplayGroupVisibilityProperty::onDisplayRemoved);
 
   for (int i = 0; i < display_group->numDisplays(); i++)
   {

--- a/src/rviz/properties/display_group_visibility_property.cpp
+++ b/src/rviz/properties/display_group_visibility_property.cpp
@@ -49,17 +49,8 @@ DisplayGroupVisibilityProperty::DisplayGroupVisibilityProperty(uint32_t vis_bit,
                                                                const QString& name,
                                                                bool default_value,
                                                                const QString& description,
-                                                               Property* parent,
-                                                               const char* changed_slot,
-                                                               QObject* receiver)
-  : DisplayVisibilityProperty(vis_bit,
-                              display_group,
-                              name,
-                              default_value,
-                              description,
-                              parent,
-                              changed_slot,
-                              receiver)
+                                                               Property* parent)
+  : DisplayVisibilityProperty(vis_bit, display_group, name, default_value, description, parent)
   , display_group_(display_group)
   , parent_display_(parent_display)
 {

--- a/src/rviz/properties/display_group_visibility_property.h
+++ b/src/rviz/properties/display_group_visibility_property.h
@@ -68,9 +68,48 @@ public:
                                  const QString& name = QString(),
                                  bool default_value = false,
                                  const QString& description = QString(),
-                                 Property* parent = nullptr,
-                                 const char* changed_slot = nullptr,
-                                 QObject* receiver = nullptr);
+                                 Property* parent = nullptr);
+  template <typename Func, typename R>
+  DisplayGroupVisibilityProperty(uint32_t vis_bit,
+                                 DisplayGroup* display_group,
+                                 Display* parent_display,
+                                 const QString& name,
+                                 bool default_value,
+                                 const QString& description,
+                                 Property* parent,
+                                 Func&& changed_slot,
+                                 const R* receiver)
+    : DisplayGroupVisibilityProperty(vis_bit,
+                                     display_group,
+                                     parent_display,
+                                     name,
+                                     default_value,
+                                     description,
+                                     parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  DisplayGroupVisibilityProperty(uint32_t vis_bit,
+                                 DisplayGroup* display_group,
+                                 Display* parent_display,
+                                 const QString& name,
+                                 bool default_value,
+                                 const QString& description,
+                                 P* parent,
+                                 Func&& changed_slot)
+    : DisplayGroupVisibilityProperty(vis_bit,
+                                     display_group,
+                                     parent_display,
+                                     name,
+                                     default_value,
+                                     description,
+                                     parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
   ~DisplayGroupVisibilityProperty() override;
 
   // @brief Update visibility masks of all objects in the Ogre scene

--- a/src/rviz/properties/display_visibility_property.cpp
+++ b/src/rviz/properties/display_visibility_property.cpp
@@ -42,12 +42,8 @@ DisplayVisibilityProperty::DisplayVisibilityProperty(uint32_t vis_bit,
                                                      const QString& name,
                                                      bool default_value,
                                                      const QString& description,
-                                                     Property* parent,
-                                                     const char* changed_slot,
-                                                     QObject* receiver)
-  : BoolProperty(name, default_value, description, parent, changed_slot, receiver)
-  , vis_bit_(vis_bit)
-  , display_(display)
+                                                     Property* parent)
+  : BoolProperty(name, default_value, description, parent), vis_bit_(vis_bit), display_(display)
 {
   custom_name_ = (name.size() != 0);
   DisplayVisibilityProperty::update();

--- a/src/rviz/properties/display_visibility_property.h
+++ b/src/rviz/properties/display_visibility_property.h
@@ -61,9 +61,35 @@ public:
                             const QString& name = QString(),
                             bool default_value = false,
                             const QString& description = QString(),
-                            Property* parent = nullptr,
-                            const char* changed_slot = nullptr,
-                            QObject* receiver = nullptr);
+                            Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  DisplayVisibilityProperty(uint32_t vis_bit,
+                            Display* display,
+                            const QString& name,
+                            bool default_value,
+                            const QString& description,
+                            Property* parent,
+                            Func&& changed_slot,
+                            const R* receiver)
+    : DisplayVisibilityProperty(vis_bit, display, name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  DisplayVisibilityProperty(uint32_t vis_bit,
+                            Display* display,
+                            const QString& name,
+                            bool default_value,
+                            const QString& description,
+                            P* parent,
+                            Func&& changed_slot)
+    : DisplayVisibilityProperty(vis_bit, display, name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   ~DisplayVisibilityProperty() override;
 

--- a/src/rviz/properties/editable_enum_property.cpp
+++ b/src/rviz/properties/editable_enum_property.cpp
@@ -37,10 +37,8 @@ namespace rviz
 EditableEnumProperty::EditableEnumProperty(const QString& name,
                                            const QString& default_value,
                                            const QString& description,
-                                           Property* parent,
-                                           const char* changed_slot,
-                                           QObject* receiver)
-  : StringProperty(name, default_value, description, parent, changed_slot, receiver)
+                                           Property* parent)
+  : StringProperty(name, default_value, description, parent)
 {
 }
 

--- a/src/rviz/properties/editable_enum_property.cpp
+++ b/src/rviz/properties/editable_enum_property.cpp
@@ -66,8 +66,8 @@ QWidget* EditableEnumProperty::createEditor(QWidget* parent, const QStyleOptionV
   cb->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
   cb->addItems(strings_);
   cb->setEditText(getValue().toString());
-  QObject::connect(cb, SIGNAL(currentIndexChanged(const QString&)), this,
-                   SLOT(setString(const QString&)));
+  QObject::connect(cb, qOverload<const QString&>(&QComboBox::currentIndexChanged), this,
+                   &EditableEnumProperty::setString);
 
   // TODO: need to better handle string value which is not in list.
   return cb;

--- a/src/rviz/properties/editable_enum_property.h
+++ b/src/rviz/properties/editable_enum_property.h
@@ -47,9 +47,31 @@ public:
   EditableEnumProperty(const QString& name = QString(),
                        const QString& default_value = QString(),
                        const QString& description = QString(),
-                       Property* parent = nullptr,
-                       const char* changed_slot = nullptr,
-                       QObject* receiver = nullptr);
+                       Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  EditableEnumProperty(const QString& name,
+                       const QString& default_value,
+                       const QString& description,
+                       Property* parent,
+                       Func&& changed_slot,
+                       const R* receiver)
+    : EditableEnumProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  EditableEnumProperty(const QString& name,
+                       const QString& default_value,
+                       const QString& description,
+                       P* parent,
+                       Func&& changed_slot)
+    : EditableEnumProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   virtual void clearOptions();
   virtual void addOption(const QString& option);

--- a/src/rviz/properties/enum_property.cpp
+++ b/src/rviz/properties/enum_property.cpp
@@ -36,10 +36,8 @@ namespace rviz
 EnumProperty::EnumProperty(const QString& name,
                            const QString& default_value,
                            const QString& description,
-                           Property* parent,
-                           const char* changed_slot,
-                           QObject* receiver)
-  : StringProperty(name, default_value, description, parent, changed_slot, receiver)
+                           Property* parent)
+  : StringProperty(name, default_value, description, parent)
 {
 }
 

--- a/src/rviz/properties/enum_property.cpp
+++ b/src/rviz/properties/enum_property.cpp
@@ -74,8 +74,8 @@ QWidget* EnumProperty::createEditor(QWidget* parent, const QStyleOptionViewItem&
   ComboBox* cb = new ComboBox(parent);
   cb->addItems(strings_);
   cb->setCurrentIndex(strings_.indexOf(getValue().toString()));
-  QObject::connect(cb, SIGNAL(currentIndexChanged(const QString&)), this,
-                   SLOT(setString(const QString&)));
+  QObject::connect(cb, qOverload<const QString&>(&QComboBox::currentIndexChanged), this,
+                   &EnumProperty::setString);
 
   // TODO: need to better handle string value which is not in list.
   return cb;

--- a/src/rviz/properties/enum_property.h
+++ b/src/rviz/properties/enum_property.h
@@ -50,9 +50,31 @@ public:
   EnumProperty(const QString& name = QString(),
                const QString& default_value = QString(),
                const QString& description = QString(),
-               Property* parent = nullptr,
-               const char* changed_slot = nullptr,
-               QObject* receiver = nullptr);
+               Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  EnumProperty(const QString& name,
+               const QString& default_value,
+               const QString& description,
+               Property* parent,
+               Func&& changed_slot,
+               const R* receiver)
+    : EnumProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  EnumProperty(const QString& name,
+               const QString& default_value,
+               const QString& description,
+               P* parent,
+               Func&& changed_slot)
+    : EnumProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   /** @brief Clear the list of options.
    *

--- a/src/rviz/properties/float_edit.cpp
+++ b/src/rviz/properties/float_edit.cpp
@@ -38,7 +38,7 @@ FloatEdit::FloatEdit(QWidget* parent) : QLineEdit(parent)
 {
   setFrame(false);
   setValidator(new QDoubleValidator(this));
-  connect(this, SIGNAL(textEdited(const QString&)), this, SLOT(updateValue()));
+  connect(this, &FloatEdit::textEdited, this, &FloatEdit::updateValue);
 }
 
 void FloatEdit::setValue(float new_value)

--- a/src/rviz/properties/float_property.cpp
+++ b/src/rviz/properties/float_property.cpp
@@ -38,12 +38,8 @@ namespace rviz
 FloatProperty::FloatProperty(const QString& name,
                              float default_value,
                              const QString& description,
-                             Property* parent,
-                             const char* changed_slot,
-                             QObject* receiver)
-  : Property(name, default_value, description, parent, changed_slot, receiver)
-  , min_(-FLT_MAX)
-  , max_(FLT_MAX)
+                             Property* parent)
+  : Property(name, default_value, description, parent), min_(-FLT_MAX), max_(FLT_MAX)
 {
 }
 

--- a/src/rviz/properties/float_property.h
+++ b/src/rviz/properties/float_property.h
@@ -41,9 +41,31 @@ public:
   FloatProperty(const QString& name = QString(),
                 float default_value = 0,
                 const QString& description = QString(),
-                Property* parent = nullptr,
-                const char* changed_slot = nullptr,
-                QObject* receiver = nullptr);
+                Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  FloatProperty(const QString& name,
+                float default_value,
+                const QString& description,
+                Property* parent,
+                Func&& changed_slot,
+                const R* receiver)
+    : FloatProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  FloatProperty(const QString& name,
+                float default_value,
+                const QString& description,
+                P* parent,
+                Func&& changed_slot)
+    : FloatProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   /** @brief Set the new value for this property.  Returns true if the
    * new value is different from the old value, false if same.

--- a/src/rviz/properties/int_property.cpp
+++ b/src/rviz/properties/int_property.cpp
@@ -70,7 +70,7 @@ QWidget* IntProperty::createEditor(QWidget* parent, const QStyleOptionViewItem& 
   QSpinBox* editor = new QSpinBox(parent);
   editor->setFrame(false);
   editor->setRange(min_, max_);
-  connect(editor, SIGNAL(valueChanged(int)), this, SLOT(setInt(int)));
+  connect(editor, qOverload<int>(&QSpinBox::valueChanged), this, &IntProperty::setInt);
   return editor;
 }
 

--- a/src/rviz/properties/int_property.cpp
+++ b/src/rviz/properties/int_property.cpp
@@ -39,12 +39,8 @@ namespace rviz
 IntProperty::IntProperty(const QString& name,
                          int default_value,
                          const QString& description,
-                         Property* parent,
-                         const char* changed_slot,
-                         QObject* receiver)
-  : Property(name, default_value, description, parent, changed_slot, receiver)
-  , min_(INT_MIN)
-  , max_(INT_MAX)
+                         Property* parent)
+  : Property(name, default_value, description, parent), min_(INT_MIN), max_(INT_MAX)
 {
 }
 

--- a/src/rviz/properties/int_property.h
+++ b/src/rviz/properties/int_property.h
@@ -54,9 +54,31 @@ public:
   IntProperty(const QString& name = QString(),
               int default_value = 0,
               const QString& description = QString(),
-              Property* parent = nullptr,
-              const char* changed_slot = nullptr,
-              QObject* receiver = nullptr);
+              Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  IntProperty(const QString& name,
+              int default_value,
+              const QString& description,
+              Property* parent,
+              Func&& changed_slot,
+              const R* receiver)
+    : IntProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  IntProperty(const QString& name,
+              int default_value,
+              const QString& description,
+              P* parent,
+              Func&& changed_slot)
+    : IntProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   /** @brief Set the new value for this property.  Returns true if the
    * new value is different from the old value, false if same.

--- a/src/rviz/properties/line_edit_with_button.cpp
+++ b/src/rviz/properties/line_edit_with_button.cpp
@@ -46,7 +46,7 @@ LineEditWithButton::LineEditWithButton(QWidget* parent) : QLineEdit(parent)
   button_->setAutoDefault(false);
   button_->setFocusPolicy(Qt::NoFocus);
 
-  connect(button_, SIGNAL(clicked()), this, SLOT(onButtonClick()));
+  connect(button_, &QPushButton::clicked, this, &LineEditWithButton::onButtonClick);
 }
 
 void LineEditWithButton::resizeEvent(QResizeEvent* event)

--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -72,17 +72,20 @@ Property::Property(const QString& name,
 {
   Property::setName(name);
   if (parent)
-  {
     parent->addChild(this);
-  }
-  if (receiver == nullptr)
-  {
-    receiver = parent;
-  }
-  if (receiver && changed_slot)
-  {
-    connect(this, SIGNAL(changed()), receiver, changed_slot);
-  }
+
+  connect(receiver, changed_slot);
+}
+
+QMetaObject::Connection
+Property::connect(const QObject* receiver, const char* slot, Qt::ConnectionType type)
+{
+  if (!receiver)
+    receiver = parent_;
+  if (receiver && slot)
+    return QObject::connect(this, SIGNAL(changed()), receiver, slot, type);
+  else
+    return QMetaObject::Connection();
 }
 
 Property::~Property()

--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -58,9 +58,7 @@ Property* Property::failprop_ = new FailureProperty;
 Property::Property(const QString& name,
                    const QVariant& default_value,
                    const QString& description,
-                   Property* parent,
-                   const char* changed_slot,
-                   QObject* receiver)
+                   Property* parent)
   : value_(default_value)
   , model_(nullptr)
   , child_indexes_valid_(false)
@@ -73,8 +71,6 @@ Property::Property(const QString& name,
   Property::setName(name);
   if (parent)
     parent->addChild(this);
-
-  connect(receiver, changed_slot);
 }
 
 QMetaObject::Connection

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -132,9 +132,31 @@ public:
   Property(const QString& name = QString(),
            const QVariant& default_value = QVariant(),
            const QString& description = QString(),
-           Property* parent = nullptr,
-           const char* changed_slot = nullptr,
-           QObject* receiver = nullptr);
+           Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  Property(const QString& name,
+           const QVariant& default_value,
+           const QString& description,
+           Property* parent,
+           Func&& changed_slot,
+           const R* receiver)
+    : Property(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  Property(const QString& name,
+           const QVariant& default_value,
+           const QString& description,
+           P* parent,
+           Func&& changed_slot)
+    : Property(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   using QObject::connect; // inherit QObject's connect functions
 

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -136,6 +136,40 @@ public:
            const char* changed_slot = nullptr,
            QObject* receiver = nullptr);
 
+  using QObject::connect; // inherit QObject's connect functions
+
+  /// Connect changed() signal to given slot of receiver
+  QMetaObject::Connection
+  connect(const QObject* receiver, const char* slot, Qt::ConnectionType type = Qt::AutoConnection);
+
+  /// Connect changed() signal to given slot member function of receiver object
+  template <typename Func>
+  inline QMetaObject::Connection
+  connect(const typename QtPrivate::FunctionPointer<Func>::Object* receiver,
+          Func&& slot,
+          Qt::ConnectionType type = Qt::AutoConnection)
+  {
+    return QObject::connect(this, &Property::changed, receiver, std::forward<Func>(slot), type);
+  }
+
+  /// Connect changed() signal to given slot functor, considering context
+  template <typename Func>
+  inline typename std::enable_if<!QtPrivate::FunctionPointer<Func>::IsPointerToMemberFunction,
+                                 QMetaObject::Connection>::type
+  connect(const QObject* context, Func&& slot, Qt::ConnectionType type = Qt::AutoConnection)
+  {
+    return QObject::connect(this, &Property::changed, context, std::forward<Func>(slot), type);
+  }
+
+  /// Connect changed() signal to given slot functor, using this as context
+  template <typename Func>
+  inline typename std::enable_if<!QtPrivate::FunctionPointer<Func>::IsPointerToMemberFunction,
+                                 QMetaObject::Connection>::type
+  connect(Func&& slot, Qt::ConnectionType type = Qt::AutoConnection)
+  {
+    return QObject::connect(this, &Property::changed, this, std::forward<Func>(slot), type);
+  }
+
   /** @brief Destructor.  Removes this property from its parent's list
    * of children.
    */

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -161,6 +161,9 @@ public:
   using QObject::connect; // inherit QObject's connect functions
 
   /// Connect changed() signal to given slot of receiver
+#ifdef RVIZ_DEPRECATE_QT4_SLOTS
+  [[deprecated("Switch to modern function/functor based slot specification")]]
+#endif
   QMetaObject::Connection
   connect(const QObject* receiver, const char* slot, Qt::ConnectionType type = Qt::AutoConnection);
 

--- a/src/rviz/properties/property.h
+++ b/src/rviz/properties/property.h
@@ -165,12 +165,13 @@ public:
   connect(const QObject* receiver, const char* slot, Qt::ConnectionType type = Qt::AutoConnection);
 
   /// Connect changed() signal to given slot member function of receiver object
-  template <typename Func>
-  inline QMetaObject::Connection
-  connect(const typename QtPrivate::FunctionPointer<Func>::Object* receiver,
-          Func&& slot,
-          Qt::ConnectionType type = Qt::AutoConnection)
+  template <typename Func, typename R>
+  inline typename std::enable_if<QtPrivate::FunctionPointer<Func>::IsPointerToMemberFunction,
+                                 QMetaObject::Connection>::type
+  connect(const R* receiver, Func&& slot, Qt::ConnectionType type = Qt::AutoConnection)
   {
+    static_assert(std::is_convertible<R*, typename QtPrivate::FunctionPointer<Func>::Object*>::value,
+                  "receiver type doesn't match that expected by member function");
     return QObject::connect(this, &Property::changed, receiver, std::forward<Func>(slot), type);
   }
 

--- a/src/rviz/properties/property_tree_widget.cpp
+++ b/src/rviz/properties/property_tree_widget.cpp
@@ -73,7 +73,7 @@ PropertyTreeWidget::PropertyTreeWidget(QWidget* parent)
   setEditTriggers(QAbstractItemView::AllEditTriggers);
 
   QTimer* timer = new QTimer(this);
-  connect(timer, SIGNAL(timeout()), this, SLOT(update()));
+  connect(timer, &QTimer::timeout, this, [this] { update(); });
   timer->start(100);
 }
 
@@ -95,10 +95,10 @@ void PropertyTreeWidget::setModel(PropertyTreeModel* model)
 {
   if (model_)
   {
-    disconnect(model_, SIGNAL(propertyHiddenChanged(const Property*)), this,
-               SLOT(propertyHiddenChanged(const Property*)));
-    disconnect(model_, SIGNAL(expand(const QModelIndex&)), this, SLOT(expand(const QModelIndex&)));
-    disconnect(model_, SIGNAL(collapse(const QModelIndex&)), this, SLOT(collapse(const QModelIndex&)));
+    disconnect(model_, &PropertyTreeModel::propertyHiddenChanged, this,
+               &PropertyTreeWidget::propertyHiddenChanged);
+    disconnect(model_, &PropertyTreeModel::expand, this, &PropertyTreeWidget::expand);
+    disconnect(model_, &PropertyTreeModel::collapse, this, &PropertyTreeWidget::collapse);
   }
   model_ = model;
   QTreeView::setModel(model_);
@@ -108,10 +108,10 @@ void PropertyTreeWidget::setModel(PropertyTreeModel* model)
     setSelectionModel(new PropertySelectionModel(model_));
     m->deleteLater();
 
-    connect(model_, SIGNAL(propertyHiddenChanged(const Property*)), this,
-            SLOT(propertyHiddenChanged(const Property*)), Qt::QueuedConnection);
-    connect(model_, SIGNAL(expand(const QModelIndex&)), this, SLOT(expand(const QModelIndex&)));
-    connect(model_, SIGNAL(collapse(const QModelIndex&)), this, SLOT(collapse(const QModelIndex&)));
+    connect(model_, &PropertyTreeModel::propertyHiddenChanged, this,
+            &PropertyTreeWidget::propertyHiddenChanged, Qt::QueuedConnection);
+    connect(model_, &PropertyTreeModel::expand, this, &PropertyTreeWidget::expand);
+    connect(model_, &PropertyTreeModel::collapse, this, &PropertyTreeWidget::collapse);
 
     // this will trigger all hiddenChanged events to get re-fired
     model_->getRoot()->setModel(model_->getRoot()->getModel());

--- a/src/rviz/properties/property_tree_with_help.cpp
+++ b/src/rviz/properties/property_tree_with_help.cpp
@@ -56,8 +56,8 @@ PropertyTreeWithHelp::PropertyTreeWithHelp(QWidget* parent) : QSplitter(parent)
   _sizes.push_back(1);
   setSizes(_sizes);
 
-  connect(property_tree_, SIGNAL(currentPropertyChanged(const Property*)), this,
-          SLOT(showHelpForProperty(const Property*)));
+  connect(property_tree_, &PropertyTreeWidget::currentPropertyChanged, this,
+          &PropertyTreeWithHelp::showHelpForProperty);
 }
 
 void PropertyTreeWithHelp::showHelpForProperty(const Property* property)

--- a/src/rviz/properties/quaternion_property.cpp
+++ b/src/rviz/properties/quaternion_property.cpp
@@ -37,10 +37,8 @@ namespace rviz
 QuaternionProperty::QuaternionProperty(const QString& name,
                                        const Ogre::Quaternion& default_value,
                                        const QString& description,
-                                       Property* parent,
-                                       const char* changed_slot,
-                                       QObject* receiver)
-  : Property(name, QVariant(), description, parent, changed_slot, receiver)
+                                       Property* parent)
+  : Property(name, QVariant(), description, parent)
   , quaternion_(default_value)
   , ignore_child_updates_(false)
 {

--- a/src/rviz/properties/quaternion_property.cpp
+++ b/src/rviz/properties/quaternion_property.cpp
@@ -49,14 +49,14 @@ QuaternionProperty::QuaternionProperty(const QString& name,
   z_ = new Property("Z", quaternion_.z, "Z coordinate", this);
   w_ = new Property("W", quaternion_.w, "W coordinate", this);
   updateString();
-  connect(x_, SIGNAL(aboutToChange()), this, SLOT(emitAboutToChange()));
-  connect(y_, SIGNAL(aboutToChange()), this, SLOT(emitAboutToChange()));
-  connect(z_, SIGNAL(aboutToChange()), this, SLOT(emitAboutToChange()));
-  connect(w_, SIGNAL(aboutToChange()), this, SLOT(emitAboutToChange()));
-  connect(x_, SIGNAL(changed()), this, SLOT(updateFromChildren()));
-  connect(y_, SIGNAL(changed()), this, SLOT(updateFromChildren()));
-  connect(z_, SIGNAL(changed()), this, SLOT(updateFromChildren()));
-  connect(w_, SIGNAL(changed()), this, SLOT(updateFromChildren()));
+  connect(x_, &Property::aboutToChange, this, &QuaternionProperty::emitAboutToChange);
+  connect(y_, &Property::aboutToChange, this, &QuaternionProperty::emitAboutToChange);
+  connect(z_, &Property::aboutToChange, this, &QuaternionProperty::emitAboutToChange);
+  connect(w_, &Property::aboutToChange, this, &QuaternionProperty::emitAboutToChange);
+  connect(x_, &Property::changed, this, &QuaternionProperty::updateFromChildren);
+  connect(y_, &Property::changed, this, &QuaternionProperty::updateFromChildren);
+  connect(z_, &Property::changed, this, &QuaternionProperty::updateFromChildren);
+  connect(w_, &Property::changed, this, &QuaternionProperty::updateFromChildren);
 }
 
 bool QuaternionProperty::setQuaternion(const Ogre::Quaternion& new_quaternion)

--- a/src/rviz/properties/quaternion_property.h
+++ b/src/rviz/properties/quaternion_property.h
@@ -42,9 +42,31 @@ public:
   QuaternionProperty(const QString& name = QString(),
                      const Ogre::Quaternion& default_value = Ogre::Quaternion::IDENTITY,
                      const QString& description = QString(),
-                     Property* parent = nullptr,
-                     const char* changed_slot = nullptr,
-                     QObject* receiver = nullptr);
+                     Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  QuaternionProperty(const QString& name,
+                     const Ogre::Quaternion& default_value,
+                     const QString& description,
+                     Property* parent,
+                     Func&& changed_slot,
+                     const R* receiver)
+    : QuaternionProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  QuaternionProperty(const QString& name,
+                     const Ogre::Quaternion& default_value,
+                     const QString& description,
+                     P* parent,
+                     Func&& changed_slot)
+    : QuaternionProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   virtual bool setQuaternion(const Ogre::Quaternion& quaternion);
   virtual Ogre::Quaternion getQuaternion() const

--- a/src/rviz/properties/ros_topic_property.cpp
+++ b/src/rviz/properties/ros_topic_property.cpp
@@ -40,11 +40,8 @@ RosTopicProperty::RosTopicProperty(const QString& name,
                                    const QString& default_value,
                                    const QString& message_type,
                                    const QString& description,
-                                   Property* parent,
-                                   const char* changed_slot,
-                                   QObject* receiver)
-  : EditableEnumProperty(name, default_value, description, parent, changed_slot, receiver)
-  , message_type_(message_type)
+                                   Property* parent)
+  : EditableEnumProperty(name, default_value, description, parent), message_type_(message_type)
 {
   connect(this, &EditableEnumProperty::requestOptions, this, &RosTopicProperty::fillTopicList);
 }

--- a/src/rviz/properties/ros_topic_property.cpp
+++ b/src/rviz/properties/ros_topic_property.cpp
@@ -46,7 +46,7 @@ RosTopicProperty::RosTopicProperty(const QString& name,
   : EditableEnumProperty(name, default_value, description, parent, changed_slot, receiver)
   , message_type_(message_type)
 {
-  connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillTopicList()));
+  connect(this, &EditableEnumProperty::requestOptions, this, &RosTopicProperty::fillTopicList);
 }
 
 void RosTopicProperty::setMessageType(const QString& message_type)

--- a/src/rviz/properties/ros_topic_property.h
+++ b/src/rviz/properties/ros_topic_property.h
@@ -44,9 +44,33 @@ public:
                    const QString& default_value = QString(),
                    const QString& message_type = QString(),
                    const QString& description = QString(),
-                   Property* parent = nullptr,
-                   const char* changed_slot = nullptr,
-                   QObject* receiver = nullptr);
+                   Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  RosTopicProperty(const QString& name,
+                   const QString& default_value,
+                   const QString& message_type,
+                   const QString& description,
+                   Property* parent,
+                   Func&& changed_slot,
+                   const R* receiver)
+    : RosTopicProperty(name, default_value, message_type, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  RosTopicProperty(const QString& name,
+                   const QString& default_value,
+                   const QString& message_type,
+                   const QString& description,
+                   P* parent,
+                   Func&& changed_slot)
+    : RosTopicProperty(name, default_value, message_type, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   void setMessageType(const QString& message_type);
   QString getMessageType() const

--- a/src/rviz/properties/string_property.cpp
+++ b/src/rviz/properties/string_property.cpp
@@ -34,10 +34,8 @@ namespace rviz
 StringProperty::StringProperty(const QString& name,
                                const QString& default_value,
                                const QString& description,
-                               Property* parent,
-                               const char* changed_slot,
-                               QObject* receiver)
-  : Property(name, default_value, description, parent, changed_slot, receiver)
+                               Property* parent)
+  : Property(name, default_value, description, parent)
 {
 }
 

--- a/src/rviz/properties/string_property.h
+++ b/src/rviz/properties/string_property.h
@@ -43,9 +43,30 @@ public:
   StringProperty(const QString& name = QString(),
                  const QString& default_value = QString(),
                  const QString& description = QString(),
-                 Property* parent = nullptr,
-                 const char* changed_slot = nullptr,
-                 QObject* receiver = nullptr);
+                 Property* parent = nullptr);
+  template <typename Func, typename R>
+  StringProperty(const QString& name,
+                 const QString& default_value,
+                 const QString& description,
+                 Property* parent,
+                 Func&& changed_slot,
+                 const R* receiver)
+    : StringProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  StringProperty(const QString& name,
+                 const QString& default_value,
+                 const QString& description,
+                 P* parent,
+                 Func&& changed_slot)
+    : StringProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   std::string getStdString()
   {

--- a/src/rviz/properties/tf_frame_property.cpp
+++ b/src/rviz/properties/tf_frame_property.cpp
@@ -42,10 +42,8 @@ TfFrameProperty::TfFrameProperty(const QString& name,
                                  const QString& description,
                                  Property* parent,
                                  FrameManager* frame_manager,
-                                 bool include_fixed_frame_string,
-                                 const char* changed_slot,
-                                 QObject* receiver)
-  : EditableEnumProperty(name, default_value, description, parent, changed_slot, receiver)
+                                 bool include_fixed_frame_string)
+  : EditableEnumProperty(name, default_value, description, parent)
   , frame_manager_(nullptr)
   , include_fixed_frame_string_(include_fixed_frame_string)
 {

--- a/src/rviz/properties/tf_frame_property.cpp
+++ b/src/rviz/properties/tf_frame_property.cpp
@@ -50,7 +50,7 @@ TfFrameProperty::TfFrameProperty(const QString& name,
   , include_fixed_frame_string_(include_fixed_frame_string)
 {
   // Parent class EditableEnumProperty has requestOptions() signal.
-  connect(this, SIGNAL(requestOptions(EditableEnumProperty*)), this, SLOT(fillFrameList()));
+  connect(this, &TfFrameProperty::requestOptions, this, &TfFrameProperty::fillFrameList);
   setFrameManager(frame_manager);
 }
 
@@ -70,12 +70,14 @@ void TfFrameProperty::setFrameManager(FrameManager* frame_manager)
 {
   if (frame_manager_ && include_fixed_frame_string_)
   {
-    disconnect(frame_manager_, SIGNAL(fixedFrameChanged()), this, SLOT(handleFixedFrameChange()));
+    disconnect(frame_manager_, &FrameManager::fixedFrameChanged, this,
+               &TfFrameProperty::handleFixedFrameChange);
   }
   frame_manager_ = frame_manager;
   if (frame_manager_ && include_fixed_frame_string_)
   {
-    connect(frame_manager_, SIGNAL(fixedFrameChanged()), this, SLOT(handleFixedFrameChange()));
+    connect(frame_manager_, &FrameManager::fixedFrameChanged, this,
+            &TfFrameProperty::handleFixedFrameChange);
   }
 }
 

--- a/src/rviz/properties/tf_frame_property.h
+++ b/src/rviz/properties/tf_frame_property.h
@@ -47,9 +47,35 @@ public:
                   const QString& description = QString(),
                   Property* parent = nullptr,
                   FrameManager* frame_manager = nullptr,
-                  bool include_fixed_frame_string = false,
-                  const char* changed_slot = nullptr,
-                  QObject* receiver = nullptr);
+                  bool include_fixed_frame_string = false);
+
+  template <typename Func, typename R>
+  TfFrameProperty(const QString& name,
+                  const QString& default_value,
+                  const QString& description,
+                  Property* parent,
+                  FrameManager* frame_manager,
+                  bool include_fixed_frame_string,
+                  Func&& changed_slot,
+                  const R* receiver)
+    : TfFrameProperty(name, default_value, description, parent, frame_manager, include_fixed_frame_string)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  TfFrameProperty(const QString& name,
+                  const QString& default_value,
+                  const QString& description,
+                  P* parent,
+                  FrameManager* frame_manager,
+                  bool include_fixed_frame_string,
+                  Func&& changed_slot)
+    : TfFrameProperty(name, default_value, description, parent, frame_manager, include_fixed_frame_string)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   /** @brief Override from Property to resolve the frame name on the way in. */
   bool setValue(const QVariant& new_value) override;

--- a/src/rviz/properties/vector_property.cpp
+++ b/src/rviz/properties/vector_property.cpp
@@ -37,12 +37,8 @@ namespace rviz
 VectorProperty::VectorProperty(const QString& name,
                                const Ogre::Vector3& default_value,
                                const QString& description,
-                               Property* parent,
-                               const char* changed_slot,
-                               QObject* receiver)
-  : Property(name, QVariant(), description, parent, changed_slot, receiver)
-  , vector_(default_value)
-  , ignore_child_updates_(false)
+                               Property* parent)
+  : Property(name, QVariant(), description, parent), vector_(default_value), ignore_child_updates_(false)
 {
   x_ = new Property("X", vector_.x, "X coordinate", this);
   y_ = new Property("Y", vector_.y, "Y coordinate", this);

--- a/src/rviz/properties/vector_property.cpp
+++ b/src/rviz/properties/vector_property.cpp
@@ -48,12 +48,12 @@ VectorProperty::VectorProperty(const QString& name,
   y_ = new Property("Y", vector_.y, "Y coordinate", this);
   z_ = new Property("Z", vector_.z, "Z coordinate", this);
   updateString();
-  connect(x_, SIGNAL(aboutToChange()), this, SLOT(emitAboutToChange()));
-  connect(y_, SIGNAL(aboutToChange()), this, SLOT(emitAboutToChange()));
-  connect(z_, SIGNAL(aboutToChange()), this, SLOT(emitAboutToChange()));
-  connect(x_, SIGNAL(changed()), this, SLOT(updateFromChildren()));
-  connect(y_, SIGNAL(changed()), this, SLOT(updateFromChildren()));
-  connect(z_, SIGNAL(changed()), this, SLOT(updateFromChildren()));
+  connect(x_, &Property::aboutToChange, this, &VectorProperty::emitAboutToChange);
+  connect(y_, &Property::aboutToChange, this, &VectorProperty::emitAboutToChange);
+  connect(z_, &Property::aboutToChange, this, &VectorProperty::emitAboutToChange);
+  connect(x_, &Property::changed, this, &VectorProperty::updateFromChildren);
+  connect(y_, &Property::changed, this, &VectorProperty::updateFromChildren);
+  connect(z_, &Property::changed, this, &VectorProperty::updateFromChildren);
 }
 
 bool VectorProperty::setVector(const Ogre::Vector3& new_vector)

--- a/src/rviz/properties/vector_property.h
+++ b/src/rviz/properties/vector_property.h
@@ -43,9 +43,31 @@ public:
   VectorProperty(const QString& name = QString(),
                  const Ogre::Vector3& default_value = Ogre::Vector3::ZERO,
                  const QString& description = QString(),
-                 Property* parent = nullptr,
-                 const char* changed_slot = nullptr,
-                 QObject* receiver = nullptr);
+                 Property* parent = nullptr);
+
+  template <typename Func, typename R>
+  VectorProperty(const QString& name,
+                 const Ogre::Vector3& default_value,
+                 const QString& description,
+                 Property* parent,
+                 Func&& changed_slot,
+                 const R* receiver)
+    : VectorProperty(name, default_value, description, parent)
+  {
+    connect(receiver, std::forward<Func>(changed_slot));
+  }
+
+  // this variant is required to allow omitting the receiver argument
+  template <typename Func, typename P>
+  VectorProperty(const QString& name,
+                 const Ogre::Vector3& default_value,
+                 const QString& description,
+                 P* parent,
+                 Func&& changed_slot)
+    : VectorProperty(name, default_value, description, parent)
+  {
+    connect(parent, std::forward<Func>(changed_slot));
+  }
 
   virtual bool setVector(const Ogre::Vector3& vector);
   virtual Ogre::Vector3 getVector() const

--- a/src/rviz/render_panel.cpp
+++ b/src/rviz/render_panel.cpp
@@ -189,7 +189,7 @@ void RenderPanel::contextMenuEvent(QContextMenuEvent* /*event*/)
 
   if (context_menu)
   {
-    connect(context_menu.get(), SIGNAL(aboutToHide()), this, SLOT(onContextMenuHide()));
+    connect(context_menu.get(), &QMenu::aboutToHide, this, &RenderPanel::onContextMenuHide);
     context_menu->exec(QCursor::pos());
   }
 }

--- a/src/rviz/robot/robot.cpp
+++ b/src/rviz/robot/robot.cpp
@@ -81,20 +81,20 @@ Robot::Robot(Ogre::SceneNode* root_node,
   link_tree_->hide(); // hide until loaded
 
   link_tree_style_ = new EnumProperty("Link Tree Style", "", "How the list of links is displayed",
-                                      link_tree_, SLOT(changedLinkTreeStyle()), this);
+                                      link_tree_, &Robot::changedLinkTreeStyle, this);
   initLinkTreeStyle();
   expand_tree_ = new BoolProperty("Expand Tree", false, "Expand or collapse link tree", link_tree_,
-                                  SLOT(changedExpandTree()), this);
+                                  &Robot::changedExpandTree, this);
   expand_link_details_ =
       new BoolProperty("Expand Link Details", false,
                        "Expand link details (sub properties) to see all info for all links.", link_tree_,
-                       SLOT(changedExpandLinkDetails()), this);
+                       &Robot::changedExpandLinkDetails, this);
   expand_joint_details_ =
       new BoolProperty("Expand Joint Details", false,
                        "Expand joint details (sub properties) to see all info for all joints.",
-                       link_tree_, SLOT(changedExpandJointDetails()), this);
+                       link_tree_, &Robot::changedExpandJointDetails, this);
   enable_all_links_ = new BoolProperty("All Links Enabled", true, "Turn all links on or off.",
-                                       link_tree_, SLOT(changedEnableAllLinks()), this);
+                                       link_tree_, &Robot::changedEnableAllLinks, this);
 }
 
 Robot::~Robot()

--- a/src/rviz/robot/robot_joint.cpp
+++ b/src/rviz/robot/robot_joint.cpp
@@ -53,13 +53,14 @@ RobotJoint::RobotJoint(Robot* robot, const urdf::JointConstSharedPtr& joint)
   , axes_(nullptr)
   , axis_(nullptr)
 {
-  joint_property_ = new Property(name_.c_str(), true, "", nullptr, SLOT(updateChildVisibility()), this);
+  joint_property_ =
+      new Property(name_.c_str(), true, "", nullptr, &RobotJoint::updateChildVisibility, this);
   joint_property_->setIcon(rviz::loadPixmap("package://rviz/icons/classes/RobotJoint.png"));
 
   details_ = new Property("Details", QVariant(), "", nullptr);
 
   axes_property_ = new Property("Show Axes", false, "Enable/disable showing the axes of this joint.",
-                                joint_property_, SLOT(updateAxes()), this);
+                                joint_property_, &RobotJoint::updateAxes, this);
 
   position_property_ =
       new VectorProperty("Position", Ogre::Vector3::ZERO,
@@ -112,7 +113,7 @@ RobotJoint::RobotJoint(Robot* robot, const urdf::JointConstSharedPtr& joint)
   {
     show_axis_property_ =
         new Property("Show Joint Axis", false, "Enable/disable showing the axis of this joint.",
-                     joint_property_, SLOT(updateAxis()), this);
+                     joint_property_, &RobotJoint::updateAxis, this);
 
     axis_property_ =
         new VectorProperty("Joint Axis", Ogre::Vector3(joint->axis.x, joint->axis.y, joint->axis.z),

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -168,20 +168,21 @@ RobotLink::RobotLink(Robot* robot,
   , is_selectable_(true)
   , material_mode_flags_(ORIGINAL)
 {
-  link_property_ = new Property(link->name.c_str(), true, "", nullptr, SLOT(updateVisibility()), this);
+  link_property_ =
+      new Property(link->name.c_str(), true, "", nullptr, &RobotLink::updateVisibility, this);
   link_property_->setIcon(rviz::loadPixmap("package://rviz/icons/classes/RobotLink.png"));
 
   details_ = new Property("Details", QVariant(), "", nullptr);
 
   alpha_property_ = new FloatProperty("Alpha", 1, "Amount of transparency to apply to this link.",
-                                      link_property_, SLOT(updateAlpha()), this);
+                                      link_property_, &RobotLink::updateAlpha, this);
 
   trail_property_ =
       new Property("Show Trail", false, "Enable/disable a 2 meter \"ribbon\" which follows this link.",
-                   link_property_, SLOT(updateTrail()), this);
+                   link_property_, &RobotLink::updateTrail, this);
 
   axes_property_ = new Property("Show Axes", false, "Enable/disable showing the axes of this link.",
-                                link_property_, SLOT(updateAxes()), this);
+                                link_property_, &RobotLink::updateAxes, this);
 
   position_property_ =
       new VectorProperty("Position", Ogre::Vector3::ZERO,

--- a/src/rviz/screenshot_dialog.cpp
+++ b/src/rviz/screenshot_dialog.cpp
@@ -72,9 +72,9 @@ ScreenshotDialog::ScreenshotDialog(QWidget* main_window,
 
   setLayout(main_layout);
 
-  connect(button_box_, SIGNAL(clicked(QAbstractButton*)), this, SLOT(onButtonClicked(QAbstractButton*)));
-  connect(full_window_checkbox, SIGNAL(toggled(bool)), this, SLOT(setSaveFullWindow(bool)));
-  connect(delay_timer_, SIGNAL(timeout()), this, SLOT(onTimeout()));
+  connect(button_box_, &QDialogButtonBox::clicked, this, &ScreenshotDialog::onButtonClicked);
+  connect(full_window_checkbox, &QCheckBox::toggled, this, &ScreenshotDialog::setSaveFullWindow);
+  connect(delay_timer_, &QTimer::timeout, this, &ScreenshotDialog::onTimeout);
 }
 
 void ScreenshotDialog::showEvent(QShowEvent* event)

--- a/src/rviz/selection/selection_manager.cpp
+++ b/src/rviz/selection/selection_manager.cpp
@@ -90,7 +90,7 @@ SelectionManager::SelectionManager(VisualizationManager* manager)
   depth_pixel_box_.data = nullptr;
 
   QTimer* timer = new QTimer(this);
-  connect(timer, SIGNAL(timeout()), this, SLOT(updateProperties()));
+  connect(timer, &QTimer::timeout, this, &SelectionManager::updateProperties);
   timer->start(200);
 }
 

--- a/src/rviz/time_panel.cpp
+++ b/src/rviz/time_panel.cpp
@@ -100,14 +100,15 @@ TimePanel::TimePanel(QWidget* parent) : Panel(parent)
   layout->setContentsMargins(11, 5, 11, 5);
   this->setLayout(layout);
 
-  connect(pause_button_, SIGNAL(toggled(bool)), this, SLOT(pauseToggled(bool)));
-  connect(sync_mode_selector_, SIGNAL(activated(int)), this, SLOT(syncModeSelected(int)));
-  connect(sync_source_selector_, SIGNAL(activated(int)), this, SLOT(syncSourceSelected(int)));
+  connect(pause_button_, &QPushButton::toggled, this, &TimePanel::pauseToggled);
+  connect(sync_mode_selector_, qOverload<int>(&QComboBox::activated), this, &TimePanel::syncModeSelected);
+  connect(sync_source_selector_, qOverload<int>(&QComboBox::activated), this,
+          &TimePanel::syncSourceSelected);
 }
 
 void TimePanel::onInitialize()
 {
-  connect(vis_manager_, SIGNAL(preUpdate()), this, SLOT(update()));
+  connect(vis_manager_, &VisualizationManager::preUpdate, this, &TimePanel::update);
 
   DisplayGroup* display_group = vis_manager_->getRootDisplayGroup();
   onDisplayAdded(display_group);
@@ -140,10 +141,8 @@ void TimePanel::onDisplayAdded(Display* display)
   DisplayGroup* display_group = qobject_cast<DisplayGroup*>(display);
   if (display_group)
   {
-    connect(display_group, SIGNAL(displayAdded(rviz::Display*)), this,
-            SLOT(onDisplayAdded(rviz::Display*)));
-    connect(display_group, SIGNAL(displayRemoved(rviz::Display*)), this,
-            SLOT(onDisplayRemoved(rviz::Display*)));
+    connect(display_group, &DisplayGroup::displayAdded, this, &TimePanel::onDisplayAdded);
+    connect(display_group, &DisplayGroup::displayRemoved, this, &TimePanel::onDisplayRemoved);
 
     for (int i = 0; i < display_group->numDisplays(); i++)
     {
@@ -153,7 +152,7 @@ void TimePanel::onDisplayAdded(Display* display)
   }
   else
   {
-    connect(display, SIGNAL(timeSignal(ros::Time)), this, SLOT(onTimeSignal(ros::Time)));
+    connect(display, &Display::timeSignal, this, &TimePanel::onTimeSignal);
   }
 }
 

--- a/src/rviz/tool_manager.cpp
+++ b/src/rviz/tool_manager.cpp
@@ -54,7 +54,7 @@ ToolManager::ToolManager(DisplayContext* context)
   , current_tool_(nullptr)
   , default_tool_(nullptr)
 {
-  connect(property_tree_model_, SIGNAL(configChanged()), this, SIGNAL(configChanged()));
+  connect(property_tree_model_, &PropertyTreeModel::configChanged, this, &ToolManager::configChanged);
 }
 
 ToolManager::~ToolManager()
@@ -248,8 +248,7 @@ Tool* ToolManager::addTool(const QString& class_id)
   }
 
   Property* container = tool->getPropertyContainer();
-  connect(container, SIGNAL(childListChanged(Property*)), this,
-          SLOT(updatePropertyVisibility(Property*)));
+  connect(container, &Property::childListChanged, this, &ToolManager::updatePropertyVisibility);
   updatePropertyVisibility(container);
 
   Q_EMIT toolAdded(tool);
@@ -262,7 +261,7 @@ Tool* ToolManager::addTool(const QString& class_id)
     setCurrentTool(tool);
   }
 
-  QObject::connect(tool, SIGNAL(close()), this, SLOT(closeTool()));
+  QObject::connect(tool, &Tool::close, this, &ToolManager::closeTool);
 
   Q_EMIT configChanged();
 

--- a/src/rviz/view_controller.cpp
+++ b/src/rviz/view_controller.cpp
@@ -58,7 +58,7 @@ ViewController::ViewController()
   near_clip_property_ =
       new FloatProperty("Near Clip Distance", 0.01f,
                         "Anything closer to the camera than this threshold will not get rendered.", this,
-                        SLOT(updateNearClipDistance()));
+                        &ViewController::updateNearClipDistance);
   near_clip_property_->setMin(0.001);
   near_clip_property_->setMax(10000);
 
@@ -66,19 +66,20 @@ ViewController::ViewController()
                                     "Render the main view in stereo if supported."
                                     "  On Linux this requires a recent version of Ogre and"
                                     " an NVIDIA Quadro card with 3DVision glasses.",
-                                    this, SLOT(updateStereoProperties()));
+                                    this, &ViewController::updateStereoProperties);
   stereo_eye_swap_ = new BoolProperty("Swap Stereo Eyes", false,
                                       "Swap eyes if the monitor shows the left eye on the right.",
-                                      stereo_enable_, SLOT(updateStereoProperties()), this);
+                                      stereo_enable_, &ViewController::updateStereoProperties, this);
   stereo_eye_separation_ =
       new FloatProperty("Stereo Eye Separation", 0.06f, "Distance between eyes for stereo rendering.",
-                        stereo_enable_, SLOT(updateStereoProperties()), this);
-  stereo_focal_distance_ = new FloatProperty("Stereo Focal Distance", 1.0f,
-                                             "Distance from eyes to screen.  For stereo rendering.",
-                                             stereo_enable_, SLOT(updateStereoProperties()), this);
+                        stereo_enable_, &ViewController::updateStereoProperties, this);
+  stereo_focal_distance_ =
+      new FloatProperty("Stereo Focal Distance", 1.0f,
+                        "Distance from eyes to screen.  For stereo rendering.", stereo_enable_,
+                        &ViewController::updateStereoProperties, this);
   invert_z_ =
       new BoolProperty("Invert Z Axis", false, "Invert camera's Z axis for Z-down environments/models.",
-                       this, SLOT(updateStereoProperties()));
+                       this, &ViewController::updateStereoProperties);
 }
 
 void ViewController::initialize(DisplayContext* context)

--- a/src/rviz/view_manager.cpp
+++ b/src/rviz/view_manager.cpp
@@ -51,8 +51,8 @@ ViewManager::ViewManager(DisplayContext* context)
   , render_panel_(nullptr)
 {
   property_model_->setDragDropClass("view-controller");
-  connect(property_model_, SIGNAL(configChanged()), this, SIGNAL(configChanged()));
-  connect(this, SIGNAL(currentChanged()), this, SIGNAL(configChanged()));
+  connect(property_model_, &PropertyTreeModel::configChanged, this, &ViewManager::configChanged);
+  connect(this, &ViewManager::currentChanged, this, &ViewManager::configChanged);
 }
 
 ViewManager::~ViewManager()
@@ -130,10 +130,10 @@ void ViewManager::setCurrent(ViewController* new_current, bool mimic_view)
     {
       new_current->transitionFrom(previous);
     }
-    disconnect(previous, SIGNAL(destroyed(QObject*)), this, SLOT(onCurrentDestroyed(QObject*)));
+    disconnect(previous, &QObject::destroyed, this, &ViewManager::onCurrentDestroyed);
   }
   new_current->setName("Current View");
-  connect(new_current, SIGNAL(destroyed(QObject*)), this, SLOT(onCurrentDestroyed(QObject*)));
+  connect(new_current, &QObject::destroyed, this, &ViewManager::onCurrentDestroyed);
   current_ = new_current;
   root_property_->addChildToFront(new_current);
   delete previous;

--- a/src/rviz/views_panel.cpp
+++ b/src/rviz/views_panel.cpp
@@ -75,13 +75,11 @@ ViewsPanel::ViewsPanel(QWidget* parent) : Panel(parent), view_man_(nullptr)
   main_layout->addLayout(button_layout);
   setLayout(main_layout);
 
-  connect(remove_button, SIGNAL(clicked()), this, SLOT(onDeleteClicked()));
-  connect(rename_button, SIGNAL(clicked()), this, SLOT(renameSelected()));
-  connect(zero_button, SIGNAL(clicked()), this, SLOT(onZeroClicked()));
-  connect(properties_view_, SIGNAL(clicked(const QModelIndex&)), this,
-          SLOT(setCurrentViewFromIndex(const QModelIndex&)));
-  connect(properties_view_, SIGNAL(activated(const QModelIndex&)), this,
-          SLOT(setCurrentViewFromIndex(const QModelIndex&)));
+  connect(remove_button, &QPushButton::clicked, this, &ViewsPanel::onDeleteClicked);
+  connect(rename_button, &QPushButton::clicked, this, &ViewsPanel::renameSelected);
+  connect(zero_button, &QPushButton::clicked, this, &ViewsPanel::onZeroClicked);
+  connect(properties_view_, &PropertyTreeWidget::clicked, this, &ViewsPanel::setCurrentViewFromIndex);
+  connect(properties_view_, &PropertyTreeWidget::activated, this, &ViewsPanel::setCurrentViewFromIndex);
 }
 
 void ViewsPanel::onInitialize()
@@ -93,9 +91,10 @@ void ViewsPanel::setViewManager(ViewManager* view_man)
 {
   if (view_man_)
   {
-    disconnect(save_button_, SIGNAL(clicked()), view_man_, SLOT(copyCurrentToList()));
-    disconnect(camera_type_selector_, SIGNAL(activated(int)), this, SLOT(onTypeSelectorChanged(int)));
-    disconnect(view_man_, SIGNAL(currentChanged()), this, SLOT(onCurrentChanged()));
+    disconnect(save_button_, &QPushButton::clicked, view_man_, &ViewManager::copyCurrentToList);
+    disconnect(camera_type_selector_, qOverload<int>(&QComboBox::activated), this,
+               &ViewsPanel::onTypeSelectorChanged);
+    disconnect(view_man_, &ViewManager::currentChanged, this, &ViewsPanel::onCurrentChanged);
   }
   view_man_ = view_man;
   camera_type_selector_->clear();
@@ -111,9 +110,10 @@ void ViewsPanel::setViewManager(ViewManager* view_man)
                                      id); // send the regular-formatted id as userData.
     }
 
-    connect(save_button_, SIGNAL(clicked()), view_man_, SLOT(copyCurrentToList()));
-    connect(camera_type_selector_, SIGNAL(activated(int)), this, SLOT(onTypeSelectorChanged(int)));
-    connect(view_man_, SIGNAL(currentChanged()), this, SLOT(onCurrentChanged()));
+    connect(save_button_, &QPushButton::clicked, view_man_, &ViewManager::copyCurrentToList);
+    connect(camera_type_selector_, qOverload<int>(&QComboBox::activated), this,
+            &ViewsPanel::onTypeSelectorChanged);
+    connect(view_man_, &ViewManager::currentChanged, this, &ViewsPanel::onCurrentChanged);
   }
   else
   {

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -140,11 +140,11 @@ VisualizationFrame::VisualizationFrame(QWidget* parent)
   reset_button->setText("Reset");
   reset_button->setContentsMargins(0, 0, 0, 0);
   statusBar()->addPermanentWidget(reset_button, 0);
-  connect(reset_button, &QToolButton::clicked, this, &VisualizationFrame::reset);
+  connect(reset_button, &QToolButton::clicked, this, &VisualizationFrame::VisualizationFrame::reset);
 
   status_label_ = new QLabel("");
   statusBar()->addPermanentWidget(status_label_, 1);
-  connect(this, &VisualizationFrame::statusUpdate, status_label_, &QLabel::setText);
+  connect(this, &VisualizationFrame::VisualizationFrame::statusUpdate, status_label_, &QLabel::setText);
 
   fps_label_ = new QLabel("");
   fps_label_->setMinimumWidth(40);
@@ -253,7 +253,7 @@ void VisualizationFrame::initialize(const QString& display_config_file)
     QPixmap splash_image(splash_path_);
     splash_ = new SplashScreen(splash_image);
     splash_->show();
-    connect(this, &VisualizationFrame::statusUpdate, splash_,
+    connect(this, &VisualizationFrame::VisualizationFrame::statusUpdate, splash_,
             [this](const QString& message) { splash_->showMessage(message); });
   }
   Q_EMIT statusUpdate("Initializing");
@@ -286,7 +286,8 @@ void VisualizationFrame::initialize(const QString& display_config_file)
   hide_left_dock_button_->setAutoRaise(true);
   hide_left_dock_button_->setCheckable(true);
 
-  connect(hide_left_dock_button_, &QToolButton::toggled, this, &VisualizationFrame::hideLeftDock);
+  connect(hide_left_dock_button_, &QToolButton::toggled, this,
+          &VisualizationFrame::VisualizationFrame::hideLeftDock);
 
   hide_right_dock_button_ = new QToolButton();
   hide_right_dock_button_->setContentsMargins(0, 0, 0, 0);
@@ -296,7 +297,8 @@ void VisualizationFrame::initialize(const QString& display_config_file)
   hide_right_dock_button_->setAutoRaise(true);
   hide_right_dock_button_->setCheckable(true);
 
-  connect(hide_right_dock_button_, &QToolButton::toggled, this, &VisualizationFrame::hideRightDock);
+  connect(hide_right_dock_button_, &QToolButton::toggled, this,
+          &VisualizationFrame::VisualizationFrame::hideRightDock);
 
   central_layout->addWidget(hide_left_dock_button_, 0);
   central_layout->addWidget(render_panel_, 1);
@@ -324,7 +326,8 @@ void VisualizationFrame::initialize(const QString& display_config_file)
 
   manager_ = new VisualizationManager(render_panel_, this);
   manager_->setHelpPath(help_path_);
-  connect(manager_, &VisualizationManager::escapePressed, this, &VisualizationFrame::exitFullScreen);
+  connect(manager_, &VisualizationManager::escapePressed, this,
+          &VisualizationFrame::VisualizationFrame::exitFullScreen);
 
   // Periodically process events for the splash screen.
   QCoreApplication::processEvents();
@@ -338,10 +341,12 @@ void VisualizationFrame::initialize(const QString& display_config_file)
 
   connect(manager_, &VisualizationManager::configChanged, this,
           &VisualizationFrame::setDisplayConfigModified);
-  connect(tool_man, &ToolManager::toolAdded, this, &VisualizationFrame::addTool);
-  connect(tool_man, &ToolManager::toolRemoved, this, &VisualizationFrame::removeTool);
-  connect(tool_man, &ToolManager::toolRefreshed, this, &VisualizationFrame::refreshTool);
-  connect(tool_man, &ToolManager::toolChanged, this, &VisualizationFrame::indicateToolIsCurrent);
+  connect(tool_man, &ToolManager::toolAdded, this, &VisualizationFrame::VisualizationFrame::addTool);
+  connect(tool_man, &ToolManager::toolRemoved, this, &VisualizationFrame::VisualizationFrame::removeTool);
+  connect(tool_man, &ToolManager::toolRefreshed, this,
+          &VisualizationFrame::VisualizationFrame::refreshTool);
+  connect(tool_man, &ToolManager::toolChanged, this,
+          &VisualizationFrame::VisualizationFrame::indicateToolIsCurrent);
 
   manager_->initialize();
 
@@ -367,8 +372,10 @@ void VisualizationFrame::initialize(const QString& display_config_file)
   initialized_ = true;
   Q_EMIT statusUpdate("RViz is ready.");
 
-  connect(manager_, &VisualizationManager::preUpdate, this, &VisualizationFrame::updateFps);
-  connect(manager_, &VisualizationManager::statusUpdate, this, &VisualizationFrame::statusUpdate);
+  connect(manager_, &VisualizationManager::preUpdate, this,
+          &VisualizationFrame::VisualizationFrame::updateFps);
+  connect(manager_, &VisualizationManager::statusUpdate, this,
+          &VisualizationFrame::VisualizationFrame::statusUpdate);
 }
 
 void VisualizationFrame::initConfigs()
@@ -447,32 +454,33 @@ void VisualizationFrame::initMenus()
   file_menu_ = menuBar()->addMenu("&File");
 
   QAction* file_menu_open_action =
-      file_menu_->addAction("&Open Config", this, SLOT(onOpen()), QKeySequence("Ctrl+O"));
+      file_menu_->addAction("&Open Config", this, &VisualizationFrame::onOpen, QKeySequence("Ctrl+O"));
   this->addAction(file_menu_open_action);
   QAction* file_menu_save_action =
-      file_menu_->addAction("&Save Config", this, SLOT(onSave()), QKeySequence("Ctrl+S"));
+      file_menu_->addAction("&Save Config", this, &VisualizationFrame::onSave, QKeySequence("Ctrl+S"));
   this->addAction(file_menu_save_action);
-  QAction* file_menu_save_as_action =
-      file_menu_->addAction("Save Config &As", this, SLOT(onSaveAs()), QKeySequence("Ctrl+Shift+S"));
+  QAction* file_menu_save_as_action = file_menu_->addAction(
+      "Save Config &As", this, &VisualizationFrame::onSaveAs, QKeySequence("Ctrl+Shift+S"));
   this->addAction(file_menu_save_as_action);
 
   recent_configs_menu_ = file_menu_->addMenu("&Recent Configs");
-  file_menu_->addAction("Save &Image", this, SLOT(onSaveImage()));
+  file_menu_->addAction("Save &Image", this, &VisualizationFrame::onSaveImage);
   if (show_choose_new_master_option_)
   {
     file_menu_->addSeparator();
-    file_menu_->addAction("Change &Master", this, SLOT(changeMaster()));
+    file_menu_->addAction("Change &Master", this, &VisualizationFrame::changeMaster);
   }
   file_menu_->addSeparator();
-  file_menu_->addAction("&Preferences", this, SLOT(openPreferencesDialog()), QKeySequence("Ctrl+P"));
+  file_menu_->addAction("&Preferences", this, &VisualizationFrame::openPreferencesDialog,
+                        QKeySequence("Ctrl+P"));
 
   QAction* file_menu_quit_action =
-      file_menu_->addAction("&Quit", this, SLOT(close()), QKeySequence("Ctrl+Q"));
+      file_menu_->addAction("&Quit", this, &VisualizationFrame::close, QKeySequence("Ctrl+Q"));
   file_menu_quit_action->setObjectName("actQuit");
   this->addAction(file_menu_quit_action);
 
   view_menu_ = menuBar()->addMenu("&Panels");
-  view_menu_->addAction("Add &New Panel", this, SLOT(openNewPanelDialog()));
+  view_menu_->addAction("Add &New Panel", this, &VisualizationFrame::openNewPanelDialog);
   delete_view_menu_ = view_menu_->addMenu("&Delete Panel");
   delete_view_menu_->setEnabled(false);
 
@@ -485,10 +493,10 @@ void VisualizationFrame::initMenus()
   view_menu_->addSeparator();
 
   QMenu* help_menu = menuBar()->addMenu("&Help");
-  help_menu->addAction("Show &Help panel", this, SLOT(showHelpPanel()));
-  help_menu->addAction("Open rviz wiki in browser", this, SLOT(onHelpWiki()));
+  help_menu->addAction("Show &Help panel", this, &VisualizationFrame::showHelpPanel);
+  help_menu->addAction("Open rviz wiki in browser", this, &VisualizationFrame::onHelpWiki);
   help_menu->addSeparator();
-  help_menu->addAction("&About", this, SLOT(onHelpAbout()));
+  help_menu->addAction("&About", this, &VisualizationFrame::onHelpAbout);
 }
 
 void VisualizationFrame::initToolbars()
@@ -514,7 +522,8 @@ void VisualizationFrame::initToolbars()
   add_tool_button->setToolTip("Add a new tool");
   add_tool_button->setIcon(loadPixmap("package://rviz/icons/plus.png"));
   toolbar_->addWidget(add_tool_button);
-  connect(add_tool_button, &QToolButton::clicked, this, &VisualizationFrame::openNewToolDialog);
+  connect(add_tool_button, &QToolButton::clicked, this,
+          &VisualizationFrame::VisualizationFrame::openNewToolDialog);
 
   remove_tool_menu_ = new QMenu(toolbar_);
   QToolButton* remove_tool_button = new QToolButton();
@@ -523,7 +532,8 @@ void VisualizationFrame::initToolbars()
   remove_tool_button->setToolTip("Remove a tool from the toolbar");
   remove_tool_button->setIcon(loadPixmap("package://rviz/icons/minus.png"));
   toolbar_->addWidget(remove_tool_button);
-  connect(remove_tool_menu_, &QMenu::triggered, this, &VisualizationFrame::onToolbarRemoveTool);
+  connect(remove_tool_menu_, &QMenu::triggered, this,
+          &VisualizationFrame::VisualizationFrame::onToolbarRemoveTool);
 
   QMenu* button_style_menu = new QMenu(toolbar_);
   QAction* action_tool_button_icon_only = new QAction("Icon only", toolbar_actions_);
@@ -545,7 +555,8 @@ void VisualizationFrame::initToolbars()
   button_style_button->setToolTip("Set toolbar style");
   button_style_button->setIcon(loadPixmap("package://rviz/icons/visibility.svg"));
   toolbar_->addWidget(button_style_button);
-  connect(button_style_menu, &QMenu::triggered, this, &VisualizationFrame::onButtonStyleTool);
+  connect(button_style_menu, &QMenu::triggered, this,
+          &VisualizationFrame::VisualizationFrame::onButtonStyleTool);
 }
 
 void VisualizationFrame::hideDockImpl(Qt::DockWidgetArea area, bool hide)
@@ -638,7 +649,8 @@ void VisualizationFrame::openNewPanelDialog()
     QDockWidget* dock = addPanelByName(display_name, class_id);
     if (dock)
     {
-      connect(dock, &QDockWidget::dockLocationChanged, this, &VisualizationFrame::onDockPanelChange);
+      connect(dock, &QDockWidget::dockLocationChanged, this,
+              &VisualizationFrame::VisualizationFrame::onDockPanelChange);
     }
   }
   manager_->startUpdate();
@@ -683,7 +695,8 @@ void VisualizationFrame::updateRecentConfigMenu()
       QString qdisplay_name = QString::fromStdString(display_name);
       QAction* action = new QAction(qdisplay_name, this);
       action->setData(QString::fromStdString(*it));
-      connect(action, &QAction::triggered, this, &VisualizationFrame::onRecentConfigSelected);
+      connect(action, &QAction::triggered, this,
+              &VisualizationFrame::VisualizationFrame::onRecentConfigSelected);
       recent_configs_menu_->addAction(action);
     }
   }
@@ -752,7 +765,8 @@ bool VisualizationFrame::loadDisplayConfigHelper(const std::string& full_path, c
   {
     dialog.reset(new LoadingDialog(this));
     dialog->show();
-    connect(this, &VisualizationFrame::statusUpdate, dialog.get(), &LoadingDialog::showMessage);
+    connect(this, &VisualizationFrame::VisualizationFrame::statusUpdate, dialog.get(),
+            &LoadingDialog::showMessage);
 
     // make the window correctly appear although running a long-term function
     QCoreApplication::processEvents();
@@ -950,7 +964,8 @@ void VisualizationFrame::loadPanels(const Config& config)
       // qobject_cast.
       if (dock)
       {
-        connect(dock, &QDockWidget::dockLocationChanged, this, &VisualizationFrame::onDockPanelChange);
+        connect(dock, &QDockWidget::dockLocationChanged, this,
+                &VisualizationFrame::VisualizationFrame::onDockPanelChange);
         Panel* panel = qobject_cast<Panel*>(dock->widget());
         if (panel)
         {
@@ -1125,7 +1140,8 @@ void VisualizationFrame::onSaveImage()
 {
   ScreenshotDialog* dialog =
       new ScreenshotDialog(this, render_panel_, QString::fromStdString(last_image_dir_));
-  connect(dialog, &ScreenshotDialog::savedInDirectory, this, &VisualizationFrame::setImageSaveDirectory);
+  connect(dialog, &ScreenshotDialog::savedInDirectory, this,
+          &VisualizationFrame::VisualizationFrame::setImageSaveDirectory);
   dialog->show();
 }
 
@@ -1161,7 +1177,8 @@ void VisualizationFrame::addTool(Tool* tool)
 
   remove_tool_menu_->addAction(tool->getName());
 
-  QObject::connect(tool, &Tool::nameChanged, this, &VisualizationFrame::onToolNameChanged);
+  QObject::connect(tool, &Tool::nameChanged, this,
+                   &VisualizationFrame::VisualizationFrame::onToolNameChanged);
 }
 
 void VisualizationFrame::onToolNameChanged(const QString& name)
@@ -1250,7 +1267,7 @@ void VisualizationFrame::showHelpPanel()
   {
     QDockWidget* dock = addPanelByName("Help", "rviz/Help");
     show_help_action_ = dock->toggleViewAction();
-    connect(dock, &QObject::destroyed, this, &VisualizationFrame::onHelpDestroyed);
+    connect(dock, &QObject::destroyed, this, &VisualizationFrame::VisualizationFrame::onHelpDestroyed);
   }
   else
   {
@@ -1381,14 +1398,16 @@ QDockWidget* VisualizationFrame::addPanelByName(const QString& name,
     panel = new FailedPanel(class_id, error);
   }
   panel->setName(name);
-  connect(panel, &Panel::configChanged, this, &VisualizationFrame::setDisplayConfigModified);
+  connect(panel, &Panel::configChanged, this,
+          &VisualizationFrame::VisualizationFrame::setDisplayConfigModified);
 
   PanelRecord record;
   record.dock = addPane(name, panel, area, floating);
   record.panel = panel;
   record.name = name;
-  record.delete_action = delete_view_menu_->addAction(name, this, SLOT(onDeletePanel()));
-  connect(record.dock, &QObject::destroyed, this, &VisualizationFrame::onPanelDeleted);
+  record.delete_action = delete_view_menu_->addAction(name, this, &VisualizationFrame::onDeletePanel);
+  connect(record.dock, &QObject::destroyed, this,
+          &VisualizationFrame::VisualizationFrame::onPanelDeleted);
   custom_panels_.append(record);
   delete_view_menu_->setEnabled(true);
 
@@ -1413,13 +1432,16 @@ VisualizationFrame::addPane(const QString& name, QWidget* panel, Qt::DockWidgetA
   // we want to know when that panel becomes visible
   connect(dock, &PanelDockWidget::visibilityChanged, this,
           &VisualizationFrame::onDockPanelVisibilityChange);
-  connect(this, &VisualizationFrame::fullScreenChange, dock, &PanelDockWidget::overrideVisibility);
+  connect(this, &VisualizationFrame::VisualizationFrame::fullScreenChange, dock,
+          &PanelDockWidget::overrideVisibility);
 
   QAction* toggle_action = dock->toggleViewAction();
   view_menu_->addAction(toggle_action);
 
-  connect(toggle_action, &QAction::triggered, this, &VisualizationFrame::setDisplayConfigModified);
-  connect(dock, &PanelDockWidget::closed, this, &VisualizationFrame::setDisplayConfigModified);
+  connect(toggle_action, &QAction::triggered, this,
+          &VisualizationFrame::VisualizationFrame::setDisplayConfigModified);
+  connect(dock, &PanelDockWidget::closed, this,
+          &VisualizationFrame::VisualizationFrame::setDisplayConfigModified);
 
   dock->installEventFilter(geom_change_detector_);
 

--- a/src/rviz/visualization_frame.h
+++ b/src/rviz/visualization_frame.h
@@ -261,9 +261,6 @@ protected Q_SLOTS:
   void onDeletePanel();
 
 protected Q_SLOTS:
-  /** @brief Set loading_ to false. */
-  void markLoadingDone();
-
   /** @brief Set the default directory in which to save screenshot images. */
   void setImageSaveDirectory(const QString& directory);
 

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -155,15 +155,16 @@ VisualizationManager::VisualizationManager(RenderPanel* render_panel,
   root_display_group_->setName("root");
   display_property_tree_model_ = new PropertyTreeModel(root_display_group_);
   display_property_tree_model_->setDragDropClass("display");
-  connect(display_property_tree_model_, SIGNAL(configChanged()), this, SIGNAL(configChanged()));
+  connect(display_property_tree_model_, &PropertyTreeModel::configChanged, this,
+          &VisualizationManager::configChanged);
 
   tool_manager_ = new ToolManager(this);
-  connect(tool_manager_, SIGNAL(configChanged()), this, SIGNAL(configChanged()));
-  connect(tool_manager_, SIGNAL(toolChanged(Tool*)), this, SLOT(onToolChanged(Tool*)));
+  connect(tool_manager_, &ToolManager::configChanged, this, &VisualizationManager::configChanged);
+  connect(tool_manager_, &ToolManager::toolChanged, this, &VisualizationManager::onToolChanged);
 
   view_manager_ = new ViewManager(this);
   view_manager_->setRenderPanel(render_panel_);
-  connect(view_manager_, SIGNAL(configChanged()), this, SIGNAL(configChanged()));
+  connect(view_manager_, &ViewManager::configChanged, this, &VisualizationManager::configChanged);
 
   IconizedProperty* ip = new IconizedProperty("Global Options", QVariant(), "", root_display_group_);
   ip->setIcon(loadPixmap("package://rviz/icons/options.png"));
@@ -200,7 +201,7 @@ VisualizationManager::VisualizationManager(RenderPanel* render_panel,
   selection_manager_ = new SelectionManager(this);
 
   update_timer_ = new QTimer;
-  connect(update_timer_, SIGNAL(timeout()), this, SLOT(onUpdate()));
+  connect(update_timer_, &QTimer::timeout, this, &VisualizationManager::onUpdate);
 
   private_->threaded_queue_threads_.create_thread(
       boost::bind(&VisualizationManager::threadedQueueThreadFunc, this));

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -90,10 +90,9 @@ public:
   IconizedProperty(const QString& name = QString(),
                    const QVariant& default_value = QVariant(),
                    const QString& description = QString(),
-                   Property* parent = nullptr,
-                   const char* changed_slot = nullptr,
-                   QObject* receiver = nullptr)
-    : Property(name, default_value, description, parent, changed_slot, receiver){};
+                   Property* parent = nullptr)
+    : Property(name, default_value, description, parent){};
+
   QVariant getViewData(int column, int role) const override
   {
     return (column == 0 && role == Qt::DecorationRole) ? icon_ : Property::getViewData(column, role);

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -169,22 +169,21 @@ VisualizationManager::VisualizationManager(RenderPanel* render_panel,
   ip->setIcon(loadPixmap("package://rviz/icons/options.png"));
   global_options_ = ip;
 
-  fixed_frame_property_ =
-      new TfFrameProperty("Fixed Frame", "map",
-                          "Frame into which all data is transformed before being displayed.",
-                          global_options_, frame_manager_, false, SLOT(updateFixedFrame()), this);
+  fixed_frame_property_ = new TfFrameProperty(
+      "Fixed Frame", "map", "Frame into which all data is transformed before being displayed.",
+      global_options_, frame_manager_, false, &VisualizationManager::updateFixedFrame, this);
 
   background_color_property_ =
       new ColorProperty("Background Color", QColor(48, 48, 48), "Background color for the 3D view.",
-                        global_options_, SLOT(updateBackgroundColor()), this);
+                        global_options_, &VisualizationManager::updateBackgroundColor, this);
 
   fps_property_ =
       new IntProperty("Frame Rate", 30, "RViz will try to render this many frames per second.",
-                      global_options_, SLOT(updateFps()), this);
+                      global_options_, &VisualizationManager::updateFps, this);
 
   default_light_enabled_property_ =
       new BoolProperty("Default Light", true, "Light source attached to the current 3D view.",
-                       global_options_, SLOT(updateDefaultLightVisible()), this);
+                       global_options_, &VisualizationManager::updateDefaultLightVisible, this);
 
   root_display_group_->initialize(
       this); // only initialize() a Display after its sub-properties are created.

--- a/src/rviz/visualizer_app.cpp
+++ b/src/rviz/visualizer_app.cpp
@@ -251,7 +251,7 @@ VisualizerApp::~VisualizerApp()
 void VisualizerApp::startContinueChecker()
 {
   continue_timer_ = new QTimer(this);
-  connect(continue_timer_, SIGNAL(timeout()), this, SLOT(checkContinue()));
+  connect(continue_timer_, &QTimer::timeout, this, &VisualizerApp::checkContinue);
   continue_timer_->start(100);
 }
 

--- a/src/rviz/wait_for_master_dialog.cpp
+++ b/src/rviz/wait_for_master_dialog.cpp
@@ -54,7 +54,7 @@ WaitForMasterDialog::WaitForMasterDialog(QWidget* parent) : QMessageBox(parent)
   setStandardButtons(QMessageBox::Cancel);
 
   QTimer* timer = new QTimer(this);
-  connect(timer, SIGNAL(timeout()), this, SLOT(onTimer()));
+  connect(timer, &QTimer::timeout, this, &WaitForMasterDialog::onTimer);
   timer->start(1000);
 }
 

--- a/src/test/mock_property_change_receiver.cpp
+++ b/src/test/mock_property_change_receiver.cpp
@@ -39,14 +39,14 @@ MockPropertyChangeReceiver::MockPropertyChangeReceiver()
 
 void MockPropertyChangeReceiver::aboutToChange()
 {
-  Property* p = qobject_cast<Property*>(sender());
-  result_ += " aboutToChange, v=" + p->getValue().toString();
+  if (Property* p = qobject_cast<Property*>(sender()))
+    result_ += " aboutToChange, v=" + p->getValue().toString();
 }
 
 void MockPropertyChangeReceiver::changed()
 {
-  Property* p = qobject_cast<Property*>(sender());
-  result_ += " changed, v=" + p->getValue().toString();
+  if (Property* p = qobject_cast<Property*>(sender()))
+    result_ += " changed, v=" + p->getValue().toString();
 }
 
 } // end namespace rviz

--- a/src/test/mock_property_change_receiver.cpp
+++ b/src/test/mock_property_change_receiver.cpp
@@ -33,18 +33,20 @@
 
 namespace rviz
 {
-MockPropertyChangeReceiver::MockPropertyChangeReceiver(Property* property) : property_(property)
+MockPropertyChangeReceiver::MockPropertyChangeReceiver()
 {
 }
 
 void MockPropertyChangeReceiver::aboutToChange()
 {
-  result_ += " aboutToChange, v=" + property_->getValue().toString();
+  Property* p = qobject_cast<Property*>(sender());
+  result_ += " aboutToChange, v=" + p->getValue().toString();
 }
 
 void MockPropertyChangeReceiver::changed()
 {
-  result_ += " changed, v=" + property_->getValue().toString();
+  Property* p = qobject_cast<Property*>(sender());
+  result_ += " changed, v=" + p->getValue().toString();
 }
 
 } // end namespace rviz

--- a/src/test/mock_property_change_receiver.cpp
+++ b/src/test/mock_property_change_receiver.cpp
@@ -33,20 +33,16 @@
 
 namespace rviz
 {
-MockPropertyChangeReceiver::MockPropertyChangeReceiver()
-{
-}
-
 void MockPropertyChangeReceiver::aboutToChange()
 {
   if (Property* p = qobject_cast<Property*>(sender()))
-    result_ += " aboutToChange, v=" + p->getValue().toString();
+    result += " aboutToChange, v=" + p->getValue().toString();
 }
 
 void MockPropertyChangeReceiver::changed()
 {
   if (Property* p = qobject_cast<Property*>(sender()))
-    result_ += " changed, v=" + p->getValue().toString();
+    result += " changed, v=" + p->getValue().toString();
 }
 
 } // end namespace rviz

--- a/src/test/mock_property_change_receiver.h
+++ b/src/test/mock_property_change_receiver.h
@@ -36,23 +36,18 @@ namespace rviz
 class MockPropertyChangeReceiver : public QObject
 {
   Q_OBJECT
+
 public:
-  MockPropertyChangeReceiver();
+  QString result;
+
   void reset()
   {
-    result_ = "";
-  }
-  QString& result()
-  {
-    return result_;
+    result = "";
   }
 
 public Q_SLOTS:
   void aboutToChange();
   void changed();
-
-private:
-  QString result_;
 };
 
 } // end namespace rviz

--- a/src/test/mock_property_change_receiver.h
+++ b/src/test/mock_property_change_receiver.h
@@ -33,13 +33,11 @@
 
 namespace rviz
 {
-class Property;
-
 class MockPropertyChangeReceiver : public QObject
 {
   Q_OBJECT
 public:
-  MockPropertyChangeReceiver(Property* prop);
+  MockPropertyChangeReceiver();
   void reset()
   {
     result_ = "";
@@ -55,7 +53,6 @@ public Q_SLOTS:
 
 private:
   QString result_;
-  Property* property_;
 };
 
 } // end namespace rviz

--- a/src/test/mock_property_change_receiver.h
+++ b/src/test/mock_property_change_receiver.h
@@ -42,7 +42,7 @@ public:
   {
     result_ = "";
   }
-  QString result()
+  QString& result()
   {
     return result_;
   }

--- a/src/test/property_test.cpp
+++ b/src/test/property_test.cpp
@@ -68,21 +68,21 @@ TEST(Property, set_value_events_qt4)
   Property p("", 1, "", nullptr, SLOT(changed()), &r);
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
   p.setValue(17);
-  EXPECT_EQ(" aboutToChange, v=1 changed, v=17", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=1 changed, v=17", r.result.toStdString());
   r.reset();
 
   // initialize from parent
   Property p2("", 2, "", &p, SIGNAL(changed()));
   p2.connect(&p2, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
   p2.setValue(27);
-  EXPECT_EQ(" aboutToChange, v=2 changed, v=17", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=2 changed, v=17", r.result.toStdString());
   r.reset();
 
   // initialize from parent
   Property p3("", 3, "", &p, SIGNAL(changed()));
   p3.connect(&p3, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
   p3.setValue(37);
-  EXPECT_EQ(" aboutToChange, v=3 changed, v=17", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=3 changed, v=17", r.result.toStdString());
 }
 
 TEST(Property, set_value_events_lambda)
@@ -92,17 +92,17 @@ TEST(Property, set_value_events_lambda)
       "", 1, "", nullptr, [&r] { r.changed(); }, &r);
   p.connect(&p, &Property::aboutToChange, &r, [&r] { r.aboutToChange(); });
   p.setValue(17);
-  EXPECT_EQ(" aboutToChange, v=1 changed, v=17", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=1 changed, v=17", r.result.toStdString());
   r.reset();
 
   // initialize from parent
   Property p2("", 2, "", &p, [&r] {
     r.changed();
-    r.result() += " free lambda";
+    r.result += " free lambda";
   });
   p2.connect(&p2, &Property::aboutToChange, &r, &MockPropertyChangeReceiver::aboutToChange);
   p2.setValue(27);
-  EXPECT_EQ(" aboutToChange, v=2 free lambda", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=2 free lambda", r.result.toStdString());
   r.reset();
 
   // initialize from receiver with parent
@@ -110,7 +110,7 @@ TEST(Property, set_value_events_lambda)
       "", 3, "", &p, [&r] { r.changed(); }, &r);
   p3.connect(&p3, &Property::aboutToChange, &r, &MockPropertyChangeReceiver::aboutToChange);
   p3.setValue(37);
-  EXPECT_EQ(" aboutToChange, v=3 changed, v=37", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=3 changed, v=37", r.result.toStdString());
   r.reset();
 }
 
@@ -120,21 +120,21 @@ TEST(Property, set_value_events_method_pointer)
   Property p("", 1, "", nullptr, &MockPropertyChangeReceiver::changed, &r);
   p.connect(&p, &Property::aboutToChange, &r, &MockPropertyChangeReceiver::aboutToChange);
   p.setValue(17);
-  EXPECT_EQ(" aboutToChange, v=1 changed, v=17", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=1 changed, v=17", r.result.toStdString());
   r.reset();
 
   // initialize from parent
   Property p2("", 2, "", &p, &Property::changed);
   p2.connect(&p2, &Property::aboutToChange, &r, &MockPropertyChangeReceiver::aboutToChange);
   p2.setValue(27);
-  EXPECT_EQ(" aboutToChange, v=2 changed, v=17", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=2 changed, v=17", r.result.toStdString());
   r.reset();
 
   // initialize from receiver with parent
   Property p3("", 3, "", &p, &MockPropertyChangeReceiver::changed, &r);
   p3.connect(&p3, &Property::aboutToChange, &r, &MockPropertyChangeReceiver::aboutToChange);
   p3.setValue(37);
-  EXPECT_EQ(" aboutToChange, v=3 changed, v=37", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=3 changed, v=37", r.result.toStdString());
   r.reset();
 
 #if 0 // This should fail to compile due to receiver type mismatching slot
@@ -244,11 +244,11 @@ TEST(VectorProperty, set_value_events)
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
 
   p.setVector(Ogre::Vector3(.1, .0001, 1000));
-  EXPECT_EQ(" aboutToChange, v=0; 0; 0 changed, v=0.1; 0.0001; 1000", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=0; 0; 0 changed, v=0.1; 0.0001; 1000", r.result.toStdString());
   r.reset();
 
   p.subProp("Z")->setValue(2.1);
-  EXPECT_EQ(" aboutToChange, v=0.1; 0.0001; 1000 changed, v=0.1; 0.0001; 2.1", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=0.1; 0.0001; 1000 changed, v=0.1; 0.0001; 2.1", r.result.toStdString());
 }
 
 TEST(QuaternionProperty, default_value)
@@ -325,12 +325,12 @@ TEST(QuaternionProperty, set_value_events)
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
 
   p.setQuaternion(Ogre::Quaternion(1, .1, .0001, 1000));
-  EXPECT_EQ(" aboutToChange, v=0; 0; 0; 1 changed, v=0.1; 0.0001; 1000; 1", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=0; 0; 0; 1 changed, v=0.1; 0.0001; 1000; 1", r.result.toStdString());
   r.reset();
 
   p.subProp("Z")->setValue(2.1);
   EXPECT_EQ(" aboutToChange, v=0.1; 0.0001; 1000; 1 changed, v=0.1; 0.0001; 2.1; 1",
-            r.result().toStdString());
+            r.result.toStdString());
 }
 
 TEST(ColorProperty, default_value)
@@ -390,7 +390,7 @@ TEST(ColorProperty, set_value_events)
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
 
   p.setColor(QColor(1, 2, 3));
-  EXPECT_EQ(" aboutToChange, v=0; 0; 0 changed, v=1; 2; 3", r.result().toStdString());
+  EXPECT_EQ(" aboutToChange, v=0; 0; 0 changed, v=1; 2; 3", r.result.toStdString());
 }
 
 TEST(EnumProperty, basic)

--- a/src/test/property_test.cpp
+++ b/src/test/property_test.cpp
@@ -64,12 +64,9 @@ TEST(Property, value)
 
 TEST(Property, set_value_events)
 {
-  Property p;
-  p.setValue(0);
-
-  MockPropertyChangeReceiver r(&p);
+  MockPropertyChangeReceiver r;
+  Property p("", 0, "", nullptr, SLOT(changed()), &r);
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
-  p.connect(&p, SIGNAL(changed()), &r, SLOT(changed()));
 
   p.setValue(17);
   EXPECT_EQ(" aboutToChange, v=0 changed, v=17", r.result().toStdString());
@@ -165,11 +162,9 @@ TEST(VectorProperty, get_child)
 
 TEST(VectorProperty, set_value_events)
 {
-  VectorProperty p;
-
-  MockPropertyChangeReceiver r(&p);
+  MockPropertyChangeReceiver r;
+  VectorProperty p("", Ogre::Vector3::ZERO, "", nullptr, SLOT(changed()), &r);
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
-  p.connect(&p, SIGNAL(changed()), &r, SLOT(changed()));
 
   p.setVector(Ogre::Vector3(.1, .0001, 1000));
   EXPECT_EQ(" aboutToChange, v=0; 0; 0 changed, v=0.1; 0.0001; 1000", r.result().toStdString());
@@ -248,11 +243,9 @@ TEST(QuaternionProperty, get_child)
 
 TEST(QuaternionProperty, set_value_events)
 {
-  QuaternionProperty p;
-
-  MockPropertyChangeReceiver r(&p);
+  MockPropertyChangeReceiver r;
+  QuaternionProperty p("", Ogre::Quaternion::IDENTITY, "", nullptr, SLOT(changed()), &r);
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
-  p.connect(&p, SIGNAL(changed()), &r, SLOT(changed()));
 
   p.setQuaternion(Ogre::Quaternion(1, .1, .0001, 1000));
   EXPECT_EQ(" aboutToChange, v=0; 0; 0; 1 changed, v=0.1; 0.0001; 1000; 1", r.result().toStdString());
@@ -315,11 +308,9 @@ TEST(ColorProperty, set_string_limits)
 
 TEST(ColorProperty, set_value_events)
 {
-  ColorProperty p;
-
-  MockPropertyChangeReceiver r(&p);
+  MockPropertyChangeReceiver r;
+  ColorProperty p("", QColor(0, 0, 0), "", nullptr, SLOT(changed()), &r);
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
-  p.connect(&p, SIGNAL(changed()), &r, SLOT(changed()));
 
   p.setColor(QColor(1, 2, 3));
   EXPECT_EQ(" aboutToChange, v=0; 0; 0 changed, v=1; 2; 3", r.result().toStdString());

--- a/src/test/property_test.cpp
+++ b/src/test/property_test.cpp
@@ -62,11 +62,33 @@ TEST(Property, value)
   EXPECT_EQ(199, p.getValue().toInt());
 }
 
-TEST(Property, set_value_events)
+TEST(Property, set_value_events_qt4)
 {
   MockPropertyChangeReceiver r;
   Property p("", 0, "", nullptr, SLOT(changed()), &r);
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
+
+  p.setValue(17);
+  EXPECT_EQ(" aboutToChange, v=0 changed, v=17", r.result().toStdString());
+}
+
+TEST(Property, set_value_events_lambda)
+{
+  MockPropertyChangeReceiver r;
+  Property p("", 0, "", nullptr);
+  p.connect(&p, &Property::aboutToChange, &r, [&r] { r.aboutToChange(); });
+  p.connect(&r, [&r] { r.changed(); });
+
+  p.setValue(17);
+  EXPECT_EQ(" aboutToChange, v=0 changed, v=17", r.result().toStdString());
+}
+
+TEST(Property, set_value_events_method_pointer)
+{
+  MockPropertyChangeReceiver r;
+  Property p("", 0, "", nullptr);
+  p.connect(&p, &Property::aboutToChange, &r, &MockPropertyChangeReceiver::aboutToChange);
+  p.connect(&r, &MockPropertyChangeReceiver::changed);
 
   p.setValue(17);
   EXPECT_EQ(" aboutToChange, v=0 changed, v=17", r.result().toStdString());


### PR DESCRIPTION
Closes #1743. Closes #1742.
This is  work-in-progress to modernize rviz' usage of signals and slots and switch to Qt5-style compile-time signal-slot definitions.