### PR TITLE
improve support to reload/switch models through urdf

### DIFF
--- a/src/rviz/default_plugin/robot_model_display.cpp
+++ b/src/rviz/default_plugin/robot_model_display.cpp
@@ -256,6 +256,7 @@ void RobotModelDisplay::clear()
 void RobotModelDisplay::reset()
 {
   Display::reset();
+  load();
   has_new_transforms_ = true;
 }
 

--- a/src/rviz/mesh_loader.cpp
+++ b/src/rviz/mesh_loader.cpp
@@ -459,8 +459,22 @@ void loadMaterials(const std::string& resource_path,
   {
     std::stringstream ss;
     ss << resource_path << "Material" << i;
-    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
-        ss.str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, true);
+    Ogre::MaterialPtr mat;
+    try
+    {
+      mat = Ogre::MaterialManager::getSingleton().create(
+          ss.str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, true);
+    }
+    catch (Ogre::ItemIdentityException& e)
+    {
+      // this is already loaded in the scene through a different code path, so we reuse it
+      // happens when the same robot description is loaded again.
+      // e.g., RobotDisplay showing RobotA, RobotB, and RobotA again.
+      mat = Ogre::MaterialManager::getSingleton().getByName(ss.str());
+      material_table_out.push_back(mat);
+      continue;
+    }
+
     material_table_out.push_back(mat);
 
     Ogre::Technique* tech = mat->getTechnique(0);

--- a/src/rviz/visualization_frame.cpp
+++ b/src/rviz/visualization_frame.cpp
@@ -142,6 +142,7 @@ VisualizationFrame::VisualizationFrame(QWidget* parent)
   reset_button->setContentsMargins(0, 0, 0, 0);
   statusBar()->addPermanentWidget(reset_button, 0);
   connect(reset_button, &QToolButton::clicked, this, &VisualizationFrame::VisualizationFrame::reset);
+  reset_button->setShortcut(QKeySequence(QString("Ctrl+Shift+R")));
 
   status_label_ = new QLabel("");
   statusBar()->addPermanentWidget(status_label_, 1);


### PR DESCRIPTION
I was working with a use-case recently where the `/robot_description` parameter was changed regularly, leading to
1. a rare crash due to Ogre,
2. observed unintuitive behavior in rviz where manually "resetting" the display worked but an overall reset did not, and
3. for convenience I added a shortcut for reloading rviz to avoid having to press the "reset" button manually by mouse.