### PR TITLE
Replace obsolete QPixmap::grabWindow() with QScreen::grabWindow()

### DIFF
--- a/src/rviz/screenshot_dialog.cpp
+++ b/src/rviz/screenshot_dialog.cpp
@@ -113,11 +113,11 @@ void ScreenshotDialog::takeScreenshotNow()
 {
   if (save_full_window_)
   {
-    screenshot_ = QPixmap::grabWindow(main_window_->winId());
+    screenshot_ = QScreen::grabWindow(main_window_->winId());
   }
   else
   {
-    screenshot_ = QPixmap::grabWindow(render_window_->winId());
+    screenshot_ = QScreen::grabWindow(render_window_->winId());
   }
   image_widget_->setImage(screenshot_);
 }

--- a/src/rviz/screenshot_dialog.cpp
+++ b/src/rviz/screenshot_dialog.cpp
@@ -38,6 +38,8 @@
 #include <QFileDialog>
 #include <QCheckBox>
 #include <QTimer>
+#include <QScreen>
+#include <QWindow>
 
 #include "scaled_image_widget.h"
 #include "screenshot_dialog.h"
@@ -111,14 +113,8 @@ void ScreenshotDialog::onTimeout()
 
 void ScreenshotDialog::takeScreenshotNow()
 {
-  if (save_full_window_)
-  {
-    screenshot_ = QScreen::grabWindow(main_window_->winId());
-  }
-  else
-  {
-    screenshot_ = QScreen::grabWindow(render_window_->winId());
-  }
+  const QWidget* w = save_full_window_ ? main_window_ : render_window_;
+  screenshot_ = w->windowHandle()->screen()->grabWindow(w->winId());
   image_widget_->setImage(screenshot_);
 }
 


### PR DESCRIPTION
Referring to the document below and based on the warnings I am getting at runtime, we replace QPixmap with QScreen:
https://doc.qt.io/qt-5/qpixmap-obsolete.html

<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

Referring to the document below and based on the warnings I am getting at runtime, we replace QPixmap with QScreen:
https://doc.qt.io/qt-5/qpixmap-obsolete.html

### Checklist

- [ ] If you are addressing rendering issues, please provide:
  - [ ] Images of both, broken and fixed renderings.
  - [ ] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
(Unfortunately I am running this on Ubuntu 22.04 right now, and not my work PC where I was getting the error, and cannot compile ROS1 code here. How do I proceed?)
- [x] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
