### PR TITLE
Fix vanishing "Global Options" property when adding a RobotModelDisplay

### DIFF
--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -34,6 +34,7 @@
 #include <QPalette>
 #include <QLineEdit>
 #include <QSpinBox>
+#include <QTimer>
 
 #include <rviz/properties/float_edit.h>
 #include <rviz/properties/property_tree_model.h>
@@ -395,7 +396,8 @@ void Property::setModel(PropertyTreeModel* model)
   model_ = model;
   if (model_ && hidden_)
   {
-    model_->emitPropertyHiddenChanged(this);
+    // process propertyHiddenChanged after insertion into model has finished
+    QTimer::singleShot(0, model_, [this]() { model_->emitPropertyHiddenChanged(this); });
   }
   int num_children = numChildren();
   for (int i = 0; i < num_children; i++)

--- a/src/rviz/properties/property_tree_model.cpp
+++ b/src/rviz/properties/property_tree_model.cpp
@@ -108,10 +108,6 @@ QModelIndex PropertyTreeModel::parentIndex(const Property* child) const
     return QModelIndex();
   }
   Property* parent = child->getParent();
-  if (parent == root_property_ || !parent)
-  {
-    return QModelIndex();
-  }
   return indexOf(parent);
 }
 

--- a/src/rviz/properties/property_tree_widget.cpp
+++ b/src/rviz/properties/property_tree_widget.cpp
@@ -37,6 +37,7 @@
 #include <rviz/properties/status_list.h>
 
 #include <rviz/properties/property_tree_widget.h>
+#include <ros/console.h>
 
 namespace rviz
 {
@@ -122,7 +123,12 @@ void PropertyTreeWidget::propertyHiddenChanged(const Property* property)
 {
   if (model_)
   {
-    setRowHidden(property->rowNumberInParent(), model_->parentIndex(property), property->getHidden());
+    const auto& parent_index = model_->parentIndex(property);
+    if (parent_index.isValid())
+      setRowHidden(property->rowNumberInParent(), parent_index, property->getHidden());
+    else
+      ROS_WARN_STREAM("Trying to hide property '" << qPrintable(property->getName())
+                                                  << "' that is not part of the model.");
   }
 }
 


### PR DESCRIPTION
With Qt 5.15, the `Global Options` property was vanishing, when a `RobotModelDisplay` was added with links having no geometry. In this case, the `Alpha` property of the corresponding link is hidden.
However, hiding a property:
https://github.com/ros-visualization/rviz/blob/4129ee477ecd47b9c941d90cdf5e3e4f26fad835/src/rviz/properties/property.cpp#L398

during the process of reparenting:
https://github.com/ros-visualization/rviz/blob/4129ee477ecd47b9c941d90cdf5e3e4f26fad835/src/rviz/properties/property.cpp#L373

caused setRowHidden to be called with an invalid `parentIndex`:
https://github.com/ros-visualization/rviz/blob/4129ee477ecd47b9c941d90cdf5e3e4f26fad835/src/rviz/properties/property_tree_widget.cpp#L125

which then caused hiding of the corresponding top-level property.