### PR TITLE
Fixed crash when raycasting while map is updated.

### DIFF
--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -221,7 +221,7 @@ void Swatch::updateData()
 
 MapDisplay::MapDisplay() : Display(), loaded_(false), resolution_(0.0f), width_(0), height_(0)
 {
-  connect(this, SIGNAL(mapUpdated()), this, SLOT(showMap()));
+  connect(this, SIGNAL(mapUpdated()), this, SLOT(showMap()), Qt::QueuedConnection);
   topic_property_ = new RosTopicProperty(
       "Topic", "", QString::fromStdString(ros::message_traits::datatype<nav_msgs::OccupancyGrid>()),
       "nav_msgs::OccupancyGrid topic to subscribe to.", this, SLOT(updateTopic()));

--- a/src/rviz/default_plugin/map_display.cpp
+++ b/src/rviz/default_plugin/map_display.cpp
@@ -221,6 +221,9 @@ void Swatch::updateData()
 
 MapDisplay::MapDisplay() : Display(), loaded_(false), resolution_(0.0f), width_(0), height_(0)
 {
+  // HACK: Using a direct connection triggers a segfault on NVIDIA hardware (#1793) when rendering
+  //       *and* having performed a depth rendering before (e.g. due to raycasting for selections)
+  // A queued connection delays the update of renderables after the current VisualizationManager::onUpdate() call
   connect(this, SIGNAL(mapUpdated()), this, SLOT(showMap()), Qt::QueuedConnection);
   topic_property_ = new RosTopicProperty(
       "Topic", "", QString::fromStdString(ros::message_traits::datatype<nav_msgs::OccupancyGrid>()),


### PR DESCRIPTION
When using the scene manager raycast in one of our tool rviz crashed when the tool touched the map area while a new map was received.
Apparently, the connection is not queued (anymore?) and therefore the update does not happen on the main thread.
This small change should fix this and is fully ABI compatible.

Fixes #1792 
