### PR TITLE
Enable to reset image display when new image has not been received for a while

### DIFF
--- a/src/rviz/image/image_display_base.cpp
+++ b/src/rviz/image/image_display_base.cpp
@@ -41,7 +41,8 @@
 
 namespace rviz
 {
-ImageDisplayBase::ImageDisplayBase() : Display(), sub_(), tf_filter_(), messages_received_(0)
+ImageDisplayBase::ImageDisplayBase()
+  : Display(), sub_(), tf_filter_(), messages_received_(0), last_received_(ros::Time())
 {
   topic_property_ = new RosTopicProperty(
       "Image Topic", "", QString::fromStdString(ros::message_traits::datatype<sensor_msgs::Image>()),

--- a/src/rviz/image/image_display_base.h
+++ b/src/rviz/image/image_display_base.h
@@ -30,6 +30,7 @@
 #define IMAGE_DISPLAY_BASE_H
 
 #include <QObject>
+#include <QTimer>
 
 #ifndef Q_MOC_RUN // See: https://bugreports.qt-project.org/browse/QTBUG-22829
 #include <message_filters/subscriber.h>
@@ -44,6 +45,7 @@
 #include "rviz/properties/ros_topic_property.h"
 #include "rviz/properties/enum_property.h"
 #include "rviz/properties/int_property.h"
+#include "rviz/properties/float_property.h"
 
 #include "rviz/display.h"
 #include "rviz/rviz_export.h"
@@ -77,8 +79,14 @@ protected Q_SLOTS:
   /** @brief Update queue size of tf filter  */
   virtual void updateQueueSize();
 
+  /** @brief Prepare for or stop resetting when timed out */
+  virtual void updateResetTO();
+
   /** @brief Fill list of available and working transport options */
   void fillTransportOptionList(EnumProperty* property);
+
+  /** @brief Timer function to reset when timed out */
+  void onResetTOTimer();
 
 protected:
   void onInitialize() override;
@@ -131,6 +139,15 @@ protected:
   std::set<std::string> transport_plugin_types_;
 
   BoolProperty* unreliable_property_;
+
+  BoolProperty* reset_to_property_;
+
+  FloatProperty* timeout_property_;
+
+  ros::Time timeout_tm_;
+  bool is_img_up_;
+
+  QTimer* reset_to_timer_;
 };
 
 } // end namespace rviz

--- a/src/rviz/image/image_display_base.h
+++ b/src/rviz/image/image_display_base.h
@@ -29,6 +29,7 @@
 #ifndef IMAGE_DISPLAY_BASE_H
 #define IMAGE_DISPLAY_BASE_H
 
+#include <atomic>
 #include <QObject>
 #include <QTimer>
 
@@ -79,14 +80,14 @@ protected Q_SLOTS:
   /** @brief Update queue size of tf filter  */
   virtual void updateQueueSize();
 
-  /** @brief Prepare for or stop resetting when timed out */
-  virtual void updateResetTO();
+  /** @brief Start or stop reset_timer_ */
+  void updateResetTimeout();
 
   /** @brief Fill list of available and working transport options */
   void fillTransportOptionList(EnumProperty* property);
 
-  /** @brief Timer function to reset when timed out */
-  void onResetTOTimer();
+  /** @brief Check for timeout and reset() if necessary */
+  void onResetTimer();
 
 protected:
   void onInitialize() override;
@@ -140,14 +141,9 @@ protected:
 
   BoolProperty* unreliable_property_;
 
-  BoolProperty* reset_to_property_;
-
   FloatProperty* timeout_property_;
-
-  ros::Time timeout_tm_;
-  bool is_img_up_;
-
-  QTimer* reset_to_timer_;
+  std::atomic<ros::Time> last_received_;
+  QTimer* reset_timer_;
 };
 
 } // end namespace rviz


### PR DESCRIPTION
With this PR, you can switch on `Reset When Timed Out` function, which makes image display show "No Image" again when new image has not been received for `Timeout` seconds.
This PR makes it easier to notice that the image publisher is in trouble.

# Before this PR

https://github.com/user-attachments/assets/55ee0e1f-c0b3-45c2-9175-3067269e16ce

# After this PR

https://github.com/user-attachments/assets/366eac6f-f3e0-41c6-bc36-a80ac79daa44

Note that the default state of `Reset When Timed Out` is OFF, which leads to the same behavior before this PR.