### PR TITLE
Replace FreeImage codec with STBI

### DIFF
--- a/src/rviz/ogre_helpers/render_system.cpp
+++ b/src/rviz/ogre_helpers/render_system.cpp
@@ -167,7 +167,7 @@ void RenderSystem::loadOgrePlugins()
   ogre_root_->loadPlugin(plugin_prefix + "Plugin_OctreeSceneManager");
   ogre_root_->loadPlugin(plugin_prefix + "Plugin_ParticleFX");
 #if OGRE_VERSION >= OGRE_VERSION_CHECK(1, 11, 0)
-  ogre_root_->loadPlugin(plugin_prefix + "Codec_FreeImage");
+  ogre_root_->loadPlugin(plugin_prefix + "Codec_STBI");
 #endif
 }
 


### PR DESCRIPTION
The FreeImage library to load texture images from common image formats such as PNG is [about to be dropped from Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1121912). The STBI implementation serves the same purpose and is available in Ogre 1.12+