### PR TITLE
Compatibility with Ogre 13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,16 +14,20 @@ jobs:
       fail-fast: false
       matrix:
         distro: [noetic, jammy]
-        ogre: ["1.9", "1.12"]
+        ogre: ["1.9", "1.12", "13.6"]
         include:
           - distro: noetic
             ogre: 1.9
             env:
               CLANG_TIDY: true
+        exclude:
+          - distro: jammy
+            ogre: "13.6"
 
     env:
       CXXFLAGS: "-DRVIZ_DEPRECATE_QT4_SLOTS -Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-strict-aliasing -Wno-sign-compare"
       UPSTREAM_WORKSPACE: ${{ matrix.distro != 'jammy' && 'github:rhaschke/python_qt_binding#silent-external-warnings' || '' }}
+      AFTER_INIT: ${{ startsWith(matrix.ogre, '13') && 'apt install -q -y software-properties-common && add-apt-repository ppa:s-schmeisser/ogre-13-${{ matrix.distro }} -y' || ''}}
       AFTER_INSTALL_TARGET_DEPENDENCIES: apt install -qq -y libogre-${{ matrix.ogre }}-dev
       CATKIN_LINT: true
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     env:
       CXXFLAGS: "-DRVIZ_DEPRECATE_QT4_SLOTS -Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-strict-aliasing -Wno-sign-compare"
       UPSTREAM_WORKSPACE: ${{ matrix.distro != 'jammy' && 'github:rhaschke/python_qt_binding#silent-external-warnings' || '' }}
-      AFTER_INIT: ${{ startsWith(matrix.ogre, '13') && 'apt install -q -y software-properties-common && add-apt-repository ppa:s-schmeisser/ogre-13-${{ matrix.distro }} -y' || ''}}
+      AFTER_INIT: ${{ startsWith(matrix.ogre, '13') && 'apt install -q -y software-properties-common && add-apt-repository ppa:s-schmeisser/ogre-13-focal -y' || ''}}
       AFTER_INSTALL_TARGET_DEPENDENCIES: apt install -qq -y libogre-${{ matrix.ogre }}-dev
       CATKIN_LINT: true
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/src/image_view/image_view.cpp
+++ b/src/image_view/image_view.cpp
@@ -58,7 +58,12 @@ using namespace rviz;
 ImageView::ImageView(QWidget* parent) : QtOgreRenderWindow(parent), texture_it_(nh_)
 {
   setAutoRender(false);
+#if (OGRE_VERSION < OGRE_VERSION_CHECK(13, 0, 0))
   scene_manager_ = ogre_root_->createSceneManager(Ogre::ST_GENERIC, "TestSceneManager");
+#else
+  scene_manager_ = ogre_root_->createSceneManager(Ogre::DefaultSceneManagerFactory::FACTORY_TYPE_NAME,
+                                                  "TestSceneManager");
+#endif
 }
 
 ImageView::~ImageView()

--- a/src/rviz/default_plugin/covariance_property.h
+++ b/src/rviz/default_plugin/covariance_property.h
@@ -30,6 +30,8 @@
 #ifndef COVARIANCE_PROPERTY_H
 #define COVARIANCE_PROPERTY_H
 
+#include <deque>
+
 #include <QColor>
 
 #include <OgreColourValue.h>

--- a/src/rviz/default_plugin/image_display.cpp
+++ b/src/rviz/default_plugin/image_display.cpp
@@ -81,7 +81,12 @@ void ImageDisplay::onInitialize()
     static uint32_t count = 0;
     std::stringstream ss;
     ss << "ImageDisplay" << count++;
+#if (OGRE_VERSION < OGRE_VERSION_CHECK(13, 0, 0))
     img_scene_manager_ = Ogre::Root::getSingleton().createSceneManager(Ogre::ST_GENERIC, ss.str());
+#else
+    img_scene_manager_ = Ogre::Root::getSingleton().createSceneManager(
+        Ogre::DefaultSceneManagerFactory::FACTORY_TYPE_NAME, ss.str());
+#endif
   }
 
   img_scene_node_ = img_scene_manager_->getRootSceneNode()->createChildSceneNode();

--- a/src/rviz/image/ros_image_texture.h
+++ b/src/rviz/image/ros_image_texture.h
@@ -41,6 +41,7 @@
 
 #include <ros/ros.h>
 
