### PR TITLE
Fix #1826: jitter in Map display updates

### DIFF
--- a/src/rviz/default_plugin/map_display.h
+++ b/src/rviz/default_plugin/map_display.h
@@ -122,17 +122,12 @@ public:
 
   void setTopic(const QString& topic, const QString& datatype) override;
 
-Q_SIGNALS:
-  /** @brief Emitted when a new map is received*/
-  void mapUpdated();
-
 protected Q_SLOTS:
   void updateAlpha();
   void updateTopic();
   void updateDrawUnder();
   void updatePalette();
-  /** @brief Show current_map_ in the scene. */
-  void showMap();
+  void updateMap();
   void transformMap();
 
 protected:
@@ -144,10 +139,10 @@ protected:
   virtual void unsubscribe();
   void update(float wall_dt, float ros_dt) override;
 
-  /** @brief Copy msg into current_map_ and call showMap(). */
+  /** @brief Copy msg into current_map_ and set flag map_updated_ */
   void incomingMap(const nav_msgs::OccupancyGrid::ConstPtr& msg);
 
-  /** @brief Copy update's data into current_map_ and call showMap(). */
+  /** @brief Copy update's data into current_map_ and set flag map_updated_ */
   void incomingUpdate(const map_msgs::OccupancyGridUpdate::ConstPtr& update);
 
   void clear();
@@ -158,6 +153,7 @@ protected:
   std::vector<Ogre::TexturePtr> palette_textures_;
   std::vector<bool> color_scheme_transparency_;
   bool loaded_;
+  bool map_updated_;
 
   std::string topic_;
   float resolution_;


### PR DESCRIPTION
The queued connection update introduced in #1793 caused the map display to first update the pose of the map and then the map itself (in the next update cycle). The resulting jittering can be perfectly seen when throttling the rviz frame rate.

Updates to the visualization should be handled in update() only. Thus, now, if a map update is received, a flag is set to perform the costly map update. If that flag is not set, only the transform is updated.

Fixes #1826