### PR TITLE
[ROS-O] drop long-empty boost system component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ find_package(Boost REQUIRED
   COMPONENTS
   filesystem
   program_options
-  system
   thread
 )
 


### PR DESCRIPTION
as their cmake config finally dropped the keyword with Ubuntu 26.04+.
It's the same change that sweeps through the whole ROS-O ecosystem with a current boost dependency.

@rhaschke 