### PR TITLE
Fix #1825/#1830: segfault when hiding deleted properties

### DIFF
--- a/src/rviz/properties/property.cpp
+++ b/src/rviz/properties/property.cpp
@@ -397,10 +397,7 @@ void Property::setModel(PropertyTreeModel* model)
   if (model_ && hidden_)
   {
     // process propertyHiddenChanged after insertion into model has finished
-    QTimer::singleShot(0, model_, [this]() {
-      if (model_)
-        model_->emitPropertyHiddenChanged(this);
-    });
+    QTimer::singleShot(0, this, [this]() { model_->emitPropertyHiddenChanged(this); });
   }
   int num_children = numChildren();
   for (int i = 0; i < num_children; i++)


### PR DESCRIPTION
When a hidden property was configured to process `propertyHiddenChanged` and got deleted in between, this was causing a segfault. We need to protect the slot/functor from being called when the property is deleted.

Fixes #1830.