### PR TITLE
Patch 1

### DIFF
--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -408,7 +408,7 @@ void loadTexture(const std::string& resource_path)
     {
       Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));
       Ogre::Image image;
-      std::string extension = fs::extension(fs::path(resource_path));
+      std::string extension = fs::path(resource_path).extension().string();
 
       if (extension[0] == '.')
       {

--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -518,7 +518,7 @@ Ogre::MaterialPtr RobotLink::getMaterialForLink(const urdf::LinkConstSharedPtr& 
       {
         Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));
         Ogre::Image image;
-        std::string extension = fs::extension(fs::path(filename));
+        std::string extension = fs::path(filename).extension().string();
 
         if (extension[0] == '.')
         {


### PR DESCRIPTION
`boost::filesystem::extension` was deprecated in Boost 1.77 and removed in 1.85
https://www.boost.org/doc/libs/1_87_0_beta1/libs/filesystem/doc/release_history.html

The alternative, calling the member function `extension()` on `path` works on Noetic too.