+#include <deque>
 #include <stdexcept>
 
 namespace rviz

--- a/src/rviz/ogre_helpers/apply_visibility_bits.cpp
+++ b/src/rviz/ogre_helpers/apply_visibility_bits.cpp
@@ -31,6 +31,7 @@
 
 #include <OgreMovableObject.h>
 #include <OgreSceneNode.h>
+#include <OgreIteratorWrapper.h>
 
 namespace rviz
 {

--- a/src/rviz/ogre_helpers/movable_text.cpp
+++ b/src/rviz/ogre_helpers/movable_text.cpp
@@ -51,7 +51,9 @@
 #include <OgreHardwareBufferManager.h>
 #include <Overlay/OgreFontManager.h>
 #include <Overlay/OgreFont.h>
+#if (OGRE_VERSION < OGRE_VERSION_CHECK(13, 0, 0))
 #include <OgreUTFString.h>
+#endif
 
 #include <sstream>
 
@@ -215,7 +217,11 @@ void MovableText::showOnTop(bool show)
 
 void MovableText::_setupGeometry()
 {
+#if (OGRE_VERSION >= OGRE_VERSION_CHECK(13, 0, 0))
+  Ogre::String utfCaption(mCaption);
+#else
   Ogre::UTFString::utf32string utfCaption(Ogre::UTFString(mCaption).asUTF32());
+#endif
 
   assert(mpFont);
   assert(!mpMaterial.isNull());

--- a/src/rviz/visualization_manager.cpp
+++ b/src/rviz/visualization_manager.cpp
@@ -140,8 +140,11 @@ VisualizationManager::VisualizationManager(RenderPanel* render_panel,
   render_panel->setAutoRender(false);
 
   private_->threaded_nh_.setCallbackQueue(&private_->threaded_queue_);
-
+#if (OGRE_VERSION < OGRE_VERSION_CHECK(13, 0, 0))
   scene_manager_ = ogre_root_->createSceneManager(Ogre::ST_GENERIC);
+#else
+  scene_manager_ = ogre_root_->createSceneManager();
+#endif
 
   rviz::RenderSystem::RenderSystem::get()->prepareOverlays(scene_manager_);
 

--- a/src/test/render_points_test.cpp
+++ b/src/test/render_points_test.cpp
@@ -52,7 +52,12 @@ MyFrame::MyFrame(QWidget* parent)
 
   try
   {
+#if (OGRE_VERSION < OGRE_VERSION_CHECK(13, 0, 0))
     scene_manager_ = root_->createSceneManager(Ogre::ST_GENERIC, "TestSceneManager");
+#else
+    scene_manager_ = root_->createSceneManager(Ogre::DefaultSceneManagerFactory::FACTORY_TYPE_NAME,
+                                               "TestSceneManager");
+#endif
 
     render_panel_ = new QtOgreRenderWindow();
     render_panel_->resize(this->size());

--- a/src/test/two_render_widgets.cpp
+++ b/src/test/two_render_widgets.cpp
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <rviz/ogre_helpers/compatibility.h>
 #include <rviz/ogre_helpers/render_system.h>
 #include <rviz/ogre_helpers/render_widget.h>
 
@@ -68,7 +69,11 @@ int main(int argc, char** argv)
   container.show();
 
   // Make a scene and show it in the window.
+#if (OGRE_VERSION < OGRE_VERSION_CHECK(13, 0, 0))
   Ogre::SceneManager* scene_manager = render_system->root()->createSceneManager(Ogre::ST_GENERIC);
+#else
+  Ogre::SceneManager* scene_manager = render_system->root()->createSceneManager();
+#endif
 
   Ogre::Entity* thing = scene_manager->createEntity("thing", "rviz_cone.mesh");
   Ogre::SceneNode* node = scene_manager->getRootSceneNode()->createChildSceneNode();


### PR DESCRIPTION
This fixes compatibility with Ogre 13.6.4, the most recent release. It requires two special cmake flags when building Ogre:
```
-DOGRE_NODELESS_POSITIONING:BOOL=TRUE \
-DOGRE_GLSUPPORT_USE_EGL:BOOL=FALSE \
```